### PR TITLE
feat(downloads): chrome://downloads page scaffold

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -56,6 +56,10 @@ const CH_SET_OPEN_WHEN_DONE = 'downloads:set-open-when-done';
 const CH_CLEAR_COMPLETED = 'downloads:clear-completed';
 const CH_GET_SHOW_ON_COMPLETE = 'downloads:get-show-on-complete';
 const CH_SET_SHOW_ON_COMPLETE = 'downloads:set-show-on-complete';
+// Added for chrome://downloads page (issue #37)
+const CH_REMOVE = 'downloads:remove';
+const CH_RETRY = 'downloads:retry';
+const CH_CLEAR_ALL = 'downloads:clear-all';
 
 // Events (main → renderer)
 const EVT_DOWNLOAD_STARTED = 'download-started';
@@ -249,7 +253,19 @@ export class DownloadManager {
       this.setShowOnComplete(value);
     });
 
-    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 10 });
+    ipcMain.handle(CH_REMOVE, (_e, id: string) => {
+      return this.removeEntry(id);
+    });
+
+    ipcMain.handle(CH_RETRY, (_e, id: string) => {
+      return this.retry(id);
+    });
+
+    ipcMain.handle(CH_CLEAR_ALL, () => {
+      return this.clearAll();
+    });
+
+    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 13 });
   }
 
   // ---------------------------------------------------------------------------
@@ -351,6 +367,89 @@ export class DownloadManager {
     this.broadcastState();
   }
 
+  /**
+   * Remove a single entry from the tracking map. If the underlying download
+   * is still in-flight it is cancelled first. Used by chrome://downloads.
+   */
+  private removeEntry(id: string): boolean {
+    const dl = this.downloads.get(id);
+    if (!dl) {
+      mainLogger.warn('DownloadManager.removeEntry.notFound', { id });
+      return false;
+    }
+    const item = this.electronItems.get(id);
+    if (item && (dl.status === 'in-progress' || dl.status === 'paused')) {
+      try {
+        item.cancel();
+      } catch (err) {
+        mainLogger.warn('DownloadManager.removeEntry.cancel.failed', { id, error: String(err) });
+      }
+    }
+    this.electronItems.delete(id);
+    this.clearThrottle(id);
+    this.downloads.delete(id);
+    mainLogger.info('DownloadManager.removeEntry', { id });
+    this.broadcastState();
+    return true;
+  }
+
+  /**
+   * Retry a failed or cancelled download by re-issuing the original URL via
+   * the default session. The original record is removed so the new download
+   * gets a fresh entry via the will-download handler. No-op if the record
+   * does not exist or is still in-flight.
+   */
+  private retry(id: string): boolean {
+    const dl = this.downloads.get(id);
+    if (!dl) {
+      mainLogger.warn('DownloadManager.retry.notFound', { id });
+      return false;
+    }
+    if (dl.status === 'in-progress' || dl.status === 'paused') {
+      mainLogger.warn('DownloadManager.retry.stillInFlight', { id, status: dl.status });
+      return false;
+    }
+    const url = dl.url;
+    // Drop the old record so the new attempt shows up as a fresh entry.
+    this.downloads.delete(id);
+    this.electronItems.delete(id);
+    this.clearThrottle(id);
+    try {
+      session.defaultSession.downloadURL(url);
+      mainLogger.info('DownloadManager.retry.issued', { id, url: url.slice(0, 200) });
+    } catch (err) {
+      mainLogger.warn('DownloadManager.retry.failed', { id, error: String(err) });
+      this.broadcastState();
+      return false;
+    }
+    this.broadcastState();
+    return true;
+  }
+
+  /**
+   * Remove every entry from the tracking map. In-flight downloads are
+   * cancelled first. Used by the "Clear all" button on chrome://downloads.
+   */
+  private clearAll(): boolean {
+    for (const [id, dl] of this.downloads) {
+      const item = this.electronItems.get(id);
+      if (item && (dl.status === 'in-progress' || dl.status === 'paused')) {
+        try {
+          item.cancel();
+        } catch (err) {
+          mainLogger.warn('DownloadManager.clearAll.cancel.failed', { id, error: String(err) });
+        }
+      }
+      this.clearThrottle(id);
+    }
+    const count = this.downloads.size;
+    this.downloads.clear();
+    this.electronItems.clear();
+    mainLogger.info('DownloadManager.clearAll', { removed: count });
+    this.broadcastState();
+    return true;
+  }
+
   // ---------------------------------------------------------------------------
   // Settings: show downloads when done
   // ---------------------------------------------------------------------------
@@ -436,6 +535,9 @@ export class DownloadManager {
     ipcMain.removeHandler(CH_CLEAR_COMPLETED);
     ipcMain.removeHandler(CH_GET_SHOW_ON_COMPLETE);
     ipcMain.removeHandler(CH_SET_SHOW_ON_COMPLETE);
+    ipcMain.removeHandler(CH_REMOVE);
+    ipcMain.removeHandler(CH_RETRY);
+    ipcMain.removeHandler(CH_CLEAR_ALL);
     for (const timer of this.throttleTimers.values()) {
       clearTimeout(timer);
     }

--- a/my-app/src/preload/downloads.ts
+++ b/my-app/src/preload/downloads.ts
@@ -1,0 +1,74 @@
+/**
+ * Preload script for the chrome://downloads internal page.
+ * Exposes a safe contextBridge API for listing and managing downloads.
+ *
+ * IPC surface is additive on top of the existing DownloadManager channels
+ * (downloads:get-all, downloads:pause, downloads:resume, downloads:cancel,
+ * downloads:open-file, downloads:show-in-folder, downloads:clear-completed).
+ * New channels added in DownloadManager: downloads:remove, downloads:retry,
+ * downloads:clear-all.
+ */
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+export type DownloadStatus =
+  | 'in-progress'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'interrupted';
+
+export interface DownloadItemDTO {
+  id: string;
+  filename: string;
+  url: string;
+  savePath: string;
+  totalBytes: number;
+  receivedBytes: number;
+  status: DownloadStatus;
+  startTime: number;
+  endTime: number | null;
+  openWhenDone: boolean;
+  speed: number;
+  eta: number;
+}
+
+contextBridge.exposeInMainWorld('downloadsAPI', {
+  list: (): Promise<DownloadItemDTO[]> =>
+    ipcRenderer.invoke('downloads:get-all'),
+
+  remove: (id: string): Promise<boolean> =>
+    ipcRenderer.invoke('downloads:remove', id),
+
+  openFile: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:open-file', id),
+
+  showInFolder: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:show-in-folder', id),
+
+  retry: (id: string): Promise<boolean> =>
+    ipcRenderer.invoke('downloads:retry', id),
+
+  pause: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:pause', id),
+
+  resume: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:resume', id),
+
+  cancel: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:cancel', id),
+
+  clearAll: (): Promise<boolean> =>
+    ipcRenderer.invoke('downloads:clear-all'),
+
+  navigateTo: (url: string): Promise<void> =>
+    ipcRenderer.invoke('tabs:navigate-active', url),
+
+  onStateChange: (cb: (items: DownloadItemDTO[]) => void): (() => void) => {
+    const listener = (_e: unknown, payload: DownloadItemDTO[]) => cb(payload);
+    ipcRenderer.on('downloads-state', listener);
+    return () => {
+      ipcRenderer.removeListener('downloads-state', listener);
+    };
+  },
+});

--- a/my-app/src/renderer/downloads/DownloadsPage.tsx
+++ b/my-app/src/renderer/downloads/DownloadsPage.tsx
@@ -1,0 +1,427 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type DownloadStatus =
+  | 'in-progress'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'interrupted';
+
+interface DownloadItemDTO {
+  id: string;
+  filename: string;
+  url: string;
+  savePath: string;
+  totalBytes: number;
+  receivedBytes: number;
+  status: DownloadStatus;
+  startTime: number;
+  endTime: number | null;
+  openWhenDone: boolean;
+  speed: number;
+  eta: number;
+}
+
+declare const downloadsAPI: {
+  list: () => Promise<DownloadItemDTO[]>;
+  remove: (id: string) => Promise<boolean>;
+  openFile: (id: string) => Promise<void>;
+  showInFolder: (id: string) => Promise<void>;
+  retry: (id: string) => Promise<boolean>;
+  pause: (id: string) => Promise<void>;
+  resume: (id: string) => Promise<void>;
+  cancel: (id: string) => Promise<void>;
+  clearAll: () => Promise<boolean>;
+  navigateTo: (url: string) => Promise<void>;
+  onStateChange: (cb: (items: DownloadItemDTO[]) => void) => () => void;
+};
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function getDateLabel(ts: number): string {
+  const now = new Date();
+  const date = new Date(ts);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const entryDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+  if (entryDate.getTime() === today.getTime()) return 'Today';
+  if (entryDate.getTime() === yesterday.getTime()) return 'Yesterday';
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function groupByDate(items: DownloadItemDTO[]): Map<string, DownloadItemDTO[]> {
+  const groups = new Map<string, DownloadItemDTO[]>();
+  for (const item of items) {
+    const label = getDateLabel(item.startTime);
+    const group = groups.get(label);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(label, [item]);
+    }
+  }
+  return groups;
+}
+
+function domainLabel(pageUrl: string): string {
+  try {
+    return new URL(pageUrl).hostname.replace(/^www\./, '');
+  } catch {
+    return pageUrl;
+  }
+}
+
+function statusLabel(dl: DownloadItemDTO): string {
+  switch (dl.status) {
+    case 'completed':
+      return formatBytes(dl.receivedBytes);
+    case 'in-progress': {
+      const totalLabel = dl.totalBytes > 0 ? formatBytes(dl.totalBytes) : 'unknown size';
+      return `${formatBytes(dl.receivedBytes)} of ${totalLabel}`;
+    }
+    case 'paused':
+      return 'Paused';
+    case 'cancelled':
+      return 'Cancelled';
+    case 'interrupted':
+      return 'Failed';
+    default:
+      return '';
+  }
+}
+
+export function DownloadsPage(): React.ReactElement {
+  const [items, setItems] = useState<DownloadItemDTO[]>([]);
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const fetchDownloads = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await downloadsAPI.list();
+      setItems(result);
+    } catch (err) {
+      console.error('DownloadsPage.fetch.failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDownloads();
+  }, [fetchDownloads]);
+
+  useEffect(() => {
+    const unsubscribe = downloadsAPI.onStateChange((next) => {
+      setItems(next);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setQuery(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(val);
+    }, 200);
+  }, []);
+
+  const handleOpen = useCallback((id: string) => {
+    downloadsAPI.openFile(id);
+  }, []);
+
+  const handleShowInFolder = useCallback((id: string) => {
+    downloadsAPI.showInFolder(id);
+  }, []);
+
+  const handleRemove = useCallback(async (id: string) => {
+    await downloadsAPI.remove(id);
+    setItems((prev) => prev.filter((d) => d.id !== id));
+  }, []);
+
+  const handleRetry = useCallback((id: string) => {
+    downloadsAPI.retry(id);
+  }, []);
+
+  const handlePause = useCallback((id: string) => {
+    downloadsAPI.pause(id);
+  }, []);
+
+  const handleResume = useCallback((id: string) => {
+    downloadsAPI.resume(id);
+  }, []);
+
+  const handleCancel = useCallback((id: string) => {
+    downloadsAPI.cancel(id);
+  }, []);
+
+  const handleNavigate = useCallback((url: string) => {
+    downloadsAPI.navigateTo(url);
+  }, []);
+
+  const handleClearAll = useCallback(async () => {
+    await downloadsAPI.clearAll();
+    setItems([]);
+  }, []);
+
+  const filteredItems = useMemo(() => {
+    const q = debouncedQuery.trim().toLowerCase();
+    const sorted = [...items].sort((a, b) => b.startTime - a.startTime);
+    if (!q) return sorted;
+    return sorted.filter((d) => {
+      const filename = d.filename.toLowerCase();
+      const url = d.url.toLowerCase();
+      return filename.includes(q) || url.includes(q);
+    });
+  }, [items, debouncedQuery]);
+
+  const groups = groupByDate(filteredItems);
+
+  return (
+    <div className="downloads">
+      <header className="downloads__header">
+        <h1 className="downloads__title">Downloads</h1>
+        {items.length > 0 && (
+          <button
+            type="button"
+            className="downloads__clear-all"
+            onClick={handleClearAll}
+            aria-label="Clear all downloads"
+          >
+            Clear all
+          </button>
+        )}
+      </header>
+
+      <div className="downloads__search-container">
+        <svg className="downloads__search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" />
+          <line x1="11" y1="11" x2="14.5" y2="14.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+        <input
+          ref={searchRef}
+          className="downloads__search"
+          type="text"
+          value={query}
+          onChange={handleQueryChange}
+          placeholder="Search downloads"
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          aria-label="Search downloads"
+        />
+      </div>
+
+      <div className="downloads__content">
+        {loading && items.length === 0 ? (
+          <div className="downloads__empty">Loading...</div>
+        ) : filteredItems.length === 0 ? (
+          <div className="downloads__empty">
+            {debouncedQuery ? 'No results found' : 'No downloads yet'}
+          </div>
+        ) : (
+          Array.from(groups.entries()).map(([dateLabel, groupItems]) => (
+            <div key={dateLabel} className="downloads__group">
+              <h2 className="downloads__date-label">{dateLabel}</h2>
+              <div className="downloads__entries">
+                {groupItems.map((dl) => (
+                  <DownloadRow
+                    key={dl.id}
+                    dl={dl}
+                    onOpen={handleOpen}
+                    onShowInFolder={handleShowInFolder}
+                    onRemove={handleRemove}
+                    onRetry={handleRetry}
+                    onPause={handlePause}
+                    onResume={handleResume}
+                    onCancel={handleCancel}
+                    onNavigate={handleNavigate}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface DownloadRowProps {
+  dl: DownloadItemDTO;
+  onOpen: (id: string) => void;
+  onShowInFolder: (id: string) => void;
+  onRemove: (id: string) => void;
+  onRetry: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onCancel: (id: string) => void;
+  onNavigate: (url: string) => void;
+}
+
+function DownloadRow({
+  dl,
+  onOpen,
+  onShowInFolder,
+  onRemove,
+  onRetry,
+  onPause,
+  onResume,
+  onCancel,
+  onNavigate,
+}: DownloadRowProps): React.ReactElement {
+  const isActive = dl.status === 'in-progress' || dl.status === 'paused';
+  const isCompleted = dl.status === 'completed';
+  const isFailed = dl.status === 'interrupted' || dl.status === 'cancelled';
+  const percent =
+    dl.totalBytes > 0 ? Math.min(100, Math.round((dl.receivedBytes / dl.totalBytes) * 100)) : 0;
+
+  return (
+    <div
+      className={`downloads__entry downloads__entry--${dl.status}`}
+      data-testid="download-row"
+    >
+      <div className="downloads__file-icon" aria-hidden="true">
+        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+          <path
+            d="M7 4h13l6 6v18a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            fill="var(--color-bg-elevated)"
+          />
+          <path d="M20 4v6h6" stroke="currentColor" strokeWidth="1.5" fill="none" />
+        </svg>
+      </div>
+
+      <div className="downloads__entry-body">
+        <button
+          type="button"
+          className="downloads__entry-filename"
+          onClick={() => (isCompleted ? onOpen(dl.id) : undefined)}
+          disabled={!isCompleted}
+          title={isCompleted ? `Open ${dl.filename}` : dl.filename}
+        >
+          {dl.filename}
+        </button>
+
+        <button
+          type="button"
+          className="downloads__entry-source"
+          onClick={() => onNavigate(dl.url)}
+          title={dl.url}
+        >
+          {domainLabel(dl.url)}
+        </button>
+
+        <div className="downloads__entry-status">
+          <span className="downloads__entry-status-text">{statusLabel(dl)}</span>
+          {isActive && dl.totalBytes > 0 && (
+            <div className="downloads__progress" aria-label={`${percent} percent`}>
+              <div
+                className="downloads__progress-fill"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="downloads__entry-actions">
+          {isCompleted && (
+            <>
+              <button
+                type="button"
+                className="downloads__action"
+                onClick={() => onShowInFolder(dl.id)}
+              >
+                Show in folder
+              </button>
+            </>
+          )}
+          {dl.status === 'in-progress' && (
+            <>
+              <button
+                type="button"
+                className="downloads__action"
+                onClick={() => onPause(dl.id)}
+              >
+                Pause
+              </button>
+              <button
+                type="button"
+                className="downloads__action"
+                onClick={() => onCancel(dl.id)}
+              >
+                Cancel
+              </button>
+            </>
+          )}
+          {dl.status === 'paused' && (
+            <>
+              <button
+                type="button"
+                className="downloads__action"
+                onClick={() => onResume(dl.id)}
+              >
+                Resume
+              </button>
+              <button
+                type="button"
+                className="downloads__action"
+                onClick={() => onCancel(dl.id)}
+              >
+                Cancel
+              </button>
+            </>
+          )}
+          {isFailed && (
+            <button
+              type="button"
+              className="downloads__action"
+              onClick={() => onRetry(dl.id)}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="downloads__entry-remove"
+        onClick={() => onRemove(dl.id)}
+        title="Remove from list"
+        aria-label="Remove from list"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/my-app/src/renderer/downloads/downloads.css
+++ b/my-app/src/renderer/downloads/downloads.css
@@ -1,0 +1,279 @@
+.downloads {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  font-family: var(--font-ui);
+  color: var(--color-fg-primary);
+  min-height: 100vh;
+  background-color: var(--color-bg-base);
+}
+
+.downloads__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.downloads__title {
+  font-size: 22px;
+  font-weight: 500;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.downloads__clear-all {
+  margin-left: auto;
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.downloads__clear-all:hover {
+  background-color: var(--color-surface-interactive-hover);
+  border-color: var(--color-border-strong);
+}
+
+.downloads__search-container {
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.downloads__search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-fg-tertiary);
+  pointer-events: none;
+}
+
+.downloads__search {
+  width: 100%;
+  padding: 10px 12px 10px 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 120ms ease;
+}
+
+.downloads__search:focus {
+  border-color: var(--color-accent-default);
+}
+
+.downloads__search::placeholder {
+  color: var(--color-fg-tertiary);
+}
+
+.downloads__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.downloads__empty {
+  text-align: center;
+  padding: 48px 0;
+  color: var(--color-fg-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+.downloads__group {
+  margin-bottom: 8px;
+}
+
+.downloads__date-label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-fg-secondary);
+  padding: 12px 0 8px;
+  margin: 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.downloads__entries {
+  display: flex;
+  flex-direction: column;
+}
+
+.downloads__entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 8px;
+  border-radius: var(--radius-sm);
+  transition: background-color 80ms ease;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.downloads__entry:last-child {
+  border-bottom: none;
+}
+
+.downloads__entry:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.downloads__file-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-fg-secondary);
+}
+
+.downloads__entry--interrupted .downloads__file-icon,
+.downloads__entry--cancelled .downloads__file-icon {
+  color: var(--color-status-danger);
+}
+
+.downloads__entry-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.downloads__entry-filename {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-accent-default);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.downloads__entry-filename:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.downloads__entry-filename:disabled {
+  color: var(--color-fg-primary);
+  cursor: default;
+}
+
+.downloads__entry-source {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.downloads__entry-source:hover {
+  text-decoration: underline;
+  color: var(--color-fg-secondary);
+}
+
+.downloads__entry-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.downloads__entry-status-text {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.downloads__entry--interrupted .downloads__entry-status-text,
+.downloads__entry--cancelled .downloads__entry-status-text {
+  color: var(--color-status-danger);
+}
+
+.downloads__progress {
+  flex: 1;
+  max-width: 240px;
+  height: 4px;
+  background-color: var(--color-surface-interactive-active);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.downloads__progress-fill {
+  height: 100%;
+  background-color: var(--color-accent-default);
+  transition: width 120ms ease;
+}
+
+.downloads__entry-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.downloads__action {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.downloads__action:hover {
+  background-color: var(--color-surface-interactive-hover);
+  border-color: var(--color-border-strong);
+  color: var(--color-fg-primary);
+}
+
+.downloads__entry-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 80ms ease, background-color 80ms ease;
+  margin-top: 4px;
+}
+
+.downloads__entry:hover .downloads__entry-remove {
+  opacity: 1;
+}
+
+.downloads__entry-remove:hover {
+  background-color: var(--color-surface-interactive-active);
+  color: var(--color-status-danger);
+}

--- a/my-app/src/renderer/downloads/downloads.html
+++ b/my-app/src/renderer/downloads/downloads.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en" data-theme="shell">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Downloads</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/my-app/src/renderer/downloads/index.tsx
+++ b/my-app/src/renderer/downloads/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { DownloadsPage } from './DownloadsPage';
+import '../design/theme.global.css';
+import './downloads.css';
+
+window.addEventListener('error', (e) => {
+  console.error('downloads.error', { message: e.message, file: e.filename, line: e.lineno });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('downloads.unhandledrejection', { reason: String(e.reason) });
+});
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('[downloads] #root element not found');
+
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <DownloadsPage />
+  </React.StrictMode>,
+);

--- a/my-app/tests/unit/downloads/DownloadsPage.spec.tsx
+++ b/my-app/tests/unit/downloads/DownloadsPage.spec.tsx
@@ -1,0 +1,176 @@
+/**
+ * DownloadsPage smoke tests — chrome://downloads full-page renderer.
+ *
+ * Mirrors the shape of tests/unit/onboarding/Welcome.spec.tsx.
+ * Covers:
+ *   - Renders the "Downloads" headline
+ *   - Shows empty state when the list is empty
+ *   - Renders entries grouped by date
+ *   - Clicking "Show in folder" invokes the preload API
+ *   - Clicking the per-row remove button invokes the preload API and drops the row
+ *   - Search filter narrows results by filename
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Stub the CSS import so vitest doesn't try to parse it
+vi.mock('../../../src/renderer/downloads/downloads.css', () => ({}));
+
+// Build a shared mock API and expose it on the global before the component is imported.
+const mockApi = {
+  list: vi.fn(),
+  remove: vi.fn(),
+  openFile: vi.fn(),
+  showInFolder: vi.fn(),
+  retry: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  cancel: vi.fn(),
+  clearAll: vi.fn(),
+  navigateTo: vi.fn(),
+  onStateChange: vi.fn(() => () => undefined),
+};
+
+beforeEach(() => {
+  for (const key of Object.keys(mockApi) as Array<keyof typeof mockApi>) {
+    const fn = mockApi[key];
+    if (typeof (fn as { mockReset?: () => void }).mockReset === 'function') {
+      (fn as { mockReset: () => void }).mockReset();
+    }
+  }
+  mockApi.list.mockResolvedValue([]);
+  mockApi.remove.mockResolvedValue(true);
+  mockApi.clearAll.mockResolvedValue(true);
+  mockApi.retry.mockResolvedValue(true);
+  mockApi.onStateChange.mockImplementation(() => () => undefined);
+  // Attach to globalThis so the component's `declare const downloadsAPI` binding resolves.
+  (globalThis as unknown as { downloadsAPI: typeof mockApi }).downloadsAPI = mockApi;
+});
+
+import { DownloadsPage } from '../../../src/renderer/downloads/DownloadsPage';
+
+function makeItem(partial: Partial<{
+  id: string;
+  filename: string;
+  url: string;
+  savePath: string;
+  totalBytes: number;
+  receivedBytes: number;
+  status: 'in-progress' | 'paused' | 'completed' | 'cancelled' | 'interrupted';
+  startTime: number;
+  endTime: number | null;
+  openWhenDone: boolean;
+  speed: number;
+  eta: number;
+}>) {
+  return {
+    id: 'dl-1',
+    filename: 'report.pdf',
+    url: 'https://example.com/report.pdf',
+    savePath: '/tmp/report.pdf',
+    totalBytes: 1024,
+    receivedBytes: 1024,
+    status: 'completed' as const,
+    startTime: Date.now(),
+    endTime: Date.now(),
+    openWhenDone: false,
+    speed: 0,
+    eta: 0,
+    ...partial,
+  };
+}
+
+describe('DownloadsPage', () => {
+  it('renders the Downloads headline', async () => {
+    render(<DownloadsPage />);
+    expect(screen.getByRole('heading', { name: /downloads/i })).toBeTruthy();
+  });
+
+  it('shows the empty state when the list is empty', async () => {
+    render(<DownloadsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/no downloads yet/i)).toBeTruthy();
+    });
+  });
+
+  it('renders a row for each download returned from the API', async () => {
+    mockApi.list.mockResolvedValueOnce([
+      makeItem({ id: 'dl-1', filename: 'report.pdf' }),
+      makeItem({ id: 'dl-2', filename: 'image.png', url: 'https://cdn.example.com/image.png' }),
+    ]);
+
+    render(<DownloadsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('report.pdf')).toBeTruthy();
+      expect(screen.getByText('image.png')).toBeTruthy();
+    });
+  });
+
+  it('invokes showInFolder when "Show in folder" is clicked', async () => {
+    mockApi.list.mockResolvedValueOnce([makeItem({ id: 'dl-1', filename: 'report.pdf' })]);
+
+    render(<DownloadsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('report.pdf')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /show in folder/i }));
+    expect(mockApi.showInFolder).toHaveBeenCalledWith('dl-1');
+  });
+
+  it('invokes remove and drops the row when the per-row remove button is clicked', async () => {
+    mockApi.list.mockResolvedValueOnce([makeItem({ id: 'dl-1', filename: 'report.pdf' })]);
+
+    render(<DownloadsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('report.pdf')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /remove from list/i }));
+
+    await waitFor(() => {
+      expect(mockApi.remove).toHaveBeenCalledWith('dl-1');
+    });
+  });
+
+  it('filters by filename via the search input', async () => {
+    mockApi.list.mockResolvedValueOnce([
+      makeItem({ id: 'dl-1', filename: 'report.pdf' }),
+      makeItem({ id: 'dl-2', filename: 'image.png', url: 'https://cdn.example.com/image.png' }),
+    ]);
+
+    render(<DownloadsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('report.pdf')).toBeTruthy();
+    });
+
+    const input = screen.getByLabelText(/search downloads/i);
+    fireEvent.change(input, { target: { value: 'image' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('report.pdf')).toBeNull();
+      expect(screen.getByText('image.png')).toBeTruthy();
+    });
+  });
+
+  it('invokes retry when "Retry" is clicked on a failed download', async () => {
+    mockApi.list.mockResolvedValueOnce([
+      makeItem({ id: 'dl-1', filename: 'broken.zip', status: 'interrupted' }),
+    ]);
+
+    render(<DownloadsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('broken.zip')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^retry$/i }));
+    expect(mockApi.retry).toHaveBeenCalledWith('dl-1');
+  });
+});

--- a/my-app/vite.downloads.config.ts
+++ b/my-app/vite.downloads.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Vite config for the downloads renderer (chrome://downloads).
+ * Follows the same pattern as vite.history.config.ts.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/downloads/downloads.html'),
+    },
+  },
+});

--- a/my-app/vitest.onboarding.config.ts
+++ b/my-app/vitest.onboarding.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     include: [
       'tests/unit/identity/**/*.spec.ts',
       'tests/unit/onboarding/**/*.spec.tsx',
+      'tests/unit/downloads/**/*.spec.tsx',
       'tests/integration/**/*.test.ts',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],


### PR DESCRIPTION
## Summary

Adds the missing scaffolding that commit 60ddc35 referenced but never
committed. The broken build on `main` (`npm run package` fails with
`Could not resolve "src/preload/downloads.ts"` /
`Could not resolve ".../vite.downloads.config.ts"`) is now green.

## What was added

- `my-app/vite.downloads.config.ts` — mirrors `vite.history.config.ts`, inputs `src/renderer/downloads/downloads.html`
- `my-app/src/preload/downloads.ts` — contextBridge surface: `list`, `remove`, `openFile`, `showInFolder`, `retry`, `pause`, `resume`, `cancel`, `clearAll`, `navigateTo`, `onStateChange`
- `my-app/src/renderer/downloads/downloads.html` + `index.tsx` — React entry
- `my-app/src/renderer/downloads/DownloadsPage.tsx` — list view with search, date grouping, per-item actions (open / show-in-folder / retry / pause / resume / cancel / remove), live updates via the existing `downloads-state` IPC event, and a `Clear all` button
- `my-app/src/renderer/downloads/downloads.css` — matches the look of `history.css` / `extensions.css`
- `my-app/tests/unit/downloads/DownloadsPage.spec.tsx` — renderer smoke tests (headline, empty state, per-row actions, search filter, retry path)
- `my-app/vitest.onboarding.config.ts` — include the new `tests/unit/downloads/**/*.spec.tsx` path (same jsdom + @testing-library/react harness already used for `Welcome.spec.tsx`)

## Main-process additions

Three new handlers on `DownloadManager` (existing contract: `my-app/src/main/downloads/DownloadManager.ts`):

- `downloads:remove` — drops a single entry (cancels in-flight first)
- `downloads:retry` — re-issues the URL via `session.defaultSession.downloadURL`; the old record is dropped so a fresh `will-download` event creates a new entry
- `downloads:clear-all` — drops every tracked entry (in-flight cancelled)

All three piggyback on the existing `broadcastState()` so the download bubble UI in the shell stays in sync. No existing behavior changes.

## Forge config

`my-app/forge.config.ts` already has the uncommented `preloads` entry for `src/preload/downloads.ts` (~line 195) and the `renderer.build` entry for `vite.downloads.config.ts` / name `downloads` (~lines 248-252) on `main`. No revert was needed on this branch since it was cut from `origin/main`, not from PR #106's workaround branch.

## Unblocks

- Commit 60ddc35 (`feat(downloads): chrome://downloads page with search and per-item actions`) — only committed `AppMenuButton.tsx` + `components.css`, not the preload/vite config/renderer entries that the description claimed
- PR #106's build job, which worked around the break by commenting out the forge entries

## Validation

- `npm run lint` — 308 problems (46 errors, 262 warnings), identical count pre-change; none attributable to the new files
- `npm run test` — 5 pre-existing failures, no new ones; the new renderer spec is in the React/jsdom config and passes (`npx vitest run --config vitest.onboarding.config.ts tests/unit/downloads`, 7/7 green)
- `SKIP_SIGNING=1 npm run package` — builds all renderer + preload targets including the new `downloads` bundle and produces the `.app`

## Test plan

- [ ] Open the app, trigger a download (any large file), and confirm the download bubble still shows it (existing behavior unchanged).
- [ ] Open the Downloads menu (⋮ -> Downloads, or the menu-bar entry) and confirm `chrome://downloads` loads, listing the download.
- [ ] Use the search box to filter by filename substring.
- [ ] For a completed download, click `Show in folder` and confirm Finder opens with the file selected.
- [ ] For an in-progress download, click `Pause` / `Resume` / `Cancel` and confirm the state updates in real time (both on the page and in the bubble).
- [ ] For a cancelled/failed download, click `Retry` and confirm a new entry appears.
- [ ] Click the per-row `x` button and confirm the row disappears.
- [ ] Click `Clear all` and confirm the list empties.
- [ ] Run `npx vitest run --config vitest.onboarding.config.ts tests/unit/downloads` and confirm 7/7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `chrome://downloads` scaffold and IPC handlers, restoring `npm run package` and shipping a functional downloads page. This unblocks the build by providing the preload and Vite config that `forge.config.ts` expects.

- New Features
  - `chrome://downloads` page with list, search, date grouping, per-item actions, “Clear all,” and live updates via `downloads-state`.
  - Preload API (`src/preload/downloads.ts`): `list`, `remove`, `openFile`, `showInFolder`, `retry`, `pause`, `resume`, `cancel`, `clearAll`, `navigateTo`, `onStateChange`.
  - `DownloadManager` IPC handlers: `downloads:remove`, `downloads:retry`, `downloads:clear-all`.
  - Vite entry `vite.downloads.config.ts` and renderer files (`downloads.html`, `index.tsx`, `DownloadsPage.tsx`, `downloads.css`).
  - Unit tests for the downloads page; `vitest.onboarding.config.ts` updated to include them.

- Bug Fixes
  - Fixes packaging failure by resolving `src/preload/downloads.ts` and `vite.downloads.config.ts` referenced by `forge.config.ts`.
  - No behavior changes to existing downloads; state broadcasts keep the shell bubble in sync.

<sup>Written for commit 66811f4b4cc6e5c7e7d1908ad5a352da4519ded6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

