### PR TITLE
feat(permissions): niche permissions for Chrome parity

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -31,6 +31,7 @@
         "@electron-forge/plugin-vite": "^7.11.1",
         "@electron/fuses": "^1.8.0",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/electron-squirrel-startup": "^1.0.2",
         "@types/node": "^20.14.0",
@@ -3017,7 +3018,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3038,7 +3038,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3052,7 +3051,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3067,8 +3065,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3124,8 +3121,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4172,7 +4168,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5382,7 +5377,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5456,8 +5450,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -9201,7 +9194,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -45,6 +45,7 @@
     "@electron-forge/plugin-vite": "^7.11.1",
     "@electron/fuses": "^1.8.0",
     "@playwright/test": "^1.59.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/electron-squirrel-startup": "^1.0.2",
     "@types/node": "^20.14.0",

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -61,6 +61,7 @@ import {
 import { PermissionStore } from './permissions/PermissionStore';
 import { PermissionManager } from './permissions/PermissionManager';
 import { registerPermissionHandlers, unregisterPermissionHandlers } from './permissions/ipc';
+import { ProtocolHandlerStore } from './permissions/ProtocolHandlerStore';
 // Issue #71 — Extensions
 import { ExtensionManager } from './extensions/ExtensionManager';
 import { registerExtensionsHandlers, unregisterExtensionsHandlers } from './extensions/ipc';
@@ -141,6 +142,7 @@ let permissionManager: PermissionManager | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
 let downloadManager: DownloadManager | null = null;
+let protocolHandlerStore: ProtocolHandlerStore | null = null;
 let activeProfileId = 'default';
 let isGuestSession = false;
 let guestPartitionName: string | null = null;
@@ -190,6 +192,7 @@ function openShellAndWire(profileId?: string): BrowserWindow {
       store: permissionStore,
       manager: permissionManager,
       getShellWindow: () => shellWindow,
+      protocolHandlerStore: protocolHandlerStore ?? undefined,
     });
   }
 
@@ -348,6 +351,7 @@ app.whenReady().then(async () => {
   // only PermissionStore accepts a data dir today.
   bookmarkStore = new BookmarkStore();
   permissionStore = new PermissionStore(getProfileDataDir(activeProfileId));
+  protocolHandlerStore = new ProtocolHandlerStore(getProfileDataDir(activeProfileId));
   registerBookmarkHandlers({
     store: bookmarkStore,
     getShellWindow: () => shellWindow,
@@ -571,6 +575,7 @@ app.whenReady().then(async () => {
       bookmarkStore?.flushSync();
       historyStore?.flushSync();
       permissionStore?.flushSync();
+      protocolHandlerStore?.flushSync();
     }
     await teardownHl();
   });

--- a/my-app/src/main/permissions/PermissionManager.ts
+++ b/my-app/src/main/permissions/PermissionManager.ts
@@ -27,16 +27,25 @@ const ELECTRON_PERMISSION_MAP: Record<string, PermissionType> = {
   'sensors': 'sensors',
   'camera': 'camera',
   'microphone': 'microphone',
+  'xr': 'webxr',
+  'ambient-light-sensor': 'ambient-light-sensor',
+  'payment-handler': 'payment-handler',
+  'background-sync': 'background-sync',
+  'protocol-handler': 'protocol-handler',
 };
 
 // Permissions that are auto-granted without prompting.
 // Sensors auto-grant on desktop (Chrome-parity: granted silently unless blocked).
+// Background sync is auto-granted in Chrome (only blocked explicitly).
+// Payment handler is auto-granted in Chrome (registered sites handle payments).
 const AUTO_GRANT: Set<PermissionType> = new Set([
   'fullscreen',
   'clipboard-sanitized-write',
   'media',
   'pointerLock',
   'sensors',
+  'background-sync',
+  'payment-handler',
 ]);
 
 // How long to wait for a paired camera+mic request before prompting individually (ms)

--- a/my-app/src/main/permissions/PermissionStore.ts
+++ b/my-app/src/main/permissions/PermissionStore.ts
@@ -29,6 +29,11 @@ export type PermissionType =
   | 'media'
   | 'sensors'
   | 'idle-detection'
+  | 'webxr'
+  | 'ambient-light-sensor'
+  | 'payment-handler'
+  | 'background-sync'
+  | 'protocol-handler'
   | 'unknown';
 
 export interface PermissionRecord {
@@ -58,6 +63,11 @@ const DEFAULT_PERMISSION_STATES: Record<PermissionType, PermissionState> = {
   media: 'allow',
   sensors: 'allow',
   'idle-detection': 'ask',
+  webxr: 'ask',
+  'ambient-light-sensor': 'ask',
+  'payment-handler': 'allow',
+  'background-sync': 'allow',
+  'protocol-handler': 'ask',
   unknown: 'ask',
 };
 

--- a/my-app/src/main/permissions/ProtocolHandlerStore.ts
+++ b/my-app/src/main/permissions/ProtocolHandlerStore.ts
@@ -1,0 +1,141 @@
+/**
+ * ProtocolHandlerStore — persistent storage for navigator.registerProtocolHandler() registrations.
+ *
+ * Mirrors chrome://settings/handlers — tracks which origins have registered
+ * to handle which URL schemes (e.g. "mailto:", "web+custom:").
+ * Follows the same debounced-atomic-write pattern as BookmarkStore / PermissionStore.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { mainLogger } from '../logger';
+
+const HANDLERS_FILE_NAME = 'protocol-handlers.json';
+const DEBOUNCE_MS = 300;
+
+export interface ProtocolHandlerRecord {
+  protocol: string;
+  origin: string;
+  url: string;
+  registeredAt: number;
+}
+
+interface PersistedHandlers {
+  version: 1;
+  handlers: ProtocolHandlerRecord[];
+}
+
+function makeEmpty(): PersistedHandlers {
+  return { version: 1, handlers: [] };
+}
+
+export class ProtocolHandlerStore {
+  private readonly filePath: string;
+  private state: PersistedHandlers;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor(dataDir?: string) {
+    this.filePath = path.join(dataDir ?? app.getPath('userData'), HANDLERS_FILE_NAME);
+    mainLogger.info('ProtocolHandlerStore.constructor', { filePath: this.filePath });
+    this.state = this.load();
+    mainLogger.info('ProtocolHandlerStore.init', { handlerCount: this.state.handlers.length });
+  }
+
+  private load(): PersistedHandlers {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedHandlers;
+      if (parsed.version !== 1 || !Array.isArray(parsed.handlers)) {
+        mainLogger.warn('ProtocolHandlerStore.load.invalid', { msg: 'Resetting handlers' });
+        return makeEmpty();
+      }
+      mainLogger.info('ProtocolHandlerStore.load.ok', { handlerCount: parsed.handlers.length });
+      return parsed;
+    } catch {
+      mainLogger.info('ProtocolHandlerStore.load.fresh', { msg: 'No protocol-handlers.json — starting fresh' });
+      return makeEmpty();
+    }
+  }
+
+  private schedulePersist(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2), 'utf-8');
+      mainLogger.info('ProtocolHandlerStore.flushSync.ok');
+    } catch (err) {
+      mainLogger.error('ProtocolHandlerStore.flushSync.failed', { error: (err as Error).message });
+    }
+    this.dirty = false;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Queries
+  // -------------------------------------------------------------------------
+
+  getAll(): ProtocolHandlerRecord[] {
+    return [...this.state.handlers];
+  }
+
+  getForProtocol(protocol: string): ProtocolHandlerRecord[] {
+    return this.state.handlers.filter((h) => h.protocol === protocol);
+  }
+
+  getForOrigin(origin: string): ProtocolHandlerRecord[] {
+    return this.state.handlers.filter((h) => h.origin === origin);
+  }
+
+  has(protocol: string, origin: string): boolean {
+    return this.state.handlers.some((h) => h.protocol === protocol && h.origin === origin);
+  }
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  register(protocol: string, origin: string, url: string): void {
+    const existing = this.state.handlers.find(
+      (h) => h.protocol === protocol && h.origin === origin,
+    );
+    if (existing) {
+      existing.url = url;
+      existing.registeredAt = Date.now();
+      mainLogger.info('ProtocolHandlerStore.register.updated', { protocol, origin, url });
+    } else {
+      this.state.handlers.push({ protocol, origin, url, registeredAt: Date.now() });
+      mainLogger.info('ProtocolHandlerStore.register.added', { protocol, origin, url });
+    }
+    this.schedulePersist();
+  }
+
+  unregister(protocol: string, origin: string): boolean {
+    const before = this.state.handlers.length;
+    this.state.handlers = this.state.handlers.filter(
+      (h) => !(h.protocol === protocol && h.origin === origin),
+    );
+    if (this.state.handlers.length < before) {
+      mainLogger.info('ProtocolHandlerStore.unregister', { protocol, origin });
+      this.schedulePersist();
+      return true;
+    }
+    return false;
+  }
+
+  clearAll(): void {
+    this.state.handlers = [];
+    mainLogger.info('ProtocolHandlerStore.clearAll');
+    this.schedulePersist();
+  }
+}

--- a/my-app/src/main/permissions/ProtocolHandlerStore.ts
+++ b/my-app/src/main/permissions/ProtocolHandlerStore.ts
@@ -71,10 +71,10 @@ export class ProtocolHandlerStore {
       fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
       fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2), 'utf-8');
       mainLogger.info('ProtocolHandlerStore.flushSync.ok');
+      this.dirty = false;
     } catch (err) {
       mainLogger.error('ProtocolHandlerStore.flushSync.failed', { error: (err as Error).message });
     }
-    this.dirty = false;
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;

--- a/my-app/src/main/permissions/ProtocolHandlerStore.ts
+++ b/my-app/src/main/permissions/ProtocolHandlerStore.ts
@@ -72,12 +72,13 @@ export class ProtocolHandlerStore {
       fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2), 'utf-8');
       mainLogger.info('ProtocolHandlerStore.flushSync.ok');
       this.dirty = false;
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = null;
+      }
     } catch (err) {
       mainLogger.error('ProtocolHandlerStore.flushSync.failed', { error: (err as Error).message });
-    }
-    if (this.debounceTimer) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = null;
+      this.schedulePersist();
     }
   }
 

--- a/my-app/src/main/permissions/ipc.ts
+++ b/my-app/src/main/permissions/ipc.ts
@@ -7,15 +7,17 @@ import { ipcMain, BrowserWindow } from 'electron';
 import { mainLogger } from '../logger';
 import { PermissionStore, PermissionType, PermissionState } from './PermissionStore';
 import { PermissionManager, PermissionDecision } from './PermissionManager';
+import { ProtocolHandlerStore } from './ProtocolHandlerStore';
 
 export interface RegisterPermissionHandlersOptions {
   store: PermissionStore;
   manager: PermissionManager;
   getShellWindow: () => BrowserWindow | null;
+  protocolHandlerStore?: ProtocolHandlerStore;
 }
 
 export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptions): void {
-  const { store, manager } = opts;
+  const { store, manager, protocolHandlerStore } = opts;
 
   ipcMain.handle('permissions:respond', (_e, promptId: string, decision: string) => {
     mainLogger.info('permissions:respond', { promptId, decision });
@@ -59,6 +61,39 @@ export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptio
     store.resetAllSitePermissions();
   });
 
+  // Protocol handler management (chrome://settings/handlers parity)
+  if (protocolHandlerStore) {
+    ipcMain.handle('protocol-handlers:get-all', () => {
+      mainLogger.info('protocol-handlers:get-all');
+      return protocolHandlerStore.getAll();
+    });
+
+    ipcMain.handle('protocol-handlers:get-for-protocol', (_e, protocol: string) => {
+      mainLogger.info('protocol-handlers:get-for-protocol', { protocol });
+      return protocolHandlerStore.getForProtocol(protocol);
+    });
+
+    ipcMain.handle('protocol-handlers:get-for-origin', (_e, origin: string) => {
+      mainLogger.info('protocol-handlers:get-for-origin', { origin });
+      return protocolHandlerStore.getForOrigin(origin);
+    });
+
+    ipcMain.handle('protocol-handlers:register', (_e, protocol: string, origin: string, url: string) => {
+      mainLogger.info('protocol-handlers:register', { protocol, origin, url });
+      protocolHandlerStore.register(protocol, origin, url);
+    });
+
+    ipcMain.handle('protocol-handlers:unregister', (_e, protocol: string, origin: string) => {
+      mainLogger.info('protocol-handlers:unregister', { protocol, origin });
+      return protocolHandlerStore.unregister(protocol, origin);
+    });
+
+    ipcMain.handle('protocol-handlers:clear-all', () => {
+      mainLogger.info('protocol-handlers:clear-all');
+      protocolHandlerStore.clearAll();
+    });
+  }
+
   mainLogger.info('permissions.ipc.registered');
 }
 
@@ -73,5 +108,11 @@ export function unregisterPermissionHandlers(): void {
   ipcMain.removeHandler('permissions:set-default');
   ipcMain.removeHandler('permissions:get-all');
   ipcMain.removeHandler('permissions:reset-all');
+  ipcMain.removeHandler('protocol-handlers:get-all');
+  ipcMain.removeHandler('protocol-handlers:get-for-protocol');
+  ipcMain.removeHandler('protocol-handlers:get-for-origin');
+  ipcMain.removeHandler('protocol-handlers:register');
+  ipcMain.removeHandler('protocol-handlers:unregister');
+  ipcMain.removeHandler('protocol-handlers:clear-all');
   mainLogger.info('permissions.ipc.unregistered');
 }

--- a/my-app/src/main/permissions/ipc.ts
+++ b/my-app/src/main/permissions/ipc.ts
@@ -80,7 +80,11 @@ export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptio
 
     ipcMain.handle('protocol-handlers:register', (e, protocol: string, origin: string, url: string) => {
       const senderOrigin = e.senderFrame?.origin;
-      if (senderOrigin && senderOrigin !== origin) {
+      if (!senderOrigin) {
+        mainLogger.warn('protocol-handlers:register.no-sender-origin', { claimedOrigin: origin });
+        throw new Error('Cannot verify caller origin');
+      }
+      if (senderOrigin !== origin) {
         mainLogger.warn('protocol-handlers:register.origin-mismatch', { senderOrigin, claimedOrigin: origin });
         throw new Error('Origin mismatch: caller origin does not match claimed origin');
       }

--- a/my-app/src/main/permissions/ipc.ts
+++ b/my-app/src/main/permissions/ipc.ts
@@ -78,7 +78,12 @@ export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptio
       return protocolHandlerStore.getForOrigin(origin);
     });
 
-    ipcMain.handle('protocol-handlers:register', (_e, protocol: string, origin: string, url: string) => {
+    ipcMain.handle('protocol-handlers:register', (e, protocol: string, origin: string, url: string) => {
+      const senderOrigin = e.senderFrame?.origin;
+      if (senderOrigin && senderOrigin !== origin) {
+        mainLogger.warn('protocol-handlers:register.origin-mismatch', { senderOrigin, claimedOrigin: origin });
+        throw new Error('Origin mismatch: caller origin does not match claimed origin');
+      }
       mainLogger.info('protocol-handlers:register', { protocol, origin, url });
       protocolHandlerStore.register(protocol, origin, url);
     });

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -13,6 +13,7 @@ import type {
 } from '../main/bookmarks/BookmarkStore';
 import type { PermissionRecord, PermissionType, PermissionState } from '../main/permissions/PermissionStore';
 import type { PermissionPromptRequest } from '../main/permissions/PermissionManager';
+import type { ProtocolHandlerRecord } from '../main/permissions/ProtocolHandlerStore';
 import type { DownloadItemDTO } from '../main/downloads/DownloadManager';
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,7 @@ export type {
   PermissionType,
   PermissionState,
   PermissionPromptRequest,
+  ProtocolHandlerRecord,
   DownloadItemDTO,
 };
 
@@ -228,6 +230,27 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     resetAll: (): Promise<void> =>
       ipcRenderer.invoke('permissions:reset-all'),
+  },
+
+  // Protocol handlers — chrome://settings/handlers parity
+  protocolHandlers: {
+    getAll: (): Promise<ProtocolHandlerRecord[]> =>
+      ipcRenderer.invoke('protocol-handlers:get-all'),
+
+    getForProtocol: (protocol: string): Promise<ProtocolHandlerRecord[]> =>
+      ipcRenderer.invoke('protocol-handlers:get-for-protocol', protocol),
+
+    getForOrigin: (origin: string): Promise<ProtocolHandlerRecord[]> =>
+      ipcRenderer.invoke('protocol-handlers:get-for-origin', origin),
+
+    register: (protocol: string, origin: string, url: string): Promise<void> =>
+      ipcRenderer.invoke('protocol-handlers:register', protocol, origin, url),
+
+    unregister: (protocol: string, origin: string): Promise<boolean> =>
+      ipcRenderer.invoke('protocol-handlers:unregister', protocol, origin),
+
+    clearAll: (): Promise<void> =>
+      ipcRenderer.invoke('protocol-handlers:clear-all'),
   },
 
   // Shell-level signals (renderer → main)

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -42,6 +42,7 @@ type TabId =
   | typeof TAB_PASSWORDS
   | typeof TAB_PROFILES
   | typeof TAB_PRIVACY
+  | typeof TAB_PASSWORDS
   | typeof TAB_ZOOM
   | typeof TAB_DANGER;
 
@@ -135,7 +136,6 @@ declare global {
       getShowProfilePicker: () => Promise<boolean>;
       setShowProfilePicker: (show: boolean) => Promise<void>;
       closeWindow: () => void;
-      // Password manager bridge (see src/preload/settings.ts)
       listPasswords: () => Promise<PasswordListEntry[]>;
       revealPassword: (id: string) => Promise<string | null>;
       updatePassword: (payload: { id: string; username?: string; password?: string }) => Promise<boolean>;

--- a/my-app/src/renderer/shell/PermissionBar.tsx
+++ b/my-app/src/renderer/shell/PermissionBar.tsx
@@ -24,6 +24,11 @@ const PERMISSION_LABELS: Record<string, string> = {
   sensors: 'use motion sensors',
   'idle-detection': 'know when you\'re idle',
   openExternal: 'open external applications',
+  webxr: 'use virtual or augmented reality',
+  'ambient-light-sensor': 'use the ambient light sensor',
+  'payment-handler': 'handle payment requests',
+  'background-sync': 'sync data in the background',
+  'protocol-handler': 'handle links for a protocol',
   unknown: 'use a feature',
 };
 
@@ -37,6 +42,12 @@ const PERMISSION_ICONS: Record<string, string> = {
   geolocation: 'M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z',
   notifications: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9',
   'camera+microphone': 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z',
+  webxr: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+  'ambient-light-sensor': 'M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z',
+  'payment-handler': 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z',
+  'background-sync': 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
+  'protocol-handler': 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
+  'idle-detection': 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
 };
 
 interface PermissionPromptData {

--- a/my-app/tests/e2e/pill-flow.spec.ts
+++ b/my-app/tests/e2e/pill-flow.spec.ts
@@ -250,9 +250,6 @@ async function injectMockAgentEvents(
 ): Promise<void> {
   await electronApp.evaluate(async (_, tid) => {
     try {
-      // Runtime path is relative to the packaged main.js inside the app bundle,
-      // not to this spec. Built as a dynamic expression so tsc doesn't try to
-      // resolve it against the test tree.
       const mod = await import(/* @vite-ignore */ './daemonLifecycle' as string);
       const forwardAgentEvent = (mod as { forwardAgentEvent: (ev: unknown) => void }).forwardAgentEvent;
       // Step 1

--- a/my-app/tests/fixtures/electron-mock.ts
+++ b/my-app/tests/fixtures/electron-mock.ts
@@ -27,10 +27,10 @@ export const app = {
 };
 
 export const ipcMain = {
-  handle: (): undefined => undefined,
-  removeHandler: (): undefined => undefined,
-  on: (): undefined => undefined,
-  off: (): undefined => undefined,
+  handle: (): void => undefined,
+  removeHandler: (): void => undefined,
+  on: (): void => undefined,
+  off: (): void => undefined,
   emit: (): boolean => false,
 };
 
@@ -41,8 +41,8 @@ export const BrowserWindow = {
 
 export const globalShortcut = {
   register: (): boolean => false,
-  unregister: (): undefined => undefined,
-  unregisterAll: (): undefined => undefined,
+  unregister: (): void => undefined,
+  unregisterAll: (): void => undefined,
 };
 
 export const screen = {
@@ -56,8 +56,8 @@ export const screen = {
 };
 
 export const nativeImage = {
-  createEmpty: () => ({}),
-  createFromPath: () => ({}),
+  createEmpty: (): Record<string, never> => ({}),
+  createFromPath: (): Record<string, never> => ({}),
 };
 
 export const shell = {
@@ -87,20 +87,20 @@ const sessionStub = {
   removeAllListeners: (_event?: string) => sessionStub,
 
   // permissions
-  setPermissionRequestHandler: (_handler: unknown): undefined => undefined,
-  setPermissionCheckHandler: (_handler: unknown): undefined => undefined,
-  setDevicePermissionHandler: (_handler: unknown): undefined => undefined,
+  setPermissionRequestHandler: (_handler: unknown): void => undefined,
+  setPermissionCheckHandler: (_handler: unknown): void => undefined,
+  setDevicePermissionHandler: (_handler: unknown): void => undefined,
 
   // web request interception (DeclarativeNetRequestEngine)
   webRequest: {
-    onBeforeRequest: (_listener: unknown): undefined => undefined,
-    onBeforeSendHeaders: (_listener: unknown): undefined => undefined,
-    onSendHeaders: (_listener: unknown): undefined => undefined,
-    onHeadersReceived: (_listener: unknown): undefined => undefined,
-    onResponseStarted: (_listener: unknown): undefined => undefined,
-    onBeforeRedirect: (_listener: unknown): undefined => undefined,
-    onCompleted: (_listener: unknown): undefined => undefined,
-    onErrorOccurred: (_listener: unknown): undefined => undefined,
+    onBeforeRequest: (_listener: unknown): void => undefined,
+    onBeforeSendHeaders: (_listener: unknown): void => undefined,
+    onSendHeaders: (_listener: unknown): void => undefined,
+    onHeadersReceived: (_listener: unknown): void => undefined,
+    onResponseStarted: (_listener: unknown): void => undefined,
+    onBeforeRedirect: (_listener: unknown): void => undefined,
+    onCompleted: (_listener: unknown): void => undefined,
+    onErrorOccurred: (_listener: unknown): void => undefined,
   },
 
   // data clearing (ClearDataController)
@@ -109,7 +109,7 @@ const sessionStub = {
   clearHistory: (): Promise<void> => Promise.resolve(),
   clearHostResolverCache: (): Promise<void> => Promise.resolve(),
   clearStorageData: (_options?: unknown): Promise<void> => Promise.resolve(),
-  flushStorageData: (): undefined => undefined,
+  flushStorageData: (): void => undefined,
 
   cookies: {
     get: (): Promise<unknown[]> => Promise.resolve([]),
@@ -119,7 +119,7 @@ const sessionStub = {
   },
 
   // extensions (ExtensionManager)
-  loadExtension: (_path: string, _opts?: unknown) =>
+  loadExtension: (_path: string, _opts?: unknown): Promise<{ id: string; manifest: Record<string, never>; name: string; path: string; version: string }> =>
     Promise.resolve({
       id: 'mock-ext-id',
       manifest: {},
@@ -127,52 +127,52 @@ const sessionStub = {
       path: _path,
       version: '0.0.0',
     }),
-  removeExtension: (_id: string): undefined => undefined,
+  removeExtension: (_id: string): void => undefined,
   getExtension: (_id: string): null => null,
   getAllExtensions: (): unknown[] => [],
 
   // spell check / proxies / misc
-  setSpellCheckerEnabled: (_enabled: boolean): undefined => undefined,
+  setSpellCheckerEnabled: (_enabled: boolean): void => undefined,
   isSpellCheckerEnabled: (): boolean => false,
   setProxy: (_config: unknown): Promise<void> => Promise.resolve(),
   resolveProxy: (_url: string): Promise<string> => Promise.resolve(''),
 
   // service workers (ServiceWorkerManager)
   serviceWorkers: {
-    getAllRunning: (): Record<string, unknown> => ({}),
+    getAllRunning: (): Record<string, never> => ({}),
     getFromVersionID: (_id: number): null => null,
     startWorkerForScope: (_scope: string): Promise<void> => Promise.resolve(),
   },
 
   // user agent
   getUserAgent: (): string => 'mock-ua',
-  setUserAgent: (_ua: string): undefined => undefined,
+  setUserAgent: (_ua: string): void => undefined,
 
   // certificate handlers
-  setCertificateVerifyProc: (_proc: unknown): undefined => undefined,
+  setCertificateVerifyProc: (_proc: unknown): void => undefined,
 };
 
 export const session = {
   defaultSession: sessionStub,
-  fromPartition: (_partition: string) => sessionStub,
+  fromPartition: (_partition: string): typeof sessionStub => sessionStub,
 };
 
 // Many main-process modules reach for app.whenReady via the namespace import.
 // The `protocol` module is also referenced by custom scheme registration code.
 export const protocol = {
-  registerSchemesAsPrivileged: (_schemes: unknown[]): undefined => undefined,
-  registerFileProtocol: (_scheme: string, _handler: unknown): undefined => undefined,
-  registerStringProtocol: (_scheme: string, _handler: unknown): undefined => undefined,
-  registerBufferProtocol: (_scheme: string, _handler: unknown): undefined => undefined,
-  handle: (_scheme: string, _handler: unknown): undefined => undefined,
-  unhandle: (_scheme: string): undefined => undefined,
+  registerSchemesAsPrivileged: (_schemes: unknown[]): void => undefined,
+  registerFileProtocol: (_scheme: string, _handler: unknown): void => undefined,
+  registerStringProtocol: (_scheme: string, _handler: unknown): void => undefined,
+  registerBufferProtocol: (_scheme: string, _handler: unknown): void => undefined,
+  handle: (_scheme: string, _handler: unknown): void => undefined,
+  unhandle: (_scheme: string): void => undefined,
 };
 
 export const Menu = {
-  setApplicationMenu: (_menu: unknown): undefined => undefined,
+  setApplicationMenu: (_menu: unknown): void => undefined,
   buildFromTemplate: (_template: unknown[]) => ({
-    popup: (): undefined => undefined,
-    closePopup: (): undefined => undefined,
+    popup: (): void => undefined,
+    closePopup: (): void => undefined,
   }),
   getApplicationMenu: (): null => null,
 };

--- a/my-app/tests/regression/preload-path.spec.ts
+++ b/my-app/tests/regression/preload-path.spec.ts
@@ -131,7 +131,7 @@ test.describe('preload path integrity', () => {
     const page = await getShellWindow(electronApp);
     log(`Shell window URL: ${page.url()}`);
 
-    const hasApi = await page.evaluate(() => typeof window.electronAPI !== 'undefined');
+    const hasApi = await page.evaluate(() => typeof (window as any).electronAPI !== 'undefined');
     expect(hasApi, 'window.electronAPI must be defined — preload path is broken if this fails').toBe(true);
   });
 

--- a/my-app/tests/unit/onboarding/GoogleScopesModal.spec.tsx
+++ b/my-app/tests/unit/onboarding/GoogleScopesModal.spec.tsx
@@ -14,7 +14,8 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/dom';
 import React from 'react';
 import type { GoogleOAuthScope } from '../../../src/shared/types';
 

--- a/my-app/tests/unit/onboarding/Welcome.spec.tsx
+++ b/my-app/tests/unit/onboarding/Welcome.spec.tsx
@@ -12,7 +12,8 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/dom';
 import React from 'react';
 
 // Stub CSS imports so vitest doesn't choke on them


### PR DESCRIPTION
## Summary
- Add 5 new permission types: `webxr`, `ambient-light-sensor`, `payment-handler`, `background-sync`, `protocol-handler`
- Map Electron permission strings (`xr`, `ambient-light-sensor`, `payment-handler`, `background-sync`, `protocol-handler`) to internal types
- Auto-grant `background-sync` and `payment-handler` (Chrome parity: granted silently unless blocked)
- Add user-facing prompt labels and SVG icons for all new types in PermissionBar

## Checklist from issue
- [x] WebXR immersive-vr and immersive-ar per-origin grants
- [x] Ambient-light-sensor prompt
- [x] Idle Detection API (already existed)
- [x] Payment Handlers (auto-granted, Chrome parity)
- [x] Background Sync default (auto-granted, Chrome parity)
- [x] registerProtocolHandler → protocol-handler permission type

## Test plan
- [ ] Navigate to a page requesting WebXR and verify prompt appears with VR/AR label and monitor icon
- [ ] Verify ambient light sensor prompt shows sun icon and correct label
- [ ] Confirm background-sync and payment-handler requests are auto-granted without prompt
- [ ] Test protocol handler registration triggers permission prompt
- [ ] Verify Allow/Never/Allow-this-time decisions persist correctly for new types
- [ ] Check permissions.json includes new default entries

Closes #57

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five Chrome-parity permission types and a persistent protocol handler store with prompts, icons, and Chrome-matching defaults; exposes handler management via IPC/preload for chrome://settings/handlers parity. Closes #57.

- **New Features**
  - Map Electron strings: `xr` → `webxr`, `ambient-light-sensor`, `payment-handler`, `background-sync`, `protocol-handler`.
  - Defaults: `webxr`, `ambient-light-sensor`, `protocol-handler` → ask; `payment-handler`, `background-sync` → allow.
  - PermissionBar: labels and SVG icons for all new types.
  - Add ProtocolHandlerStore: persist `registerProtocolHandler()` records; IPC/preload methods (`getAll`, `getForProtocol`, `getForOrigin`, `register`, `unregister`, `clearAll`); wired into app init and flush.

- **Bug Fixes**
  - Block protocol handler registrations when sender origin is missing or mismatched.
  - Keep dirty state and retry persistence on failed writes.
  - Type/CI: remove deprecated Vite `browserField`; add missing `window.settingsAPI` methods and `TAB_PASSWORDS`; add return type annotations to `electron-mock.ts`; add `@testing-library/dom` and update imports for v16 compatibility.

<sup>Written for commit 7413c4bc69f997af3984b64684b1cb3d63891fd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

