### PR TITLE
feat(extensions): Manifest V3 runtime integration

### DIFF
--- a/my-app/src/main/extensions/ExtensionManager.ts
+++ b/my-app/src/main/extensions/ExtensionManager.ts
@@ -4,12 +4,15 @@
  * Handles loading, enabling, disabling, and removing extensions.
  * Persists extension state (enabled/disabled, paths) to a JSON file in userData.
  * Uses session.defaultSession.loadExtension / removeExtension under the hood.
+ * Delegates MV3-specific lifecycle to ManifestV3Runtime.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { app, session } from 'electron';
 import { mainLogger } from '../logger';
+import { ManifestV3Runtime } from './mv3/ManifestV3Runtime';
+import type { MV3ExtensionInfo } from './mv3/ManifestV3Runtime';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,6 +29,7 @@ export interface ExtensionRecord {
   hostPermissions: string[];
   hostAccess: 'all-sites' | 'specific-sites' | 'on-click';
   icons: Record<string, string>;
+  manifestVersion: number;
 }
 
 interface PersistedState {
@@ -52,10 +56,12 @@ const LOG_PREFIX = 'ExtensionManager';
 export class ExtensionManager {
   private statePath: string;
   private state: PersistedState;
+  readonly mv3Runtime: ManifestV3Runtime;
 
   constructor() {
     this.statePath = path.join(app.getPath('userData'), STATE_FILE_NAME);
     this.state = this.loadState();
+    this.mv3Runtime = new ManifestV3Runtime();
     mainLogger.info(`${LOG_PREFIX}.init`, {
       statePath: this.statePath,
       extensionCount: this.state.extensions.length,
@@ -103,6 +109,32 @@ export class ExtensionManager {
   }
 
   // -------------------------------------------------------------------------
+  // MV3 lifecycle hook — called after Electron loads an extension
+  // -------------------------------------------------------------------------
+
+  private notifyMV3Loaded(extensionId: string, extensionPath: string): MV3ExtensionInfo | null {
+    mainLogger.info(`${LOG_PREFIX}.notifyMV3Loaded`, { extensionId, extensionPath });
+    const info = this.mv3Runtime.onExtensionLoaded(extensionId, extensionPath);
+    if (info) {
+      mainLogger.info(`${LOG_PREFIX}.notifyMV3Loaded.mv3Active`, {
+        extensionId,
+        isServiceWorker: info.isServiceWorker,
+        hasDeclarativeNetRequest: info.hasDeclarativeNetRequest,
+        hasActionApi: info.hasActionApi,
+        hasActiveTab: info.hasActiveTab,
+      });
+    }
+    return info;
+  }
+
+  private notifyMV3Unloaded(extensionId: string): void {
+    if (this.mv3Runtime.isMV3Extension(extensionId)) {
+      mainLogger.info(`${LOG_PREFIX}.notifyMV3Unloaded`, { extensionId });
+      this.mv3Runtime.onExtensionUnloaded(extensionId);
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Startup: load all enabled extensions into the session
   // -------------------------------------------------------------------------
 
@@ -137,6 +169,7 @@ export class ExtensionManager {
           id: ext.id,
           name: ext.name,
         });
+        this.notifyMV3Loaded(ext.id, record.path);
       } catch (err) {
         mainLogger.error(`${LOG_PREFIX}.loadAllEnabled.loadFailed`, {
           id: record.id,
@@ -162,6 +195,7 @@ export class ExtensionManager {
     for (const record of this.state.extensions) {
       const live = loadedMap.get(record.id);
       const manifest = live?.manifest as Record<string, unknown> | undefined;
+      const manifestVersion = (manifest?.manifest_version as number) ?? 2;
 
       results.push({
         id: record.id,
@@ -174,6 +208,7 @@ export class ExtensionManager {
         hostPermissions: (manifest?.host_permissions as string[]) ?? [],
         hostAccess: (record.hostAccess as ExtensionRecord['hostAccess']) ?? 'on-click',
         icons: this.extractIcons(manifest, record.path),
+        manifestVersion,
       });
     }
 
@@ -212,6 +247,7 @@ export class ExtensionManager {
     }
 
     this.saveState();
+    this.notifyMV3Loaded(ext.id, resolvedPath);
 
     const manifest = ext.manifest as Record<string, unknown>;
     const record: ExtensionRecord = {
@@ -225,6 +261,7 @@ export class ExtensionManager {
       hostPermissions: (manifest?.host_permissions as string[]) ?? [],
       hostAccess: 'on-click',
       icons: this.extractIcons(manifest, resolvedPath),
+      manifestVersion: (manifest?.manifest_version as number) ?? 2,
     };
 
     mainLogger.info(`${LOG_PREFIX}.loadUnpacked.ok`, {
@@ -251,6 +288,7 @@ export class ExtensionManager {
 
     record.enabled = true;
     this.saveState();
+    this.notifyMV3Loaded(id, record.path);
     mainLogger.info(`${LOG_PREFIX}.enableExtension.ok`, { id });
   }
 
@@ -259,6 +297,8 @@ export class ExtensionManager {
 
     const record = this.state.extensions.find((e) => e.id === id);
     if (!record) throw new Error(`Extension not found: ${id}`);
+
+    this.notifyMV3Unloaded(id);
 
     try {
       session.defaultSession.removeExtension(id);
@@ -276,6 +316,8 @@ export class ExtensionManager {
 
   removeExtension(id: string): void {
     mainLogger.info(`${LOG_PREFIX}.removeExtension`, { id });
+
+    this.notifyMV3Unloaded(id);
 
     try {
       session.defaultSession.removeExtension(id);
@@ -297,6 +339,8 @@ export class ExtensionManager {
     const record = this.state.extensions.find((e) => e.id === id);
     if (!record) throw new Error(`Extension not found: ${id}`);
 
+    this.notifyMV3Unloaded(id);
+
     try {
       session.defaultSession.removeExtension(id);
     } catch {
@@ -307,6 +351,7 @@ export class ExtensionManager {
       allowFileAccess: true,
     });
 
+    this.notifyMV3Loaded(id, record.path);
     mainLogger.info(`${LOG_PREFIX}.updateExtension.ok`, { id });
   }
 
@@ -334,6 +379,27 @@ export class ExtensionManager {
   getExtensionDetails(id: string): ExtensionRecord | null {
     const all = this.listExtensions();
     return all.find((e) => e.id === id) ?? null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab lifecycle — forward to MV3 runtime for activeTab revocation
+  // -------------------------------------------------------------------------
+
+  onTabNavigated(tabId: number): void {
+    this.mv3Runtime.onTabNavigated(tabId);
+  }
+
+  onTabClosed(tabId: number): void {
+    this.mv3Runtime.onTabClosed(tabId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  dispose(): void {
+    mainLogger.info(`${LOG_PREFIX}.dispose`);
+    this.mv3Runtime.dispose();
   }
 
   // -------------------------------------------------------------------------

--- a/my-app/src/main/extensions/mv3/index.ts
+++ b/my-app/src/main/extensions/mv3/index.ts
@@ -3,6 +3,7 @@ export { ServiceWorkerManager } from './ServiceWorkerManager';
 export { DeclarativeNetRequestEngine } from './DeclarativeNetRequestEngine';
 export { ActionAPIBridge } from './ActionAPIBridge';
 export { ManifestValidator } from './ManifestValidator';
+export { registerMV3Handlers, unregisterMV3Handlers } from './ipc';
 export * from './constants';
 
 export type { MV3ExtensionInfo } from './ManifestV3Runtime';

--- a/my-app/src/main/extensions/mv3/ipc.ts
+++ b/my-app/src/main/extensions/mv3/ipc.ts
@@ -1,0 +1,275 @@
+/**
+ * mv3/ipc.ts — IPC handlers for Manifest V3 runtime queries.
+ *
+ * Exposes MV3 subsystem state (service workers, DNR rules, action API,
+ * validation, activeTab) via ipcMain.handle channels namespaced under 'mv3:'.
+ */
+
+import { ipcMain } from 'electron';
+import { mainLogger } from '../../logger';
+import { assertString } from '../../ipc-validators';
+import type { ExtensionManager } from '../ExtensionManager';
+import type { DnrRule } from './DeclarativeNetRequestEngine';
+
+// ---------------------------------------------------------------------------
+// Channel constants
+// ---------------------------------------------------------------------------
+
+const CH_GET_INFO           = 'mv3:get-info';
+const CH_LIST_MV3           = 'mv3:list';
+const CH_VALIDATE           = 'mv3:validate';
+const CH_WORKER_STATE       = 'mv3:worker-state';
+const CH_WORKER_WAKE        = 'mv3:worker-wake';
+const CH_WORKER_STOP        = 'mv3:worker-stop';
+const CH_ACTION_STATE       = 'mv3:action-state';
+const CH_ACTION_SET_BADGE   = 'mv3:action-set-badge';
+const CH_ACTION_SET_TITLE   = 'mv3:action-set-title';
+const CH_ACTION_SET_POPUP   = 'mv3:action-set-popup';
+const CH_DNR_GET_RULES      = 'mv3:dnr-get-rules';
+const CH_DNR_UPDATE_DYNAMIC = 'mv3:dnr-update-dynamic';
+const CH_DNR_UPDATE_SESSION = 'mv3:dnr-update-session';
+const CH_ACTIVE_TAB_GRANT   = 'mv3:active-tab-grant';
+const CH_ACTIVE_TAB_CHECK   = 'mv3:active-tab-check';
+const CH_ACTIVE_TAB_REVOKE  = 'mv3:active-tab-revoke';
+
+const LOG_PREFIX = 'mv3.ipc';
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let _manager: ExtensionManager | null = null;
+
+function runtime() {
+  if (!_manager) throw new Error('ExtensionManager not initialised for MV3 IPC');
+  return _manager.mv3Runtime;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleGetInfo(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.getInfo`, { extensionId: id });
+  return runtime().getExtensionInfo(id);
+}
+
+function handleListMV3() {
+  mainLogger.info(`${LOG_PREFIX}.list`);
+  return runtime().getAllMV3Extensions();
+}
+
+function handleValidate(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionPath: string,
+) {
+  const validPath = assertString(extensionPath, 'extensionPath', 1024);
+  mainLogger.info(`${LOG_PREFIX}.validate`, { extensionPath: validPath });
+  return runtime().validator.validateManifest(validPath);
+}
+
+function handleWorkerState(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.workerState`, { extensionId: id });
+  return {
+    state: runtime().serviceWorkers.getWorkerState(id),
+    info: runtime().serviceWorkers.getWorkerInfo(id),
+  };
+}
+
+async function handleWorkerWake(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.workerWake`, { extensionId: id });
+  await runtime().serviceWorkers.startWorker(id);
+  return runtime().serviceWorkers.getWorkerState(id);
+}
+
+function handleWorkerStop(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.workerStop`, { extensionId: id });
+  runtime().serviceWorkers.stopWorker(id);
+  return runtime().serviceWorkers.getWorkerState(id);
+}
+
+function handleActionState(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  tabId?: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.actionState`, { extensionId: id, tabId });
+  return runtime().actionApi.getState(id, tabId);
+}
+
+function handleActionSetBadge(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  text: string,
+  tabId?: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.actionSetBadge`, { extensionId: id, text, tabId });
+  runtime().actionApi.setBadgeText(id, text, tabId);
+}
+
+function handleActionSetTitle(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  title: string,
+  tabId?: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.actionSetTitle`, { extensionId: id, title, tabId });
+  runtime().actionApi.setTitle(id, title, tabId);
+}
+
+function handleActionSetPopup(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  popup: string,
+  tabId?: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.actionSetPopup`, { extensionId: id, popup, tabId });
+  runtime().actionApi.setPopup(id, popup, tabId);
+}
+
+function handleDnrGetRules(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  source: 'dynamic' | 'session',
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.dnrGetRules`, { extensionId: id, source });
+
+  if (source === 'session') {
+    return runtime().dnr.getSessionRules(id);
+  }
+  return runtime().dnr.getDynamicRules(id);
+}
+
+function handleDnrUpdateDynamic(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  addRules: DnrRule[],
+  removeRuleIds: number[],
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.dnrUpdateDynamic`, {
+    extensionId: id,
+    addCount: addRules?.length ?? 0,
+    removeCount: removeRuleIds?.length ?? 0,
+  });
+  runtime().dnr.updateDynamicRules(id, addRules ?? [], removeRuleIds ?? []);
+}
+
+function handleDnrUpdateSession(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  addRules: DnrRule[],
+  removeRuleIds: number[],
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.dnrUpdateSession`, {
+    extensionId: id,
+    addCount: addRules?.length ?? 0,
+    removeCount: removeRuleIds?.length ?? 0,
+  });
+  runtime().dnr.updateSessionRules(id, addRules ?? [], removeRuleIds ?? []);
+}
+
+function handleActiveTabGrant(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  tabId: number,
+  url: string,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.activeTabGrant`, { extensionId: id, tabId, url: url?.slice(0, 80) });
+  runtime().grantActiveTab(id, tabId, url);
+}
+
+function handleActiveTabCheck(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  tabId: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.activeTabCheck`, { extensionId: id, tabId });
+  return runtime().hasActiveTabAccess(id, tabId);
+}
+
+function handleActiveTabRevoke(
+  _event: Electron.IpcMainInvokeEvent,
+  extensionId: string,
+  tabId?: number,
+) {
+  const id = assertString(extensionId, 'extensionId', 200);
+  mainLogger.info(`${LOG_PREFIX}.activeTabRevoke`, { extensionId: id, tabId });
+  runtime().revokeActiveTab(id, tabId);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerMV3Handlers(manager: ExtensionManager): void {
+  mainLogger.info(`${LOG_PREFIX}.register`);
+  _manager = manager;
+
+  ipcMain.handle(CH_GET_INFO, handleGetInfo);
+  ipcMain.handle(CH_LIST_MV3, handleListMV3);
+  ipcMain.handle(CH_VALIDATE, handleValidate);
+  ipcMain.handle(CH_WORKER_STATE, handleWorkerState);
+  ipcMain.handle(CH_WORKER_WAKE, handleWorkerWake);
+  ipcMain.handle(CH_WORKER_STOP, handleWorkerStop);
+  ipcMain.handle(CH_ACTION_STATE, handleActionState);
+  ipcMain.handle(CH_ACTION_SET_BADGE, handleActionSetBadge);
+  ipcMain.handle(CH_ACTION_SET_TITLE, handleActionSetTitle);
+  ipcMain.handle(CH_ACTION_SET_POPUP, handleActionSetPopup);
+  ipcMain.handle(CH_DNR_GET_RULES, handleDnrGetRules);
+  ipcMain.handle(CH_DNR_UPDATE_DYNAMIC, handleDnrUpdateDynamic);
+  ipcMain.handle(CH_DNR_UPDATE_SESSION, handleDnrUpdateSession);
+  ipcMain.handle(CH_ACTIVE_TAB_GRANT, handleActiveTabGrant);
+  ipcMain.handle(CH_ACTIVE_TAB_CHECK, handleActiveTabCheck);
+  ipcMain.handle(CH_ACTIVE_TAB_REVOKE, handleActiveTabRevoke);
+
+  mainLogger.info(`${LOG_PREFIX}.register.ok`, { channelCount: 16 });
+}
+
+export function unregisterMV3Handlers(): void {
+  mainLogger.info(`${LOG_PREFIX}.unregister`);
+
+  ipcMain.removeHandler(CH_GET_INFO);
+  ipcMain.removeHandler(CH_LIST_MV3);
+  ipcMain.removeHandler(CH_VALIDATE);
+  ipcMain.removeHandler(CH_WORKER_STATE);
+  ipcMain.removeHandler(CH_WORKER_WAKE);
+  ipcMain.removeHandler(CH_WORKER_STOP);
+  ipcMain.removeHandler(CH_ACTION_STATE);
+  ipcMain.removeHandler(CH_ACTION_SET_BADGE);
+  ipcMain.removeHandler(CH_ACTION_SET_TITLE);
+  ipcMain.removeHandler(CH_ACTION_SET_POPUP);
+  ipcMain.removeHandler(CH_DNR_GET_RULES);
+  ipcMain.removeHandler(CH_DNR_UPDATE_DYNAMIC);
+  ipcMain.removeHandler(CH_DNR_UPDATE_SESSION);
+  ipcMain.removeHandler(CH_ACTIVE_TAB_GRANT);
+  ipcMain.removeHandler(CH_ACTIVE_TAB_CHECK);
+  ipcMain.removeHandler(CH_ACTIVE_TAB_REVOKE);
+
+  _manager = null;
+  mainLogger.info(`${LOG_PREFIX}.unregister.ok`);
+}

--- a/my-app/src/main/extensions/mv3/ipc.ts
+++ b/my-app/src/main/extensions/mv3/ipc.ts
@@ -121,8 +121,9 @@ function handleActionSetBadge(
   tabId?: number,
 ) {
   const id = assertString(extensionId, 'extensionId', 200);
-  mainLogger.info(`${LOG_PREFIX}.actionSetBadge`, { extensionId: id, text, tabId });
-  runtime().actionApi.setBadgeText(id, text, tabId);
+  const validText = assertString(text, 'text', 200);
+  mainLogger.info(`${LOG_PREFIX}.actionSetBadge`, { extensionId: id, text: validText, tabId });
+  runtime().actionApi.setBadgeText(id, validText, tabId);
 }
 
 function handleActionSetTitle(
@@ -132,8 +133,9 @@ function handleActionSetTitle(
   tabId?: number,
 ) {
   const id = assertString(extensionId, 'extensionId', 200);
-  mainLogger.info(`${LOG_PREFIX}.actionSetTitle`, { extensionId: id, title, tabId });
-  runtime().actionApi.setTitle(id, title, tabId);
+  const validTitle = assertString(title, 'title', 500);
+  mainLogger.info(`${LOG_PREFIX}.actionSetTitle`, { extensionId: id, title: validTitle, tabId });
+  runtime().actionApi.setTitle(id, validTitle, tabId);
 }
 
 function handleActionSetPopup(
@@ -143,8 +145,9 @@ function handleActionSetPopup(
   tabId?: number,
 ) {
   const id = assertString(extensionId, 'extensionId', 200);
-  mainLogger.info(`${LOG_PREFIX}.actionSetPopup`, { extensionId: id, popup, tabId });
-  runtime().actionApi.setPopup(id, popup, tabId);
+  const validPopup = assertString(popup, 'popup', 1024);
+  mainLogger.info(`${LOG_PREFIX}.actionSetPopup`, { extensionId: id, popup: validPopup, tabId });
+  runtime().actionApi.setPopup(id, validPopup, tabId);
 }
 
 function handleDnrGetRules(
@@ -198,8 +201,9 @@ function handleActiveTabGrant(
   url: string,
 ) {
   const id = assertString(extensionId, 'extensionId', 200);
-  mainLogger.info(`${LOG_PREFIX}.activeTabGrant`, { extensionId: id, tabId, url: url?.slice(0, 80) });
-  runtime().grantActiveTab(id, tabId, url);
+  const validUrl = assertString(url, 'url', 2048);
+  mainLogger.info(`${LOG_PREFIX}.activeTabGrant`, { extensionId: id, tabId, url: validUrl.slice(0, 80) });
+  runtime().grantActiveTab(id, tabId, validUrl);
 }
 
 function handleActiveTabCheck(

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -65,6 +65,8 @@ import { registerPermissionHandlers, unregisterPermissionHandlers } from './perm
 import { ExtensionManager } from './extensions/ExtensionManager';
 import { registerExtensionsHandlers, unregisterExtensionsHandlers } from './extensions/ipc';
 import { openExtensionsWindow } from './extensions/ExtensionsWindow';
+// Issue #72 — Manifest V3 runtime
+import { registerMV3Handlers, unregisterMV3Handlers } from './extensions/mv3/ipc';
 // Issue #40 — History
 import { HistoryStore } from './history/HistoryStore';
 import { registerHistoryHandlers, unregisterHistoryHandlers } from './history/ipc';
@@ -486,6 +488,7 @@ app.whenReady().then(async () => {
   // Issue #71 — Extensions: init manager + register IPC
   extensionManager = new ExtensionManager();
   registerExtensionsHandlers(extensionManager);
+  registerMV3Handlers(extensionManager);
   void extensionManager.loadAllEnabled();
 
   // Issue #95 — Settings zoom override IPC (needs tabManager access)
@@ -589,9 +592,8 @@ app.whenReady().then(async () => {
     unregisterProfileHandlers();
     unregisterPermissionHandlers();
     unregisterExtensionsHandlers();
-    // ExtensionManager currently has no dispose()/destroy() hook; its
-    // internal MV3 runtime tears itself down via its own lifecycle. If a
-    // top-level cleanup is ever added, wire it in here.
+    unregisterMV3Handlers();
+    extensionManager?.dispose();
     downloadManager?.destroy();
     downloadManager = null;
   });

--- a/my-app/src/preload/extensions.ts
+++ b/my-app/src/preload/extensions.ts
@@ -1,8 +1,8 @@
 /**
  * Extensions preload — contextBridge API for the extensions renderer.
  *
- * Exposes a typed API surface on window.extensionsAPI.
- * All IPC channels are namespaced under 'extensions:' to avoid collisions.
+ * Exposes a typed API surface on window.extensionsAPI and window.mv3API.
+ * IPC channels are namespaced under 'extensions:' and 'mv3:' to avoid collisions.
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
@@ -41,8 +41,27 @@ export interface ExtensionsAPI {
   closeWindow: () => void;
 }
 
+export interface MV3API {
+  getInfo: (extensionId: string) => Promise<unknown>;
+  list: () => Promise<unknown[]>;
+  validate: (extensionPath: string) => Promise<unknown>;
+  getWorkerState: (extensionId: string) => Promise<unknown>;
+  wakeWorker: (extensionId: string) => Promise<unknown>;
+  stopWorker: (extensionId: string) => Promise<unknown>;
+  getActionState: (extensionId: string, tabId?: number) => Promise<unknown>;
+  setActionBadge: (extensionId: string, text: string, tabId?: number) => Promise<void>;
+  setActionTitle: (extensionId: string, title: string, tabId?: number) => Promise<void>;
+  setActionPopup: (extensionId: string, popup: string, tabId?: number) => Promise<void>;
+  getDnrRules: (extensionId: string, source: 'dynamic' | 'session') => Promise<unknown[]>;
+  updateDynamicRules: (extensionId: string, addRules: unknown[], removeRuleIds: number[]) => Promise<void>;
+  updateSessionRules: (extensionId: string, addRules: unknown[], removeRuleIds: number[]) => Promise<void>;
+  grantActiveTab: (extensionId: string, tabId: number, url: string) => Promise<void>;
+  checkActiveTab: (extensionId: string, tabId: number) => Promise<boolean>;
+  revokeActiveTab: (extensionId: string, tabId?: number) => Promise<void>;
+}
+
 // ---------------------------------------------------------------------------
-// contextBridge exposure
+// contextBridge exposure — extensions
 // ---------------------------------------------------------------------------
 
 const api: ExtensionsAPI = {
@@ -107,4 +126,91 @@ const api: ExtensionsAPI = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// contextBridge exposure — MV3 runtime
+// ---------------------------------------------------------------------------
+
+const mv3Api: MV3API = {
+  getInfo: async (extensionId: string) => {
+    console.debug('[mv3-preload] getInfo', { extensionId });
+    return ipcRenderer.invoke('mv3:get-info', extensionId);
+  },
+
+  list: async () => {
+    console.debug('[mv3-preload] list');
+    return ipcRenderer.invoke('mv3:list') as Promise<unknown[]>;
+  },
+
+  validate: async (extensionPath: string) => {
+    console.debug('[mv3-preload] validate', { extensionPath });
+    return ipcRenderer.invoke('mv3:validate', extensionPath);
+  },
+
+  getWorkerState: async (extensionId: string) => {
+    console.debug('[mv3-preload] getWorkerState', { extensionId });
+    return ipcRenderer.invoke('mv3:worker-state', extensionId);
+  },
+
+  wakeWorker: async (extensionId: string) => {
+    console.debug('[mv3-preload] wakeWorker', { extensionId });
+    return ipcRenderer.invoke('mv3:worker-wake', extensionId);
+  },
+
+  stopWorker: async (extensionId: string) => {
+    console.debug('[mv3-preload] stopWorker', { extensionId });
+    return ipcRenderer.invoke('mv3:worker-stop', extensionId);
+  },
+
+  getActionState: async (extensionId: string, tabId?: number) => {
+    console.debug('[mv3-preload] getActionState', { extensionId, tabId });
+    return ipcRenderer.invoke('mv3:action-state', extensionId, tabId);
+  },
+
+  setActionBadge: async (extensionId: string, text: string, tabId?: number) => {
+    console.debug('[mv3-preload] setActionBadge', { extensionId, text, tabId });
+    await ipcRenderer.invoke('mv3:action-set-badge', extensionId, text, tabId);
+  },
+
+  setActionTitle: async (extensionId: string, title: string, tabId?: number) => {
+    console.debug('[mv3-preload] setActionTitle', { extensionId, title, tabId });
+    await ipcRenderer.invoke('mv3:action-set-title', extensionId, title, tabId);
+  },
+
+  setActionPopup: async (extensionId: string, popup: string, tabId?: number) => {
+    console.debug('[mv3-preload] setActionPopup', { extensionId, popup, tabId });
+    await ipcRenderer.invoke('mv3:action-set-popup', extensionId, popup, tabId);
+  },
+
+  getDnrRules: async (extensionId: string, source: 'dynamic' | 'session') => {
+    console.debug('[mv3-preload] getDnrRules', { extensionId, source });
+    return ipcRenderer.invoke('mv3:dnr-get-rules', extensionId, source) as Promise<unknown[]>;
+  },
+
+  updateDynamicRules: async (extensionId: string, addRules: unknown[], removeRuleIds: number[]) => {
+    console.debug('[mv3-preload] updateDynamicRules', { extensionId, addCount: addRules.length, removeCount: removeRuleIds.length });
+    await ipcRenderer.invoke('mv3:dnr-update-dynamic', extensionId, addRules, removeRuleIds);
+  },
+
+  updateSessionRules: async (extensionId: string, addRules: unknown[], removeRuleIds: number[]) => {
+    console.debug('[mv3-preload] updateSessionRules', { extensionId, addCount: addRules.length, removeCount: removeRuleIds.length });
+    await ipcRenderer.invoke('mv3:dnr-update-session', extensionId, addRules, removeRuleIds);
+  },
+
+  grantActiveTab: async (extensionId: string, tabId: number, url: string) => {
+    console.debug('[mv3-preload] grantActiveTab', { extensionId, tabId });
+    await ipcRenderer.invoke('mv3:active-tab-grant', extensionId, tabId, url);
+  },
+
+  checkActiveTab: async (extensionId: string, tabId: number) => {
+    console.debug('[mv3-preload] checkActiveTab', { extensionId, tabId });
+    return ipcRenderer.invoke('mv3:active-tab-check', extensionId, tabId) as Promise<boolean>;
+  },
+
+  revokeActiveTab: async (extensionId: string, tabId?: number) => {
+    console.debug('[mv3-preload] revokeActiveTab', { extensionId, tabId });
+    await ipcRenderer.invoke('mv3:active-tab-revoke', extensionId, tabId);
+  },
+};
+
 contextBridge.exposeInMainWorld('extensionsAPI', api);
+contextBridge.exposeInMainWorld('mv3API', mv3Api);

--- a/my-app/vite.newtab.config.ts
+++ b/my-app/vite.newtab.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/newtab/newtab.html'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Wires the existing MV3 subsystems (ServiceWorkerManager, DeclarativeNetRequestEngine, ActionAPIBridge, ManifestValidator) into ExtensionManager so they activate automatically on extension load/unload/enable/disable
- Adds 16 MV3-specific IPC channels (`mv3:*`) for service worker control, DNR rule management, action API state, and activeTab enforcement
- Exposes `mv3API` on the extensions preload bridge for renderer access
- Adds `manifestVersion` field to `ExtensionRecord` for UI differentiation

## Issue checklist coverage
- [x] Background scripts run as event-driven Service Workers (ServiceWorkerManager with idle/lifetime timeouts)
- [x] declarativeNetRequest rule engine for request modification (DeclarativeNetRequestEngine with static/dynamic/session rules)
- [x] chrome.action API replaces browserAction/pageAction (ActionAPIBridge with unified state management)
- [x] No remotely-hosted code execution; bundled JS only (ManifestValidator blocks remote schemes)
- [x] activeTab permission requires explicit user invocation (grant/revoke/check with tab navigation auto-revocation)

## Test plan
- [ ] Load an MV3 extension via developer mode — verify service worker starts and logs appear
- [ ] Verify DNR rules load from manifest and block/redirect requests
- [ ] Verify action API state (badge, title, popup) is tracked per-extension
- [ ] Verify activeTab grants are revoked on tab navigation
- [ ] Verify MV2 extensions still load without MV3 subsystem activation
- [ ] TypeScript compiles cleanly (no new errors introduced)

Closes #72

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the Manifest V3 runtime into the extension lifecycle and exposes `mv3:*` IPC plus `window.mv3API` so MV3 service workers, DNR, action state, and activeTab are managed automatically. Registers handlers in the main process with clean shutdown; adds `manifestVersion` to `ExtensionRecord`; validates MV3 IPC inputs; fixes a missing renderer build config. MV2 extensions continue to work unchanged.

- **New Features**
  - Wire `ManifestV3Runtime` into `ExtensionManager` on load/enable/disable/remove/update; forward tab navigation/close for activeTab auto‑revoke.
  - Register 16 `mv3:*` IPC channels at app start; unregister on shutdown.
  - Expose `window.mv3API` for worker/DNR/action/validate/activeTab calls.
  - Add `manifestVersion` to `ExtensionRecord` and `dispose()` to `ExtensionManager` for MV3 teardown.
  - Satisfies Issue #72: event‑driven workers, DNR engine, unified `chrome.action`, block remote code, explicit activeTab grants with auto‑revoke.

- **Bug Fixes**
  - Validate renderer-supplied strings in MV3 IPC (`text`, `title`, `popup`, `url`, `extensionId`, `extensionPath`) with `assertString`.
  - Add missing `vite.newtab.config.ts` to fix the renderer build.

<sup>Written for commit a27e414f6ee25a8dbb05749d90930612402eecf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

