### PR TITLE
feat(security): HTTPS-First mode with interstitial warning

### DIFF
--- a/my-app/src/main/https/HttpsFirstController.ts
+++ b/my-app/src/main/https/HttpsFirstController.ts
@@ -93,7 +93,7 @@ export function clearAllowedHttpOrigins(): void {
 function extractOrigin(url: string): string {
   try {
     const u = new URL(url);
-    return u.hostname;
+    return u.host;
   } catch {
     return url;
   }
@@ -222,7 +222,7 @@ export function buildInterstitialHtml(httpUrl: string, hostname: string): string
   </div>
   <script>
     function proceedToHttp() {
-      console.log('__HTTPS_FIRST_PROCEED__' + ${JSON.stringify(httpUrl)});
+      console.log('__HTTPS_FIRST_PROCEED__' + ${JSON.stringify(httpUrl).replace(/</g, '\\u003c')});
     }
   </script>
 </body>

--- a/my-app/src/main/https/HttpsFirstController.ts
+++ b/my-app/src/main/https/HttpsFirstController.ts
@@ -1,0 +1,232 @@
+/**
+ * HttpsFirstController — HTTPS-First mode for the browser.
+ *
+ * When enabled:
+ *   1. Typed/navigated http:// URLs are upgraded to https://
+ *   2. If the HTTPS load fails, a full-page interstitial is shown
+ *   3. The user can proceed to the HTTP version from the interstitial
+ *   4. Allowed HTTP origins are remembered for the session
+ *
+ * When disabled:
+ *   - HTTP URLs are loaded directly without upgrade or interstitial
+ */
+
+import { mainLogger } from '../logger';
+import { readPrefs } from '../settings/ipc';
+
+const PREFS_KEY = 'httpsFirst';
+
+// Origins the user has explicitly allowed HTTP for this session
+const allowedHttpOrigins = new Set<string>();
+
+// Per-tab tracking of pending HTTPS upgrades (tabId → original http URL)
+const pendingUpgrades = new Map<string, string>();
+
+export function isHttpsFirstEnabled(): boolean {
+  const prefs = readPrefs();
+  const enabled = prefs[PREFS_KEY] === true;
+  mainLogger.debug('HttpsFirstController.isEnabled', { enabled });
+  return enabled;
+}
+
+/**
+ * Try to upgrade an http:// URL to https://.
+ * Returns the upgraded URL if applicable, or the original URL if:
+ *   - The URL is not http://
+ *   - HTTPS-First mode is disabled
+ *   - The origin has been allowed for HTTP this session
+ */
+export function maybeUpgradeUrl(url: string): { upgraded: boolean; url: string } {
+  if (!url.startsWith('http://')) {
+    return { upgraded: false, url };
+  }
+
+  if (!isHttpsFirstEnabled()) {
+    mainLogger.debug('HttpsFirstController.maybeUpgrade.disabled', { url });
+    return { upgraded: false, url };
+  }
+
+  const origin = extractOrigin(url);
+  if (allowedHttpOrigins.has(origin)) {
+    mainLogger.info('HttpsFirstController.maybeUpgrade.allowedOrigin', { url, origin });
+    return { upgraded: false, url };
+  }
+
+  const httpsUrl = 'https://' + url.slice('http://'.length);
+  mainLogger.info('HttpsFirstController.maybeUpgrade.upgrading', {
+    originalUrl: url,
+    upgradedUrl: httpsUrl,
+  });
+  return { upgraded: true, url: httpsUrl };
+}
+
+export function trackPendingUpgrade(tabId: string, originalHttpUrl: string): void {
+  mainLogger.info('HttpsFirstController.trackPendingUpgrade', { tabId, originalHttpUrl });
+  pendingUpgrades.set(tabId, originalHttpUrl);
+}
+
+export function getPendingUpgrade(tabId: string): string | undefined {
+  return pendingUpgrades.get(tabId);
+}
+
+export function clearPendingUpgrade(tabId: string): void {
+  const had = pendingUpgrades.delete(tabId);
+  if (had) {
+    mainLogger.debug('HttpsFirstController.clearPendingUpgrade', { tabId });
+  }
+}
+
+export function allowHttpForOrigin(origin: string): void {
+  mainLogger.info('HttpsFirstController.allowHttpForOrigin', { origin });
+  allowedHttpOrigins.add(origin);
+}
+
+export function isHttpAllowedForOrigin(origin: string): boolean {
+  return allowedHttpOrigins.has(origin);
+}
+
+export function clearAllowedHttpOrigins(): void {
+  mainLogger.info('HttpsFirstController.clearAllowedHttpOrigins', { count: allowedHttpOrigins.size });
+  allowedHttpOrigins.clear();
+}
+
+function extractOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.hostname;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Build the full-page interstitial HTML shown when HTTPS upgrade fails.
+ * The page includes a "Continue to HTTP" button that posts a message
+ * via console.log with a known prefix so the main process can intercept it.
+ */
+export function buildInterstitialHtml(httpUrl: string, hostname: string): string {
+  const escapedUrl = httpUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  const escapedHostname = hostname
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Connection is not secure</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body {
+      height: 100vh;
+      background: #0a0a0d;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      max-width: 520px;
+      padding: 48px 40px;
+      text-align: center;
+    }
+    .shield {
+      width: 64px;
+      height: 64px;
+      margin: 0 auto 24px;
+      color: #ef4444;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 600;
+      color: #ffffff;
+      margin-bottom: 12px;
+      line-height: 1.3;
+    }
+    .desc {
+      font-size: 14px;
+      line-height: 1.6;
+      color: #a0a0a0;
+      margin-bottom: 8px;
+    }
+    .url-display {
+      font-size: 13px;
+      color: #ef4444;
+      background: rgba(239, 68, 68, 0.08);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+      border-radius: 6px;
+      padding: 8px 16px;
+      margin: 16px 0 32px;
+      word-break: break-all;
+      font-family: ui-monospace, "SF Mono", Monaco, monospace;
+    }
+    .actions {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    button {
+      padding: 10px 24px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: opacity 0.15s;
+    }
+    button:hover { opacity: 0.85; }
+    .btn-back {
+      background: #6366f1;
+      color: #fff;
+    }
+    .btn-proceed {
+      background: transparent;
+      color: #a0a0a0;
+      border: 1px solid #333;
+    }
+    .btn-proceed:hover {
+      color: #e0e0e0;
+      border-color: #555;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <svg class="shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+      <line x1="12" y1="8" x2="12" y2="12"/>
+      <line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+    <h1>Your connection to this site is not secure</h1>
+    <p class="desc">
+      You should not enter any sensitive information on this site (for example,
+      passwords or credit cards) because it could be stolen by attackers.
+    </p>
+    <div class="url-display">${escapedUrl}</div>
+    <p class="desc" style="margin-bottom: 24px; font-size: 13px;">
+      <strong>${escapedHostname}</strong> does not support HTTPS.
+      Your data will be sent unencrypted.
+    </p>
+    <div class="actions">
+      <button class="btn-back" onclick="history.back()">Go back</button>
+      <button class="btn-proceed" onclick="proceedToHttp()">Continue to HTTP site</button>
+    </div>
+  </div>
+  <script>
+    function proceedToHttp() {
+      console.log('__HTTPS_FIRST_PROCEED__' + ${JSON.stringify(httpUrl)});
+    }
+  </script>
+</body>
+</html>`;
+}
+
+export const HTTPS_PROCEED_PREFIX = '__HTTPS_FIRST_PROCEED__';

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -87,6 +87,8 @@ const CH_SET_DEFAULT_ZOOM    = 'settings:set-default-page-zoom';
 const CH_GET_BIOMETRIC_LOCK  = 'settings:get-biometric-lock';
 const CH_SET_BIOMETRIC_LOCK  = 'settings:set-biometric-lock';
 const CH_BIOMETRIC_AVAILABLE = 'settings:biometric-available';
+const CH_GET_HTTPS_FIRST     = 'settings:get-https-first';
+const CH_SET_HTTPS_FIRST     = 'settings:set-https-first';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -570,6 +572,23 @@ function handleBiometricAvailable(): boolean {
   return available;
 }
 
+function handleGetHttpsFirst(): boolean {
+  mainLogger.info(CH_GET_HTTPS_FIRST);
+  const prefs = readPrefs();
+  const enabled = prefs.httpsFirst === true;
+  mainLogger.info(`${CH_GET_HTTPS_FIRST}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetHttpsFirst(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('httpsFirst must be a boolean');
+  }
+  mainLogger.info(CH_SET_HTTPS_FIRST, { enabled });
+  mergePrefs({ httpsFirst: enabled });
+  mainLogger.info(`${CH_SET_HTTPS_FIRST}.ok`, { enabled });
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -612,8 +631,10 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_GET_BIOMETRIC_LOCK,  handleGetBiometricLock);
   ipcMain.handle(CH_SET_BIOMETRIC_LOCK,  handleSetBiometricLock);
   ipcMain.handle(CH_BIOMETRIC_AVAILABLE, handleBiometricAvailable);
+  ipcMain.handle(CH_GET_HTTPS_FIRST,    handleGetHttpsFirst);
+  ipcMain.handle(CH_SET_HTTPS_FIRST,    handleSetHttpsFirst);
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 19 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 21 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -638,6 +659,8 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_GET_BIOMETRIC_LOCK);
   ipcMain.removeHandler(CH_SET_BIOMETRIC_LOCK);
   ipcMain.removeHandler(CH_BIOMETRIC_AVAILABLE);
+  ipcMain.removeHandler(CH_GET_HTTPS_FIRST);
+  ipcMain.removeHandler(CH_SET_HTTPS_FIRST);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -25,6 +25,15 @@ import { HistoryStore } from '../history/HistoryStore';
 import { attachContextMenu } from '../contextMenu/ContextMenuController';
 import { getFormDetectorScript, FORM_DETECTOR_PREFIX } from '../passwords/formDetector';
 import { readPrefs } from '../settings/ipc';
+import {
+  maybeUpgradeUrl,
+  trackPendingUpgrade,
+  getPendingUpgrade,
+  clearPendingUpgrade,
+  allowHttpForOrigin,
+  buildInterstitialHtml,
+  HTTPS_PROCEED_PREFIX,
+} from '../https/HttpsFirstController';
 
 // Forge VitePlugin globals for the new-tab page (injected at build time)
 declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
@@ -615,11 +624,23 @@ export class TabManager {
       return;
     }
     const nav = this.navControllers.get(tabId);
-    if (nav) {
-      nav.navigate(url);
-    } else {
+    if (!nav) {
       mainLogger.warn('TabManager.navigate.noController', { tabId });
+      return;
     }
+
+    const upgrade = maybeUpgradeUrl(url);
+    if (upgrade.upgraded) {
+      mainLogger.info('TabManager.navigate.httpsUpgrade', {
+        tabId,
+        originalUrl: url,
+        upgradedUrl: upgrade.url,
+      });
+      trackPendingUpgrade(tabId, url);
+    } else {
+      clearPendingUpgrade(tabId);
+    }
+    nav.navigate(upgrade.url);
   }
 
   navigateActive(input: string): void {
@@ -1255,6 +1276,9 @@ export class TabManager {
 
     wc.on('did-navigate', (_e, url) => {
       mainLogger.info('TabManager.tab.navigate', { tabId, url });
+      if (url.startsWith('https://')) {
+        clearPendingUpgrade(tabId);
+      }
       this.applyPersistedZoom(wc);
       this.sendTabUpdate(tabId);
       this.saveSession();
@@ -1284,8 +1308,42 @@ export class TabManager {
       }
     });
 
+    // HTTPS-First: if an HTTPS upgrade fails, show an interstitial warning page
+    wc.on('did-fail-load', (_e, errorCode, _errorDesc, validatedURL) => {
+      const pendingHttpUrl = getPendingUpgrade(tabId);
+      if (!pendingHttpUrl) return;
+
+      mainLogger.info('TabManager.tab.httpsUpgradeFailed', {
+        tabId,
+        errorCode,
+        validatedURL,
+        pendingHttpUrl,
+      });
+
+      clearPendingUpgrade(tabId);
+
+      let hostname = '';
+      try { hostname = new URL(pendingHttpUrl).hostname; } catch { hostname = pendingHttpUrl; }
+
+      const interstitialHtml = buildInterstitialHtml(pendingHttpUrl, hostname);
+      const dataUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(interstitialHtml);
+      wc.loadURL(dataUrl);
+    });
+
     // Listen for password form submissions via console-message prefix
     wc.on('console-message', (_e, _level, message) => {
+      // HTTPS-First: intercept "proceed to HTTP" from interstitial page
+      if (message.startsWith(HTTPS_PROCEED_PREFIX)) {
+        const httpUrl = message.slice(HTTPS_PROCEED_PREFIX.length);
+        mainLogger.info('TabManager.tab.httpsProceed', { tabId, httpUrl });
+        try {
+          const hostname = new URL(httpUrl).hostname;
+          allowHttpForOrigin(hostname);
+        } catch { /* ignore parse errors */ }
+        clearPendingUpgrade(tabId);
+        wc.loadURL(httpUrl);
+        return;
+      }
       if (!message.startsWith(FORM_DETECTOR_PREFIX)) return;
       try {
         const json = message.slice(FORM_DETECTOR_PREFIX.length);

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -1333,12 +1333,14 @@ export class TabManager {
     // Listen for password form submissions via console-message prefix
     wc.on('console-message', (_e, _level, message) => {
       // HTTPS-First: intercept "proceed to HTTP" from interstitial page
-      if (message.startsWith(HTTPS_PROCEED_PREFIX)) {
+      // Only trust this message from our data: URL interstitial, not arbitrary pages
+      const currentUrl = wc.getURL();
+      if (message.startsWith(HTTPS_PROCEED_PREFIX) && currentUrl.startsWith('data:text/html')) {
         const httpUrl = message.slice(HTTPS_PROCEED_PREFIX.length);
         mainLogger.info('TabManager.tab.httpsProceed', { tabId, httpUrl });
         try {
-          const hostname = new URL(httpUrl).hostname;
-          allowHttpForOrigin(hostname);
+          const host = new URL(httpUrl).host;
+          allowHttpForOrigin(host);
         } catch { /* ignore parse errors */ }
         clearPendingUpgrade(tabId);
         wc.loadURL(httpUrl);

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -132,6 +132,12 @@ export interface SettingsAPI {
 
   /** Set whether biometric lock is enabled for password operations */
   setBiometricLock: (enabled: boolean) => Promise<void>;
+
+  /** Get whether HTTPS-First mode is enabled */
+  getHttpsFirst: () => Promise<boolean>;
+
+  /** Set whether HTTPS-First mode is enabled */
+  setHttpsFirst: (enabled: boolean) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -307,6 +313,16 @@ const api: SettingsAPI = {
   setBiometricLock: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setBiometricLock', { enabled });
     await ipcRenderer.invoke('settings:set-biometric-lock', enabled);
+  },
+
+  getHttpsFirst: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getHttpsFirst');
+    return ipcRenderer.invoke('settings:get-https-first') as Promise<boolean>;
+  },
+
+  setHttpsFirst: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setHttpsFirst', { enabled });
+    await ipcRenderer.invoke('settings:set-https-first', enabled);
   },
 };
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -749,6 +749,8 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
   useEffect(() => {
     void window.settingsAPI.getHttpsFirst().then((val) => {
       setHttpsFirst(val);
+    }).catch(() => {
+    }).finally(() => {
       setHttpsFirstLoading(false);
     });
   }, []);

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -145,6 +145,8 @@ declare global {
       isBiometricAvailable: () => Promise<boolean>;
       getBiometricLock: () => Promise<boolean>;
       setBiometricLock: (enabled: boolean) => Promise<void>;
+      getHttpsFirst: () => Promise<boolean>;
+      setHttpsFirst: (enabled: boolean) => Promise<void>;
     };
   }
 }
@@ -741,6 +743,33 @@ interface PrivacyTabProps {
 
 function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.ReactElement {
   const toast = useToast();
+  const [httpsFirst, setHttpsFirst] = useState(false);
+  const [httpsFirstLoading, setHttpsFirstLoading] = useState(true);
+
+  useEffect(() => {
+    void window.settingsAPI.getHttpsFirst().then((val) => {
+      setHttpsFirst(val);
+      setHttpsFirstLoading(false);
+    });
+  }, []);
+
+  async function handleHttpsFirstToggle(checked: boolean): Promise<void> {
+    setHttpsFirst(checked);
+    try {
+      await window.settingsAPI.setHttpsFirst(checked);
+      toast.show({
+        variant: 'success',
+        title: checked ? 'HTTPS-First mode enabled' : 'HTTPS-First mode disabled',
+      });
+    } catch (err) {
+      setHttpsFirst(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
 
   return (
     <div className="settings-section">
@@ -748,6 +777,29 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
       <p className="settings-section-desc">
         Control what local browsing data is stored on this device.
       </p>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">
+              Always use secure connections
+            </span>
+            <span className="settings-toggle-desc">
+              Automatically upgrade HTTP connections to HTTPS. When a site
+              does not support HTTPS, a warning is shown before continuing.
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={httpsFirst}
+              disabled={httpsFirstLoading}
+              onChange={(e) => void handleHttpsFirstToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </Card>
 
       <Card variant="default" padding="md" className="settings-card">
         <div className="settings-privacy-row">


### PR DESCRIPTION
## Summary
- Adds **HTTPS-First mode** toggle in Settings > Privacy and security
- Automatically upgrades `http://` URLs to `https://` when enabled
- Shows a full-page interstitial warning when HTTPS upgrade fails, letting the user proceed to HTTP or go back
- Remembers allowed HTTP origins for the session so users aren't warned repeatedly

## Implementation
- `HttpsFirstController` — core logic for URL upgrading, pending upgrade tracking, session-scoped HTTP allowlist, and interstitial HTML generation
- `TabManager` — integrates HTTPS upgrade in `navigate()`, handles `did-fail-load` to show interstitial, intercepts "proceed" via `console-message`
- `settings/ipc.ts` — adds `settings:get-https-first` / `settings:set-https-first` IPC handlers persisted to `preferences.json`
- `preload/settings.ts` — exposes `getHttpsFirst` / `setHttpsFirst` to settings renderer
- `SettingsApp.tsx` — adds toggle card in Privacy tab

## Test plan
- [ ] Enable HTTPS-First in Settings > Privacy and security
- [ ] Navigate to an HTTP-only site — verify HTTPS upgrade is attempted, then interstitial shown
- [ ] Click "Continue to HTTP site" — verify site loads over HTTP
- [ ] Navigate to same HTTP site again — verify no interstitial (origin remembered for session)
- [ ] Navigate to an HTTPS site — verify no interstitial
- [ ] Disable HTTPS-First — verify HTTP sites load directly without upgrade or warning
- [ ] Verify toggle state persists across app restarts

Closes #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTPS-First mode that upgrades `http://` to `https://` and shows a full-page warning if the upgrade fails, with an option to proceed to HTTP. Implements the behavior requested in #60.

- **New Features**
  - Core: `HttpsFirstController` for upgrades, per-tab tracking, session HTTP allowlist, and interstitial HTML.
  - Settings: Toggle in Privacy; IPC `settings:get-https-first` / `settings:set-https-first`; preload `getHttpsFirst` / `setHttpsFirst`; preference persisted.
  - Tabs: Upgrade in `navigate()`, clear pending on HTTPS; on `did-fail-load` show `data:` interstitial; proceed via `console-message` prefix `__HTTPS_FIRST_PROCEED__`.

- **Bug Fixes**
  - Accept proceed messages only from `data:` interstitial pages.
  - Escape `</script>` in the interstitial’s inline script (XSS fix).
  - Use `URL.host` for origin allowlisting and in the TabManager proceed handler (includes port).
  - Settings: handle `getHttpsFirst()` errors and always clear loading state.

<sup>Written for commit 0e66677a9ac457833e44d0789e9b4433c0a6c484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

