### PR TITLE
feat(devtools): core DevTools panel surface

### DIFF
--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -220,6 +220,12 @@ const config: ForgeConfig = {
         //   config: 'vite.preload.config.ts',
         //   target: 'preload',
         // },
+        {
+          // Issue #77: devtools panel preload
+          entry: 'src/preload/devtools.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
       ],
       renderer: [
         {
@@ -282,6 +288,11 @@ const config: ForgeConfig = {
         //   name: 'newtab',
         //   config: 'vite.newtab.config.ts',
         // },
+        {
+          // Issue #77: devtools panel renderer
+          name: 'devtools_panel',
+          config: 'vite.devtools.config.ts',
+        },
       ],
     }),
 

--- a/my-app/src/main/devtools/DevToolsBridge.ts
+++ b/my-app/src/main/devtools/DevToolsBridge.ts
@@ -13,6 +13,8 @@ export class DevToolsBridge {
   private enabledDomains = new Set<string>();
   private targetWebContents: WebContents | null = null;
   private devtoolsWindow: BrowserWindow | null = null;
+  private messageHandler: ((_event: Electron.Event, method: string, params: unknown) => void) | null = null;
+  private detachHandler: ((_event: Electron.Event, reason: string) => void) | null = null;
 
   attach(webContents: WebContents, devtoolsWindow: BrowserWindow): void {
     if (this.attached && this.targetWebContents === webContents) {
@@ -34,25 +36,38 @@ export class DevToolsBridge {
         error: (err as Error).message,
         targetId: webContents.id,
       });
+      this.targetWebContents = null;
+      this.devtoolsWindow = null;
       return;
     }
 
-    webContents.debugger.on('message', (_event, method, params) => {
+    this.messageHandler = (_event, method, params) => {
       if (this.devtoolsWindow && !this.devtoolsWindow.isDestroyed()) {
         this.devtoolsWindow.webContents.send('devtools:cdp-event', method, params);
       }
-    });
-
-    webContents.debugger.on('detach', (_event, reason) => {
+    };
+    this.detachHandler = (_event, reason) => {
       mainLogger.info('DevToolsBridge.detach.event', { reason });
       this.attached = false;
       this.enabledDomains.clear();
       this.targetWebContents = null;
-    });
+    };
+
+    webContents.debugger.on('message', this.messageHandler);
+    webContents.debugger.on('detach', this.detachHandler);
   }
 
   detach(): void {
     if (!this.attached || !this.targetWebContents) return;
+
+    if (this.messageHandler) {
+      this.targetWebContents.debugger.removeListener('message', this.messageHandler);
+      this.messageHandler = null;
+    }
+    if (this.detachHandler) {
+      this.targetWebContents.debugger.removeListener('detach', this.detachHandler);
+      this.detachHandler = null;
+    }
 
     try {
       this.targetWebContents.debugger.detach();

--- a/my-app/src/main/devtools/DevToolsBridge.ts
+++ b/my-app/src/main/devtools/DevToolsBridge.ts
@@ -1,0 +1,106 @@
+/**
+ * DevToolsBridge — attaches Electron's debugger API to a tab's webContents
+ * and proxies CDP commands/events between the DevTools renderer and the page.
+ */
+
+import { BrowserWindow, WebContents } from 'electron';
+import { mainLogger } from '../logger';
+
+const CDP_VERSION = '1.3';
+
+export class DevToolsBridge {
+  private attached = false;
+  private enabledDomains = new Set<string>();
+  private targetWebContents: WebContents | null = null;
+  private devtoolsWindow: BrowserWindow | null = null;
+
+  attach(webContents: WebContents, devtoolsWindow: BrowserWindow): void {
+    if (this.attached && this.targetWebContents === webContents) {
+      mainLogger.debug('DevToolsBridge.attach — already attached to same target');
+      return;
+    }
+
+    this.detach();
+
+    this.targetWebContents = webContents;
+    this.devtoolsWindow = devtoolsWindow;
+
+    try {
+      webContents.debugger.attach(CDP_VERSION);
+      this.attached = true;
+      mainLogger.info('DevToolsBridge.attach', { targetId: webContents.id });
+    } catch (err) {
+      mainLogger.error('DevToolsBridge.attach.failed', {
+        error: (err as Error).message,
+        targetId: webContents.id,
+      });
+      return;
+    }
+
+    webContents.debugger.on('message', (_event, method, params) => {
+      if (this.devtoolsWindow && !this.devtoolsWindow.isDestroyed()) {
+        this.devtoolsWindow.webContents.send('devtools:cdp-event', method, params);
+      }
+    });
+
+    webContents.debugger.on('detach', (_event, reason) => {
+      mainLogger.info('DevToolsBridge.detach.event', { reason });
+      this.attached = false;
+      this.enabledDomains.clear();
+      this.targetWebContents = null;
+    });
+  }
+
+  detach(): void {
+    if (!this.attached || !this.targetWebContents) return;
+
+    try {
+      this.targetWebContents.debugger.detach();
+      mainLogger.info('DevToolsBridge.detach');
+    } catch (err) {
+      mainLogger.warn('DevToolsBridge.detach.failed', {
+        error: (err as Error).message,
+      });
+    }
+
+    this.attached = false;
+    this.enabledDomains.clear();
+    this.targetWebContents = null;
+  }
+
+  async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!this.attached || !this.targetWebContents) {
+      mainLogger.warn('DevToolsBridge.send — not attached', { method });
+      throw new Error('DevTools bridge not attached to any target');
+    }
+
+    mainLogger.debug('DevToolsBridge.send', { method, hasParams: !!params });
+
+    try {
+      const result = await this.targetWebContents.debugger.sendCommand(method, params);
+
+      const domain = method.split('.')[0];
+      if (method.endsWith('.enable') && domain) {
+        this.enabledDomains.add(domain);
+      } else if (method.endsWith('.disable') && domain) {
+        this.enabledDomains.delete(domain);
+      }
+
+      return result;
+    } catch (err) {
+      mainLogger.error('DevToolsBridge.send.failed', {
+        method,
+        error: (err as Error).message,
+      });
+      throw err;
+    }
+  }
+
+  isAttached(): boolean {
+    return this.attached;
+  }
+
+  getEnabledDomains(): string[] {
+    return Array.from(this.enabledDomains);
+  }
+}

--- a/my-app/src/main/devtools/DevToolsWindow.ts
+++ b/my-app/src/main/devtools/DevToolsWindow.ts
@@ -1,0 +1,101 @@
+/**
+ * DevToolsWindow — creates and manages the custom DevTools BrowserWindow.
+ *
+ * Follows SettingsWindow singleton pattern.
+ * Preload: src/preload/devtools.ts (built as devtools.js in .vite/build/)
+ * Renderer: devtools/devtools.html
+ */
+
+import path from 'node:path';
+import { BrowserWindow } from 'electron';
+import { mainLogger } from '../logger';
+
+declare const DEVTOOLS_PANEL_VITE_DEV_SERVER_URL: string | undefined;
+declare const DEVTOOLS_PANEL_VITE_NAME: string | undefined;
+
+let devtoolsWindow: BrowserWindow | null = null;
+
+export function openDevToolsWindow(): BrowserWindow {
+  if (devtoolsWindow && !devtoolsWindow.isDestroyed()) {
+    mainLogger.info('DevToolsWindow.focus', { windowId: devtoolsWindow.id });
+    devtoolsWindow.focus();
+    return devtoolsWindow;
+  }
+
+  mainLogger.info('DevToolsWindow.create');
+
+  const preloadPath = path.join(__dirname, 'devtools.js');
+
+  devtoolsWindow = new BrowserWindow({
+    width: 1100,
+    height: 720,
+    minWidth: 680,
+    minHeight: 400,
+    resizable: true,
+    titleBarStyle: 'hiddenInset',
+    show: false,
+    backgroundColor: '#0a0a0d',
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  devtoolsWindow.once('ready-to-show', () => {
+    if (!devtoolsWindow || devtoolsWindow.isDestroyed()) return;
+    devtoolsWindow.show();
+    devtoolsWindow.focus();
+    mainLogger.info('DevToolsWindow.readyToShow', { windowId: devtoolsWindow.id });
+  });
+
+  devtoolsWindow.on('closed', () => {
+    mainLogger.info('DevToolsWindow.closed');
+    devtoolsWindow = null;
+  });
+
+  devtoolsWindow.webContents.on('did-fail-load', (_e, code, desc, url) => {
+    mainLogger.error('DevToolsWindow.did-fail-load', { code, desc, url });
+  });
+
+  devtoolsWindow.webContents.on('did-finish-load', () => {
+    mainLogger.info('DevToolsWindow.did-finish-load', {
+      url: devtoolsWindow?.webContents.getURL(),
+    });
+  });
+
+  devtoolsWindow.webContents.on('console-message', (_e, level, message, line, source) => {
+    mainLogger.info('devtoolsRenderer.console', { level, source, line, message });
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    devtoolsWindow.webContents.openDevTools({ mode: 'detach' });
+  }
+
+  if (typeof DEVTOOLS_PANEL_VITE_DEV_SERVER_URL !== 'undefined' && DEVTOOLS_PANEL_VITE_DEV_SERVER_URL) {
+    const url = `${DEVTOOLS_PANEL_VITE_DEV_SERVER_URL}/src/renderer/devtools/devtools.html`;
+    mainLogger.debug('DevToolsWindow.loadURL', { url });
+    void devtoolsWindow.loadURL(url);
+  } else {
+    const name = typeof DEVTOOLS_PANEL_VITE_NAME !== 'undefined' ? DEVTOOLS_PANEL_VITE_NAME : 'devtools_panel';
+    const filePath = path.join(__dirname, `../../renderer/${name}/devtools.html`);
+    mainLogger.debug('DevToolsWindow.loadFile', { filePath });
+    void devtoolsWindow.loadFile(filePath);
+  }
+
+  mainLogger.info('DevToolsWindow.create.ok', { windowId: devtoolsWindow.id });
+  return devtoolsWindow;
+}
+
+export function getDevToolsWindow(): BrowserWindow | null {
+  if (devtoolsWindow && !devtoolsWindow.isDestroyed()) return devtoolsWindow;
+  return null;
+}
+
+export function closeDevToolsWindow(): void {
+  if (devtoolsWindow && !devtoolsWindow.isDestroyed()) {
+    mainLogger.info('DevToolsWindow.closeRequested');
+    devtoolsWindow.close();
+  }
+}

--- a/my-app/src/main/devtools/ipc.ts
+++ b/my-app/src/main/devtools/ipc.ts
@@ -31,6 +31,9 @@ export function registerDevToolsHandlers(tabManager: TabManager): void {
 
     try {
       bridge!.attach(wc, senderWindow);
+      if (!bridge!.isAttached()) {
+        return { success: false, error: 'Debugger attach failed' };
+      }
       return { success: true };
     } catch (err) {
       return { success: false, error: (err as Error).message };

--- a/my-app/src/main/devtools/ipc.ts
+++ b/my-app/src/main/devtools/ipc.ts
@@ -1,0 +1,83 @@
+/**
+ * DevTools IPC handlers — bridges CDP commands from the DevTools renderer
+ * to the active tab via the DevToolsBridge.
+ */
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { mainLogger } from '../logger';
+import { DevToolsBridge } from './DevToolsBridge';
+import { TabManager } from '../tabs/TabManager';
+
+let bridge: DevToolsBridge | null = null;
+
+export function registerDevToolsHandlers(tabManager: TabManager): void {
+  bridge = new DevToolsBridge();
+
+  mainLogger.info('devtools.ipc.register');
+
+  ipcMain.handle('devtools:attach', async (_e) => {
+    mainLogger.info('devtools:attach');
+    const wc = tabManager.getActiveWebContents();
+    if (!wc) {
+      mainLogger.warn('devtools:attach — no active tab');
+      return { success: false, error: 'No active tab' };
+    }
+
+    const senderWindow = BrowserWindow.fromWebContents(_e.sender);
+    if (!senderWindow) {
+      mainLogger.warn('devtools:attach — no sender window');
+      return { success: false, error: 'No DevTools window' };
+    }
+
+    try {
+      bridge!.attach(wc, senderWindow);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  });
+
+  ipcMain.handle('devtools:detach', async () => {
+    mainLogger.info('devtools:detach');
+    bridge!.detach();
+    return { success: true };
+  });
+
+  ipcMain.handle('devtools:send', async (_e, method: string, params?: Record<string, unknown>) => {
+    mainLogger.debug('devtools:send', { method });
+    try {
+      const result = await bridge!.send(method, params);
+      return { success: true, result };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  });
+
+  ipcMain.handle('devtools:is-attached', async () => {
+    return bridge?.isAttached() ?? false;
+  });
+
+  ipcMain.handle('devtools:get-active-tab-info', async () => {
+    const state = tabManager.getState();
+    if (!state.activeTabId) return null;
+    const tab = state.tabs.find((t) => t.id === state.activeTabId);
+    return tab ?? null;
+  });
+}
+
+export function unregisterDevToolsHandlers(): void {
+  mainLogger.info('devtools.ipc.unregister');
+  if (bridge) {
+    bridge.detach();
+    bridge = null;
+  }
+  ipcMain.removeHandler('devtools:attach');
+  ipcMain.removeHandler('devtools:detach');
+  ipcMain.removeHandler('devtools:send');
+  ipcMain.removeHandler('devtools:is-attached');
+  ipcMain.removeHandler('devtools:get-active-tab-info');
+}
+
+export function getDevToolsBridge(): DevToolsBridge | null {
+  return bridge;
+}

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -392,7 +392,11 @@ app.whenReady().then(async () => {
   );
 
   // Issue #77 — DevTools panels
-  registerDevToolsHandlers(tabManager!);
+  if (tabManager) {
+    registerDevToolsHandlers(tabManager);
+  } else {
+    mainLogger.warn('main.openShellAndWire — tabManager null, skipping DevTools IPC registration');
+  }
 
   // pill:submit — spawns a Docker container with the agent loop.
   ipcMain.handle('pill:submit', async (_event, { prompt }: { prompt: string }) => {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -75,6 +75,9 @@ import { registerChromeHandlers, unregisterChromeHandlers } from './chrome/ipc';
 // Downloads
 // Issue #97 — Print Preview
 import { openPrintPreviewWindow } from './print/PrintPreviewWindow';
+// Issue #77 — DevTools panels
+import { openDevToolsWindow } from './devtools/DevToolsWindow';
+import { registerDevToolsHandlers, unregisterDevToolsHandlers } from './devtools/ipc';
 
 // ---------------------------------------------------------------------------
 // Crash telemetry: catch unhandled errors before anything else
@@ -388,6 +391,9 @@ app.whenReady().then(async () => {
     () => openExtensionsWindow(),
   );
 
+  // Issue #77 — DevTools panels
+  registerDevToolsHandlers(tabManager!);
+
   // pill:submit — spawns a Docker container with the agent loop.
   ipcMain.handle('pill:submit', async (_event, { prompt }: { prompt: string }) => {
     const validatedPrompt = assertString(prompt, 'prompt', 10000);
@@ -588,6 +594,7 @@ app.whenReady().then(async () => {
     unregisterChromeHandlers();
     unregisterProfileHandlers();
     unregisterPermissionHandlers();
+    unregisterDevToolsHandlers();
     unregisterExtensionsHandlers();
     // ExtensionManager currently has no dispose()/destroy() hook; its
     // internal MV3 runtime tears itself down via its own lifecycle. If a
@@ -1005,6 +1012,14 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
               click: () => {
                 mainLogger.debug('shortcuts.jsConsole');
                 tabManager?.openDevToolsConsoleForActive();
+              },
+            },
+            {
+              label: 'DevTools Panel',
+              accelerator: 'CommandOrControl+Alt+D',
+              click: () => {
+                mainLogger.debug('shortcuts.devToolsPanel');
+                openDevToolsWindow();
               },
             },
             { type: 'separator' },

--- a/my-app/src/preload/devtools.ts
+++ b/my-app/src/preload/devtools.ts
@@ -1,0 +1,81 @@
+/**
+ * DevTools preload — contextBridge API for the DevTools renderer.
+ *
+ * Exposes CDP bridge methods on window.devtoolsAPI.
+ * All IPC channels namespaced under 'devtools:'.
+ */
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+export interface CdpResponse {
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+export interface TabInfo {
+  id: string;
+  url: string;
+  title: string;
+  favicon: string | null;
+  isLoading: boolean;
+}
+
+export interface DevToolsAPI {
+  attach: () => Promise<CdpResponse>;
+  detach: () => Promise<CdpResponse>;
+  send: (method: string, params?: Record<string, unknown>) => Promise<CdpResponse>;
+  isAttached: () => Promise<boolean>;
+  getActiveTabInfo: () => Promise<TabInfo | null>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  onTabChanged: (cb: (tabId: string) => void) => () => void;
+}
+
+const api: DevToolsAPI = {
+  attach: async (): Promise<CdpResponse> => {
+    console.debug('[devtools-preload] attach');
+    return ipcRenderer.invoke('devtools:attach') as Promise<CdpResponse>;
+  },
+
+  detach: async (): Promise<CdpResponse> => {
+    console.debug('[devtools-preload] detach');
+    return ipcRenderer.invoke('devtools:detach') as Promise<CdpResponse>;
+  },
+
+  send: async (method: string, params?: Record<string, unknown>): Promise<CdpResponse> => {
+    console.debug('[devtools-preload] send', { method });
+    return ipcRenderer.invoke('devtools:send', method, params) as Promise<CdpResponse>;
+  },
+
+  isAttached: async (): Promise<boolean> => {
+    console.debug('[devtools-preload] isAttached');
+    return ipcRenderer.invoke('devtools:is-attached') as Promise<boolean>;
+  },
+
+  getActiveTabInfo: async (): Promise<TabInfo | null> => {
+    console.debug('[devtools-preload] getActiveTabInfo');
+    return ipcRenderer.invoke('devtools:get-active-tab-info') as Promise<TabInfo | null>;
+  },
+
+  onCdpEvent: (cb: (method: string, params: unknown) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, method: string, params: unknown): void => {
+      cb(method, params);
+    };
+    ipcRenderer.on('devtools:cdp-event', listener);
+    return () => {
+      ipcRenderer.removeListener('devtools:cdp-event', listener);
+    };
+  },
+
+  onTabChanged: (cb: (tabId: string) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, tabId: string): void => {
+      cb(tabId);
+    };
+    ipcRenderer.on('devtools:tab-changed', listener);
+    return () => {
+      ipcRenderer.removeListener('devtools:tab-changed', listener);
+    };
+  },
+};
+
+contextBridge.exposeInMainWorld('devtoolsAPI', api);

--- a/my-app/src/renderer/devtools/DevToolsApp.tsx
+++ b/my-app/src/renderer/devtools/DevToolsApp.tsx
@@ -93,35 +93,41 @@ export function DevToolsApp(): React.ReactElement {
     setConnectionState('connecting');
     setError(null);
 
-    const info = await devtoolsAPI.getActiveTabInfo();
-    if (!info) {
-      setError('No active tab found');
-      setConnectionState('disconnected');
-      return;
-    }
-    setTabInfo(info);
-
-    const resp = await devtoolsAPI.attach();
-    if (!resp.success) {
-      console.error('[DevToolsApp] attach failed:', resp.error);
-      setError(resp.error ?? 'Failed to attach debugger');
-      setConnectionState('disconnected');
-      return;
-    }
-
-    const cleanup = devtoolsAPI.onCdpEvent((method, params) => {
-      for (const listener of cdpListenersRef.current) {
-        try {
-          listener(method, params);
-        } catch (err) {
-          console.error('[DevToolsApp] cdp listener error:', err);
-        }
+    try {
+      const info = await devtoolsAPI.getActiveTabInfo();
+      if (!info) {
+        setError('No active tab found');
+        setConnectionState('disconnected');
+        return;
       }
-    });
-    cleanupRef.current = cleanup;
+      setTabInfo(info);
 
-    setConnectionState('connected');
-    console.log('[DevToolsApp] connected to tab:', info.title);
+      const resp = await devtoolsAPI.attach();
+      if (!resp.success) {
+        console.error('[DevToolsApp] attach failed:', resp.error);
+        setError(resp.error ?? 'Failed to attach debugger');
+        setConnectionState('disconnected');
+        return;
+      }
+
+      const cleanup = devtoolsAPI.onCdpEvent((method, params) => {
+        for (const listener of cdpListenersRef.current) {
+          try {
+            listener(method, params);
+          } catch (err) {
+            console.error('[DevToolsApp] cdp listener error:', err);
+          }
+        }
+      });
+      cleanupRef.current = cleanup;
+
+      setConnectionState('connected');
+      console.log('[DevToolsApp] connected to tab:', info.title);
+    } catch (err) {
+      console.error('[DevToolsApp] connect failed:', err);
+      setError(String(err));
+      setConnectionState('disconnected');
+    }
   }, []);
 
   useEffect(() => {

--- a/my-app/src/renderer/devtools/DevToolsApp.tsx
+++ b/my-app/src/renderer/devtools/DevToolsApp.tsx
@@ -2,7 +2,13 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ConsolePanel } from './panels/ConsolePanel';
 import { ElementsPanel } from './panels/ElementsPanel';
 import { NetworkPanel } from './panels/NetworkPanel';
-import { PlaceholderPanel } from './panels/PlaceholderPanel';
+import { SourcesPanel } from './panels/SourcesPanel';
+import { PerformancePanel } from './panels/PerformancePanel';
+import { MemoryPanel } from './panels/MemoryPanel';
+import { ApplicationPanel } from './panels/ApplicationPanel';
+import { SecurityPanel } from './panels/SecurityPanel';
+import { LighthousePanel } from './panels/LighthousePanel';
+import { RecorderPanel } from './panels/RecorderPanel';
 
 declare const devtoolsAPI: {
   attach: () => Promise<{ success: boolean; error?: string }>;
@@ -45,16 +51,6 @@ const PANELS: PanelDef[] = [
   { id: 'recorder', label: 'Recorder', icon: '●' },
 ];
 
-const PLACEHOLDER_DESCRIPTIONS: Record<string, string> = {
-  sources: 'Debug JavaScript with breakpoints, watch expressions, call stack inspection, and code snippets.',
-  performance: 'Record and analyze runtime performance with flame charts, Web Vitals overlay, and frame rendering.',
-  memory: 'Take heap snapshots, track allocation timelines, and sample memory usage over time.',
-  application: 'Inspect storage (localStorage, sessionStorage, IndexedDB, cookies), service workers, and manifest.',
-  security: 'View TLS certificate details, mixed content warnings, and connection security information.',
-  lighthouse: 'Run performance, accessibility, best practices, and SEO audits on the current page.',
-  recorder: 'Record user flows, replay interactions, measure performance, and export as Puppeteer scripts.',
-};
-
 type ConnectionState = 'disconnected' | 'connecting' | 'connected';
 
 interface TabInfo {
@@ -84,6 +80,13 @@ export function DevToolsApp(): React.ReactElement {
     if (!resp.success) throw new Error(resp.error ?? 'CDP command failed');
     return resp.result;
   }, []);
+
+  const cdpSend = useCallback(
+    async (method: string, params?: Record<string, unknown>): Promise<{ success: boolean; result?: any; error?: string }> => {
+      return devtoolsAPI.send(method, params);
+    },
+    [],
+  );
 
   const connect = useCallback(async () => {
     console.log('[DevToolsApp] connecting...');
@@ -129,7 +132,9 @@ export function DevToolsApp(): React.ReactElement {
     };
   }, [connect]);
 
-  const renderPanel = (): React.ReactElement => {
+  const isAttached = connectionState === 'connected';
+
+  const renderPanel = (): React.ReactElement | null => {
     if (connectionState !== 'connected') {
       return (
         <div className="devtools-connect-overlay">
@@ -160,13 +165,22 @@ export function DevToolsApp(): React.ReactElement {
         return <ElementsPanel sendCdp={sendCdp} subscribeCdp={subscribeCdp} />;
       case 'network':
         return <NetworkPanel sendCdp={sendCdp} subscribeCdp={subscribeCdp} />;
+      case 'sources':
+        return <SourcesPanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'performance':
+        return <PerformancePanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'memory':
+        return <MemoryPanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'application':
+        return <ApplicationPanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'security':
+        return <SecurityPanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'lighthouse':
+        return <LighthousePanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
+      case 'recorder':
+        return <RecorderPanel cdpSend={cdpSend} onCdpEvent={subscribeCdp} isAttached={isAttached} />;
       default:
-        return (
-          <PlaceholderPanel
-            name={PANELS.find((p) => p.id === activePanel)?.label ?? activePanel}
-            description={PLACEHOLDER_DESCRIPTIONS[activePanel] ?? ''}
-          />
-        );
+        return null;
     }
   };
 

--- a/my-app/src/renderer/devtools/DevToolsApp.tsx
+++ b/my-app/src/renderer/devtools/DevToolsApp.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { ConsolePanel } from './panels/ConsolePanel';
+import { ElementsPanel } from './panels/ElementsPanel';
+import { NetworkPanel } from './panels/NetworkPanel';
+import { PlaceholderPanel } from './panels/PlaceholderPanel';
+
+declare const devtoolsAPI: {
+  attach: () => Promise<{ success: boolean; error?: string }>;
+  detach: () => Promise<{ success: boolean }>;
+  send: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: unknown; error?: string }>;
+  isAttached: () => Promise<boolean>;
+  getActiveTabInfo: () => Promise<{ id: string; url: string; title: string; favicon: string | null; isLoading: boolean } | null>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  onTabChanged: (cb: (tabId: string) => void) => () => void;
+};
+
+type PanelId =
+  | 'elements'
+  | 'console'
+  | 'sources'
+  | 'network'
+  | 'performance'
+  | 'memory'
+  | 'application'
+  | 'security'
+  | 'lighthouse'
+  | 'recorder';
+
+interface PanelDef {
+  id: PanelId;
+  label: string;
+  icon: string;
+}
+
+const PANELS: PanelDef[] = [
+  { id: 'elements', label: 'Elements', icon: '◇' },
+  { id: 'console', label: 'Console', icon: '▸' },
+  { id: 'sources', label: 'Sources', icon: '{ }' },
+  { id: 'network', label: 'Network', icon: '⇄' },
+  { id: 'performance', label: 'Performance', icon: '◔' },
+  { id: 'memory', label: 'Memory', icon: '▦' },
+  { id: 'application', label: 'Application', icon: '⊞' },
+  { id: 'security', label: 'Security', icon: '⊡' },
+  { id: 'lighthouse', label: 'Lighthouse', icon: '☆' },
+  { id: 'recorder', label: 'Recorder', icon: '●' },
+];
+
+const PLACEHOLDER_DESCRIPTIONS: Record<string, string> = {
+  sources: 'Debug JavaScript with breakpoints, watch expressions, call stack inspection, and code snippets.',
+  performance: 'Record and analyze runtime performance with flame charts, Web Vitals overlay, and frame rendering.',
+  memory: 'Take heap snapshots, track allocation timelines, and sample memory usage over time.',
+  application: 'Inspect storage (localStorage, sessionStorage, IndexedDB, cookies), service workers, and manifest.',
+  security: 'View TLS certificate details, mixed content warnings, and connection security information.',
+  lighthouse: 'Run performance, accessibility, best practices, and SEO audits on the current page.',
+  recorder: 'Record user flows, replay interactions, measure performance, and export as Puppeteer scripts.',
+};
+
+type ConnectionState = 'disconnected' | 'connecting' | 'connected';
+
+interface TabInfo {
+  id: string;
+  url: string;
+  title: string;
+  favicon: string | null;
+}
+
+export function DevToolsApp(): React.ReactElement {
+  const [activePanel, setActivePanel] = useState<PanelId>('console');
+  const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
+  const [tabInfo, setTabInfo] = useState<TabInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const cdpListenersRef = useRef<Array<(method: string, params: unknown) => void>>([]);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const subscribeCdp = useCallback((listener: (method: string, params: unknown) => void) => {
+    cdpListenersRef.current.push(listener);
+    return () => {
+      cdpListenersRef.current = cdpListenersRef.current.filter((l) => l !== listener);
+    };
+  }, []);
+
+  const sendCdp = useCallback(async (method: string, params?: Record<string, unknown>): Promise<unknown> => {
+    const resp = await devtoolsAPI.send(method, params);
+    if (!resp.success) throw new Error(resp.error ?? 'CDP command failed');
+    return resp.result;
+  }, []);
+
+  const connect = useCallback(async () => {
+    console.log('[DevToolsApp] connecting...');
+    setConnectionState('connecting');
+    setError(null);
+
+    const info = await devtoolsAPI.getActiveTabInfo();
+    if (!info) {
+      setError('No active tab found');
+      setConnectionState('disconnected');
+      return;
+    }
+    setTabInfo(info);
+
+    const resp = await devtoolsAPI.attach();
+    if (!resp.success) {
+      console.error('[DevToolsApp] attach failed:', resp.error);
+      setError(resp.error ?? 'Failed to attach debugger');
+      setConnectionState('disconnected');
+      return;
+    }
+
+    const cleanup = devtoolsAPI.onCdpEvent((method, params) => {
+      for (const listener of cdpListenersRef.current) {
+        try {
+          listener(method, params);
+        } catch (err) {
+          console.error('[DevToolsApp] cdp listener error:', err);
+        }
+      }
+    });
+    cleanupRef.current = cleanup;
+
+    setConnectionState('connected');
+    console.log('[DevToolsApp] connected to tab:', info.title);
+  }, []);
+
+  useEffect(() => {
+    void connect();
+    return () => {
+      cleanupRef.current?.();
+      void devtoolsAPI.detach();
+    };
+  }, [connect]);
+
+  const renderPanel = (): React.ReactElement => {
+    if (connectionState !== 'connected') {
+      return (
+        <div className="devtools-connect-overlay">
+          <div className="panel-placeholder-icon">⚡</div>
+          <div className="panel-placeholder-title">
+            {connectionState === 'connecting' ? 'Connecting...' : 'DevTools'}
+          </div>
+          {error && (
+            <div style={{ color: 'var(--color-status-error)', fontSize: 'var(--font-size-sm)' }}>
+              {error}
+            </div>
+          )}
+          <button
+            className="devtools-connect-btn"
+            onClick={() => void connect()}
+            disabled={connectionState === 'connecting'}
+          >
+            {connectionState === 'connecting' ? 'Connecting...' : 'Connect to Active Tab'}
+          </button>
+        </div>
+      );
+    }
+
+    switch (activePanel) {
+      case 'console':
+        return <ConsolePanel sendCdp={sendCdp} subscribeCdp={subscribeCdp} />;
+      case 'elements':
+        return <ElementsPanel sendCdp={sendCdp} subscribeCdp={subscribeCdp} />;
+      case 'network':
+        return <NetworkPanel sendCdp={sendCdp} subscribeCdp={subscribeCdp} />;
+      default:
+        return (
+          <PlaceholderPanel
+            name={PANELS.find((p) => p.id === activePanel)?.label ?? activePanel}
+            description={PLACEHOLDER_DESCRIPTIONS[activePanel] ?? ''}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="devtools-layout">
+      <div className="devtools-titlebar">
+        <div className="devtools-target-info">
+          {tabInfo?.favicon && (
+            <img className="devtools-target-favicon" src={tabInfo.favicon} alt="" />
+          )}
+          {tabInfo && (
+            <>
+              <span className="devtools-target-title">{tabInfo.title || 'Untitled'}</span>
+              <span className="devtools-target-url">{tabInfo.url}</span>
+            </>
+          )}
+        </div>
+        <div className="devtools-status">
+          <span
+            className="devtools-status-dot"
+            data-state={connectionState}
+          />
+          <span>{connectionState}</span>
+        </div>
+      </div>
+
+      <div className="devtools-tabs">
+        {PANELS.map((panel) => (
+          <button
+            key={panel.id}
+            className="devtools-tab"
+            data-active={activePanel === panel.id ? 'true' : 'false'}
+            onClick={() => setActivePanel(panel.id)}
+          >
+            <span className="devtools-tab-icon">{panel.icon}</span>
+            {panel.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="devtools-content">
+        {renderPanel()}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/devtools.css
+++ b/my-app/src/renderer/devtools/devtools.css
@@ -1,0 +1,611 @@
+/* DevTools panel styles — uses CSS vars from theme.global.css exclusively */
+
+.devtools-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background-color: var(--color-bg-base);
+  -webkit-app-region: drag;
+}
+
+.devtools-titlebar {
+  display: flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 var(--space-4);
+  padding-left: 78px;
+  background-color: var(--color-bg-sunken);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+  gap: var(--space-3);
+  -webkit-app-region: drag;
+}
+
+.devtools-target-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-secondary);
+  overflow: hidden;
+  -webkit-app-region: no-drag;
+}
+
+.devtools-target-favicon {
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-xs);
+  flex-shrink: 0;
+}
+
+.devtools-target-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+}
+
+.devtools-target-url {
+  color: var(--color-fg-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+}
+
+.devtools-status {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-2xs);
+  color: var(--color-fg-tertiary);
+  -webkit-app-region: no-drag;
+}
+
+.devtools-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-status-success);
+}
+
+.devtools-status-dot[data-state="disconnected"] {
+  background-color: var(--color-status-error);
+}
+
+.devtools-status-dot[data-state="connecting"] {
+  background-color: var(--color-status-warning);
+}
+
+/* Panel tabs */
+
+.devtools-tabs {
+  display: flex;
+  align-items: stretch;
+  height: 32px;
+  background-color: var(--color-bg-sunken);
+  border-bottom: 1px solid var(--color-border-default);
+  flex-shrink: 0;
+  overflow-x: auto;
+  -webkit-app-region: no-drag;
+}
+
+.devtools-tabs::-webkit-scrollbar {
+  height: 0;
+}
+
+.devtools-tab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-6);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+  user-select: none;
+}
+
+.devtools-tab:hover {
+  color: var(--color-fg-primary);
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.devtools-tab[data-active="true"] {
+  color: var(--color-accent-default);
+  border-bottom-color: var(--color-accent-default);
+}
+
+.devtools-tab-icon {
+  font-size: var(--font-size-sm);
+  line-height: 1;
+}
+
+/* Panel content */
+
+.devtools-content {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  -webkit-app-region: no-drag;
+}
+
+/* Console panel */
+
+.console-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.console-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.console-filter-input {
+  flex: 1;
+  padding: var(--space-1) var(--space-3);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+}
+
+.console-filter-input:focus {
+  border-color: var(--color-accent-default);
+}
+
+.console-level-btn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-2xs);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-secondary);
+  transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.console-level-btn:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.console-level-btn[data-active="true"] {
+  background-color: var(--color-surface-interactive-active);
+  color: var(--color-fg-primary);
+}
+
+.console-clear-btn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-2xs);
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+}
+
+.console-clear-btn:hover {
+  background-color: var(--color-surface-interactive-hover);
+  color: var(--color-fg-secondary);
+}
+
+.console-messages {
+  flex: 1;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.console-message {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  line-height: var(--line-height-relaxed);
+}
+
+.console-message:hover {
+  background-color: var(--color-surface-interactive);
+}
+
+.console-message[data-level="error"] {
+  background-color: rgba(248, 113, 113, 0.06);
+  color: var(--color-status-error);
+}
+
+.console-message[data-level="warning"] {
+  background-color: rgba(245, 158, 11, 0.06);
+  color: var(--color-status-warning);
+}
+
+.console-message[data-level="info"] {
+  color: var(--color-fg-primary);
+}
+
+.console-message-level {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: var(--font-size-2xs);
+}
+
+.console-message-text {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-all;
+  min-width: 0;
+}
+
+.console-message-source {
+  flex-shrink: 0;
+  color: var(--color-fg-tertiary);
+  font-size: var(--font-size-2xs);
+  text-align: right;
+}
+
+.console-input-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-sunken);
+  flex-shrink: 0;
+}
+
+.console-prompt-symbol {
+  color: var(--color-accent-default);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  flex-shrink: 0;
+}
+
+.console-input {
+  flex: 1;
+  padding: var(--space-1) 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-primary);
+  background: transparent;
+}
+
+/* Elements panel */
+
+.elements-panel {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.elements-tree {
+  flex: 1;
+  overflow: auto;
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-relaxed);
+}
+
+.elements-node {
+  padding-left: var(--space-8);
+  cursor: pointer;
+}
+
+.elements-node:hover {
+  background-color: var(--color-surface-interactive);
+  border-radius: var(--radius-xs);
+}
+
+.elements-node[data-selected="true"] {
+  background-color: var(--color-accent-muted);
+}
+
+.elements-tag {
+  color: #7cacf8;
+}
+
+.elements-attr-name {
+  color: #c792ea;
+}
+
+.elements-attr-value {
+  color: #c3e88d;
+}
+
+.elements-text-content {
+  color: var(--color-fg-primary);
+}
+
+.elements-comment {
+  color: var(--color-fg-tertiary);
+}
+
+.elements-toggle {
+  display: inline-block;
+  width: 16px;
+  text-align: center;
+  color: var(--color-fg-tertiary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.elements-styles {
+  width: 320px;
+  border-left: 1px solid var(--color-border-default);
+  overflow: auto;
+  padding: var(--space-4);
+  flex-shrink: 0;
+}
+
+.elements-styles-header {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg-secondary);
+  margin-bottom: var(--space-4);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.elements-style-rule {
+  margin-bottom: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+}
+
+.elements-style-selector {
+  color: #7cacf8;
+  margin-bottom: var(--space-1);
+}
+
+.elements-style-prop {
+  padding-left: var(--space-6);
+  color: var(--color-fg-primary);
+}
+
+.elements-style-prop-name {
+  color: #c792ea;
+}
+
+.elements-style-prop-value {
+  color: #c3e88d;
+}
+
+/* Network panel */
+
+.network-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.network-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.network-filter-input {
+  flex: 1;
+  padding: var(--space-1) var(--space-3);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+}
+
+.network-filter-input:focus {
+  border-color: var(--color-accent-default);
+}
+
+.network-type-filters {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.network-type-btn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-2xs);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-secondary);
+}
+
+.network-type-btn:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.network-type-btn[data-active="true"] {
+  background-color: var(--color-surface-interactive-active);
+  color: var(--color-fg-primary);
+}
+
+.network-table-wrapper {
+  flex: 1;
+  overflow: auto;
+}
+
+.network-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-xs);
+}
+
+.network-table th {
+  position: sticky;
+  top: 0;
+  padding: var(--space-2) var(--space-4);
+  text-align: left;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-secondary);
+  background-color: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border-default);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.network-table td {
+  padding: var(--space-1) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.network-table tr:hover td {
+  background-color: var(--color-surface-interactive);
+}
+
+.network-table tr[data-selected="true"] td {
+  background-color: var(--color-accent-muted);
+}
+
+.network-status {
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+}
+
+.network-status[data-ok="true"] {
+  color: var(--color-status-success);
+}
+
+.network-status[data-ok="false"] {
+  color: var(--color-status-error);
+}
+
+.network-method {
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg-secondary);
+}
+
+.network-url {
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+}
+
+.network-size {
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+}
+
+.network-time {
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+}
+
+.network-waterfall {
+  position: relative;
+  height: 12px;
+  min-width: 100px;
+}
+
+.network-waterfall-bar {
+  position: absolute;
+  height: 8px;
+  top: 2px;
+  border-radius: var(--radius-xs);
+  min-width: 2px;
+}
+
+.network-waterfall-bar[data-type="document"] { background-color: #7cacf8; }
+.network-waterfall-bar[data-type="script"] { background-color: #f7c948; }
+.network-waterfall-bar[data-type="stylesheet"] { background-color: #4ade80; }
+.network-waterfall-bar[data-type="image"] { background-color: #c792ea; }
+.network-waterfall-bar[data-type="font"] { background-color: #f87171; }
+.network-waterfall-bar[data-type="xhr"] { background-color: #60a5fa; }
+.network-waterfall-bar[data-type="fetch"] { background-color: #60a5fa; }
+.network-waterfall-bar[data-type="other"] { background-color: var(--color-fg-tertiary); }
+
+.network-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-default);
+  background-color: var(--color-bg-sunken);
+  font-size: var(--font-size-2xs);
+  color: var(--color-fg-secondary);
+  flex-shrink: 0;
+}
+
+/* Placeholder panel (for unimplemented panels) */
+
+.panel-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: var(--space-4);
+  color: var(--color-fg-tertiary);
+}
+
+.panel-placeholder-icon {
+  font-size: 48px;
+  opacity: 0.3;
+}
+
+.panel-placeholder-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-fg-secondary);
+}
+
+.panel-placeholder-desc {
+  font-size: var(--font-size-sm);
+  max-width: 400px;
+  text-align: center;
+  line-height: var(--line-height-relaxed);
+}
+
+/* Connection overlay */
+
+.devtools-connect-overlay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: var(--space-6);
+}
+
+.devtools-connect-btn {
+  padding: var(--space-3) var(--space-8);
+  background-color: var(--color-accent-default);
+  color: var(--color-fg-inverse);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+  transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.devtools-connect-btn:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.devtools-connect-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/my-app/src/renderer/devtools/devtools.html
+++ b/my-app/src/renderer/devtools/devtools.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: http: https:" />
+    <title>DevTools</title>
+  </head>
+  <body>
+    <div id="devtools-root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/my-app/src/renderer/devtools/index.tsx
+++ b/my-app/src/renderer/devtools/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { loadFonts } from '../design/fonts';
+import '../design/theme.global.css';
+import '../components/base/components.css';
+import './devtools.css';
+
+import { DevToolsApp } from './DevToolsApp';
+
+loadFonts();
+
+window.addEventListener('error', (e) => {
+  console.error('[devtools] renderer.error', { message: e.message, file: e.filename, line: e.lineno });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('[devtools] renderer.unhandledrejection', { reason: String(e.reason) });
+});
+
+const container = document.getElementById('devtools-root');
+if (!container) {
+  throw new Error('[devtools] #devtools-root element not found in devtools.html');
+}
+
+const root = createRoot(container);
+root.render(
+  <React.StrictMode>
+    <DevToolsApp />
+  </React.StrictMode>,
+);

--- a/my-app/src/renderer/devtools/panels/ApplicationPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ApplicationPanel.tsx
@@ -70,7 +70,7 @@ export function ApplicationPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps
   const evalExpr = useCallback(
     async (expression: string): Promise<unknown> => {
       console.log('[ApplicationPanel] Runtime.evaluate:', expression.slice(0, 80));
-      const resp = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: false });
+      const resp = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
       if (!resp.success) throw new Error(resp.error ?? 'Runtime.evaluate failed');
       const evalResult = resp.result as { result?: { value?: unknown }; exceptionDetails?: { text?: string } } | undefined;
       if (evalResult?.exceptionDetails) {

--- a/my-app/src/renderer/devtools/panels/ApplicationPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ApplicationPanel.tsx
@@ -1,0 +1,687 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+type StorageCategory =
+  | 'cookies'
+  | 'localStorage'
+  | 'sessionStorage'
+  | 'indexedDB'
+  | 'cacheStorage'
+  | 'serviceWorkers'
+  | 'manifest';
+
+interface StorageEntry {
+  key: string;
+  value: string;
+}
+
+interface ServiceWorkerInfo {
+  registrationId: string;
+  scopeURL: string;
+  isDeleted: boolean;
+  versions: Array<{ versionId: string; registrationId: string; scriptURL: string; runningStatus: string; status: string }>;
+}
+
+interface IndexedDBDatabase {
+  name: string;
+  origin: string;
+  objectStores: Array<{ name: string; keyPath: unknown; autoIncrement: boolean }>;
+}
+
+interface ManifestInfo {
+  name?: string;
+  shortName?: string;
+  startUrl?: string;
+  display?: string;
+  themeColor?: string;
+  backgroundColor?: string;
+  icons?: Array<{ src: string; sizes?: string; type?: string }>;
+}
+
+const STORAGE_CATEGORIES: Array<{ id: StorageCategory; label: string }> = [
+  { id: 'cookies', label: 'Cookies' },
+  { id: 'localStorage', label: 'Local Storage' },
+  { id: 'sessionStorage', label: 'Session Storage' },
+  { id: 'indexedDB', label: 'IndexedDB' },
+  { id: 'cacheStorage', label: 'Cache Storage' },
+  { id: 'serviceWorkers', label: 'Service Workers' },
+  { id: 'manifest', label: 'Manifest' },
+];
+
+export function ApplicationPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [activeCategory, setActiveCategory] = useState<StorageCategory>('cookies');
+  const [cookieEntries, setCookieEntries] = useState<StorageEntry[]>([]);
+  const [localStorageEntries, setLocalStorageEntries] = useState<StorageEntry[]>([]);
+  const [sessionStorageEntries, setSessionStorageEntries] = useState<StorageEntry[]>([]);
+  const [indexedDBDatabases, setIndexedDBDatabases] = useState<IndexedDBDatabase[]>([]);
+  const [cacheNames, setCacheNames] = useState<string[]>([]);
+  const [serviceWorkers, setServiceWorkers] = useState<ServiceWorkerInfo[]>([]);
+  const [manifestInfo, setManifestInfo] = useState<ManifestInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  const evalExpr = useCallback(
+    async (expression: string): Promise<unknown> => {
+      console.log('[ApplicationPanel] Runtime.evaluate:', expression.slice(0, 80));
+      const resp = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: false });
+      if (!resp.success) throw new Error(resp.error ?? 'Runtime.evaluate failed');
+      const evalResult = resp.result as { result?: { value?: unknown }; exceptionDetails?: { text?: string } } | undefined;
+      if (evalResult?.exceptionDetails) {
+        throw new Error(evalResult.exceptionDetails.text ?? 'JS exception');
+      }
+      return evalResult?.result?.value;
+    },
+    [cdpSend],
+  );
+
+  // ── loaders ──────────────────────────────────────────────────────────────
+
+  const loadCookies = useCallback(async () => {
+    console.log('[ApplicationPanel] loading cookies via Runtime.evaluate');
+    setLoading(true);
+    setError(null);
+    try {
+      const raw = (await evalExpr('document.cookie')) as string;
+      const entries: StorageEntry[] = raw
+        ? raw.split(';').map((pair) => {
+            const idx = pair.indexOf('=');
+            const key = pair.slice(0, idx).trim();
+            const value = pair.slice(idx + 1).trim();
+            return { key, value };
+          })
+        : [];
+      console.log('[ApplicationPanel] cookies loaded, count:', entries.length);
+      setCookieEntries(entries);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadCookies error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [evalExpr]);
+
+  const loadLocalStorage = useCallback(async () => {
+    console.log('[ApplicationPanel] loading localStorage');
+    setLoading(true);
+    setError(null);
+    try {
+      const raw = (await evalExpr('JSON.stringify(Object.entries(localStorage))')) as string;
+      const pairs: Array<[string, string]> = raw ? JSON.parse(raw) : [];
+      const entries: StorageEntry[] = pairs.map(([key, value]) => ({ key, value }));
+      console.log('[ApplicationPanel] localStorage loaded, count:', entries.length);
+      setLocalStorageEntries(entries);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadLocalStorage error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [evalExpr]);
+
+  const loadSessionStorage = useCallback(async () => {
+    console.log('[ApplicationPanel] loading sessionStorage');
+    setLoading(true);
+    setError(null);
+    try {
+      const raw = (await evalExpr('JSON.stringify(Object.entries(sessionStorage))')) as string;
+      const pairs: Array<[string, string]> = raw ? JSON.parse(raw) : [];
+      const entries: StorageEntry[] = pairs.map(([key, value]) => ({ key, value }));
+      console.log('[ApplicationPanel] sessionStorage loaded, count:', entries.length);
+      setSessionStorageEntries(entries);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadSessionStorage error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [evalExpr]);
+
+  const loadIndexedDB = useCallback(async () => {
+    console.log('[ApplicationPanel] loading IndexedDB database names');
+    setLoading(true);
+    setError(null);
+    try {
+      const securityOriginResp = await cdpSend('Runtime.evaluate', {
+        expression: 'location.origin',
+        returnByValue: true,
+      });
+      const securityOrigin = (securityOriginResp.result as any)?.result?.value as string ?? 'null';
+      console.log('[ApplicationPanel] securityOrigin:', securityOrigin);
+
+      const namesResp = await cdpSend('IndexedDB.requestDatabaseNames', { securityOrigin });
+      if (!namesResp.success) throw new Error(namesResp.error ?? 'IndexedDB.requestDatabaseNames failed');
+
+      const dbNames = (namesResp.result as { databaseNames?: string[] })?.databaseNames ?? [];
+      console.log('[ApplicationPanel] IndexedDB names:', dbNames);
+
+      const databases: IndexedDBDatabase[] = [];
+      for (const dbName of dbNames) {
+        const dbResp = await cdpSend('IndexedDB.requestDatabase', { securityOrigin, databaseName: dbName });
+        if (dbResp.success) {
+          const dbInfo = dbResp.result as { databaseWithObjectStores?: { name: string; version: number; objectStores: Array<{ name: string; keyPath: unknown; autoIncrement: boolean }> } };
+          if (dbInfo?.databaseWithObjectStores) {
+            databases.push({
+              name: dbInfo.databaseWithObjectStores.name,
+              origin: securityOrigin,
+              objectStores: dbInfo.databaseWithObjectStores.objectStores,
+            });
+          }
+        }
+      }
+
+      console.log('[ApplicationPanel] IndexedDB databases loaded:', databases.length);
+      setIndexedDBDatabases(databases);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadIndexedDB error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [cdpSend]);
+
+  const loadCacheStorage = useCallback(async () => {
+    console.log('[ApplicationPanel] loading CacheStorage names');
+    setLoading(true);
+    setError(null);
+    try {
+      const securityOriginResp = await cdpSend('Runtime.evaluate', {
+        expression: 'location.origin',
+        returnByValue: true,
+      });
+      const securityOrigin = (securityOriginResp.result as any)?.result?.value as string ?? 'null';
+
+      const resp = await cdpSend('CacheStorage.requestCacheNames', { securityOrigin });
+      if (!resp.success) throw new Error(resp.error ?? 'CacheStorage.requestCacheNames failed');
+
+      const caches = (resp.result as { caches?: Array<{ cacheName: string }> })?.caches ?? [];
+      const names = caches.map((c) => c.cacheName);
+      console.log('[ApplicationPanel] CacheStorage names:', names);
+      setCacheNames(names);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadCacheStorage error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [cdpSend]);
+
+  const loadServiceWorkers = useCallback(async () => {
+    console.log('[ApplicationPanel] enabling ServiceWorker domain');
+    setLoading(true);
+    setError(null);
+    try {
+      await cdpSend('ServiceWorker.enable');
+      // Service worker registrations come via events; trigger a list via workerRegistrationUpdated
+      // We collect any registrations already fired and display them
+      console.log('[ApplicationPanel] ServiceWorker domain enabled');
+    } catch (err) {
+      console.error('[ApplicationPanel] loadServiceWorkers error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [cdpSend]);
+
+  const loadManifest = useCallback(async () => {
+    console.log('[ApplicationPanel] loading manifest info');
+    setLoading(true);
+    setError(null);
+    try {
+      const manifestUrl = (await evalExpr(
+        'document.querySelector(\'link[rel="manifest"]\')?.href ?? null',
+      )) as string | null;
+      console.log('[ApplicationPanel] manifest href:', manifestUrl);
+
+      if (!manifestUrl) {
+        setManifestInfo(null);
+        return;
+      }
+
+      const manifestJson = (await evalExpr(
+        `fetch(${JSON.stringify(manifestUrl)}).then(r => r.text())`,
+      )) as string;
+
+      const parsed: ManifestInfo = JSON.parse(manifestJson);
+      console.log('[ApplicationPanel] manifest parsed:', parsed);
+      setManifestInfo(parsed);
+    } catch (err) {
+      console.error('[ApplicationPanel] loadManifest error:', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [evalExpr]);
+
+  // ── category switching ────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log('[ApplicationPanel] category changed to:', activeCategory);
+
+    switch (activeCategory) {
+      case 'cookies':
+        void loadCookies();
+        break;
+      case 'localStorage':
+        void loadLocalStorage();
+        break;
+      case 'sessionStorage':
+        void loadSessionStorage();
+        break;
+      case 'indexedDB':
+        void loadIndexedDB();
+        break;
+      case 'cacheStorage':
+        void loadCacheStorage();
+        break;
+      case 'serviceWorkers':
+        void loadServiceWorkers();
+        break;
+      case 'manifest':
+        void loadManifest();
+        break;
+    }
+  }, [
+    activeCategory,
+    isAttached,
+    loadCookies,
+    loadLocalStorage,
+    loadSessionStorage,
+    loadIndexedDB,
+    loadCacheStorage,
+    loadServiceWorkers,
+    loadManifest,
+  ]);
+
+  // ── listen for ServiceWorker events ──────────────────────────────────────
+
+  useEffect(() => {
+    if (!isAttached) return;
+
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'ServiceWorker.workerRegistrationUpdated') {
+        const registrations = p.registrations as ServiceWorkerInfo[] | undefined;
+        console.log('[ApplicationPanel] ServiceWorker.workerRegistrationUpdated, count:', registrations?.length ?? 0);
+        if (registrations) {
+          setServiceWorkers(registrations);
+        }
+      }
+
+      if (method === 'ServiceWorker.workerVersionUpdated') {
+        const versions = p.versions as Array<{ versionId: string; registrationId: string; scriptURL: string; runningStatus: string; status: string }> | undefined;
+        console.log('[ApplicationPanel] ServiceWorker.workerVersionUpdated, count:', versions?.length ?? 0);
+        if (versions) {
+          setServiceWorkers((prev) =>
+            prev.map((sw) => ({
+              ...sw,
+              versions: versions.filter((v) => v.registrationId === sw.registrationId),
+            })),
+          );
+        }
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      console.log('[ApplicationPanel] unsubscribed from CDP events');
+    };
+  }, [isAttached, onCdpEvent]);
+
+  // ── clear handlers ────────────────────────────────────────────────────────
+
+  const handleClear = useCallback(async () => {
+    console.log('[ApplicationPanel] clearing storage category:', activeCategory);
+    try {
+      switch (activeCategory) {
+        case 'cookies':
+          await evalExpr(
+            'document.cookie.split(";").forEach(c => { const e = c.trim().split("=")[0]; document.cookie = e + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/"; })',
+          );
+          void loadCookies();
+          break;
+        case 'localStorage':
+          await evalExpr('localStorage.clear()');
+          void loadLocalStorage();
+          break;
+        case 'sessionStorage':
+          await evalExpr('sessionStorage.clear()');
+          void loadSessionStorage();
+          break;
+        case 'indexedDB': {
+          const securityOriginResp = await cdpSend('Runtime.evaluate', { expression: 'location.origin', returnByValue: true });
+          const origin = (securityOriginResp.result as any)?.result?.value as string ?? 'null';
+          for (const db of indexedDBDatabases) {
+            await cdpSend('IndexedDB.deleteDatabase', { securityOrigin: origin, databaseName: db.name });
+          }
+          void loadIndexedDB();
+          break;
+        }
+        case 'cacheStorage':
+          await evalExpr('caches.keys().then(names => Promise.all(names.map(n => caches.delete(n))))');
+          void loadCacheStorage();
+          break;
+      }
+    } catch (err) {
+      console.error('[ApplicationPanel] clear failed:', err);
+      setError(String(err));
+    }
+  }, [activeCategory, evalExpr, cdpSend, indexedDBDatabases, loadCookies, loadLocalStorage, loadSessionStorage, loadIndexedDB, loadCacheStorage]);
+
+  // ── render helpers ────────────────────────────────────────────────────────
+
+  const renderStorageTable = (entries: StorageEntry[]): React.ReactElement => {
+    if (entries.length === 0) {
+      return (
+        <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+          No data
+        </div>
+      );
+    }
+    return (
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-xs)', fontFamily: 'var(--font-mono)' }}>
+        <thead>
+          <tr>
+            <th style={thStyle}>Key</th>
+            <th style={thStyle}>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry, i) => (
+            <tr key={i} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+              <td style={tdKeyStyle}>{entry.key}</td>
+              <td style={tdValueStyle}>{entry.value.length > 200 ? entry.value.slice(0, 200) + '…' : entry.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  const renderContent = (): React.ReactElement => {
+    if (!isAttached) {
+      return (
+        <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-sm)', textAlign: 'center' }}>
+          Not attached to a tab
+        </div>
+      );
+    }
+
+    if (loading) {
+      return (
+        <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+          Loading...
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div style={{ padding: 'var(--space-6)', color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)' }}>
+          {error}
+        </div>
+      );
+    }
+
+    switch (activeCategory) {
+      case 'cookies':
+        return renderStorageTable(cookieEntries);
+
+      case 'localStorage':
+        return renderStorageTable(localStorageEntries);
+
+      case 'sessionStorage':
+        return renderStorageTable(sessionStorageEntries);
+
+      case 'indexedDB':
+        if (indexedDBDatabases.length === 0) {
+          return (
+            <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+              No IndexedDB databases
+            </div>
+          );
+        }
+        return (
+          <div style={{ padding: 'var(--space-4)' }}>
+            {indexedDBDatabases.map((db, i) => (
+              <div key={i} style={{ marginBottom: 'var(--space-6)' }}>
+                <div style={{ fontSize: 'var(--font-size-xs)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-primary)', marginBottom: 'var(--space-2)' }}>
+                  {db.name}
+                </div>
+                {db.objectStores.length === 0 ? (
+                  <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>No object stores</div>
+                ) : (
+                  db.objectStores.map((store, j) => (
+                    <div key={j} style={{ paddingLeft: 'var(--space-4)', fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-secondary)', borderBottom: '1px solid var(--color-border-subtle)', padding: 'var(--space-1) var(--space-4)' }}>
+                      {store.name} {store.autoIncrement ? '(auto-increment)' : ''}
+                    </div>
+                  ))
+                )}
+              </div>
+            ))}
+          </div>
+        );
+
+      case 'cacheStorage':
+        if (cacheNames.length === 0) {
+          return (
+            <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+              No caches
+            </div>
+          );
+        }
+        return (
+          <div style={{ padding: 'var(--space-4)' }}>
+            {cacheNames.map((name, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: 'var(--space-2) var(--space-3)',
+                  borderBottom: '1px solid var(--color-border-subtle)',
+                  fontSize: 'var(--font-size-xs)',
+                  fontFamily: 'var(--font-mono)',
+                  color: 'var(--color-fg-primary)',
+                }}
+              >
+                {name}
+              </div>
+            ))}
+          </div>
+        );
+
+      case 'serviceWorkers':
+        if (serviceWorkers.length === 0) {
+          return (
+            <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+              No service workers registered
+            </div>
+          );
+        }
+        return (
+          <div style={{ padding: 'var(--space-4)' }}>
+            {serviceWorkers.map((sw, i) => (
+              <div key={i} style={{ marginBottom: 'var(--space-4)', padding: 'var(--space-3)', border: '1px solid var(--color-border-subtle)', borderRadius: 'var(--radius-sm)' }}>
+                <div style={{ fontSize: 'var(--font-size-xs)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-primary)', marginBottom: 'var(--space-1)' }}>
+                  {sw.scopeURL}
+                </div>
+                <div style={{ fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)', fontFamily: 'var(--font-mono)' }}>
+                  ID: {sw.registrationId}
+                </div>
+                {sw.versions?.map((v, j) => (
+                  <div key={j} style={{ marginTop: 'var(--space-2)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-secondary)' }}>
+                    <span style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)' }}>{v.scriptURL}</span>
+                    {' — '}
+                    <span style={{ color: v.runningStatus === 'running' ? 'var(--color-status-success)' : 'var(--color-fg-tertiary)' }}>
+                      {v.runningStatus}
+                    </span>
+                    {' / '}
+                    <span>{v.status}</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        );
+
+      case 'manifest':
+        if (!manifestInfo) {
+          return (
+            <div style={{ padding: 'var(--space-8)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)', textAlign: 'center' }}>
+              No web app manifest found
+            </div>
+          );
+        }
+        return (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-xs)', fontFamily: 'var(--font-mono)' }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Property</th>
+                <th style={thStyle}>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(manifestInfo)
+                .filter(([, v]) => v !== undefined && v !== null && typeof v !== 'object')
+                .map(([key, value], i) => (
+                  <tr key={i} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                    <td style={tdKeyStyle}>{key}</td>
+                    <td style={tdValueStyle}>{String(value)}</td>
+                  </tr>
+                ))}
+              {manifestInfo.icons && manifestInfo.icons.length > 0 && (
+                <tr style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                  <td style={tdKeyStyle}>icons</td>
+                  <td style={tdValueStyle}>{manifestInfo.icons.map((ic) => `${ic.src} (${ic.sizes ?? '?'})`).join(', ')}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        );
+    }
+  };
+
+  const showClearButton = ['cookies', 'localStorage', 'sessionStorage', 'indexedDB', 'cacheStorage'].includes(activeCategory);
+
+  return (
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      {/* Sidebar */}
+      <div
+        style={{
+          width: '200px',
+          flexShrink: 0,
+          borderRight: '1px solid var(--color-border-default)',
+          overflowY: 'auto',
+          backgroundColor: 'var(--color-bg-sunken)',
+        }}
+      >
+        {STORAGE_CATEGORIES.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => setActiveCategory(cat.id)}
+            style={{
+              display: 'block',
+              width: '100%',
+              textAlign: 'left',
+              padding: 'var(--space-2) var(--space-4)',
+              fontSize: 'var(--font-size-xs)',
+              color: activeCategory === cat.id ? 'var(--color-accent-default)' : 'var(--color-fg-secondary)',
+              backgroundColor: activeCategory === cat.id ? 'var(--color-accent-muted)' : 'transparent',
+              borderLeft: activeCategory === cat.id ? '2px solid var(--color-accent-default)' : '2px solid transparent',
+              cursor: 'pointer',
+            }}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content area */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* Toolbar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: 'var(--space-2) var(--space-4)',
+            borderBottom: '1px solid var(--color-border-subtle)',
+            flexShrink: 0,
+            backgroundColor: 'var(--color-bg-elevated)',
+          }}
+        >
+          <span style={{ fontSize: 'var(--font-size-xs)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-secondary)' }}>
+            {STORAGE_CATEGORIES.find((c) => c.id === activeCategory)?.label}
+          </span>
+          <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+            <button
+              className="console-clear-btn"
+              onClick={() => {
+                console.log('[ApplicationPanel] refresh clicked for:', activeCategory);
+                switch (activeCategory) {
+                  case 'cookies': void loadCookies(); break;
+                  case 'localStorage': void loadLocalStorage(); break;
+                  case 'sessionStorage': void loadSessionStorage(); break;
+                  case 'indexedDB': void loadIndexedDB(); break;
+                  case 'cacheStorage': void loadCacheStorage(); break;
+                  case 'serviceWorkers': void loadServiceWorkers(); break;
+                  case 'manifest': void loadManifest(); break;
+                }
+              }}
+            >
+              Refresh
+            </button>
+            {showClearButton && (
+              <button className="console-clear-btn" onClick={() => void handleClear()}>
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Data */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {renderContent()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── shared inline style constants ─────────────────────────────────────────
+
+const thStyle: React.CSSProperties = {
+  position: 'sticky',
+  top: 0,
+  padding: 'var(--space-2) var(--space-4)',
+  textAlign: 'left',
+  fontWeight: 'var(--font-weight-medium)',
+  color: 'var(--color-fg-secondary)',
+  backgroundColor: 'var(--color-bg-elevated)',
+  borderBottom: '1px solid var(--color-border-default)',
+  whiteSpace: 'nowrap',
+  userSelect: 'none',
+};
+
+const tdKeyStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-4)',
+  color: '#c792ea',
+  whiteSpace: 'nowrap',
+  width: '200px',
+  maxWidth: '200px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+};
+
+const tdValueStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-4)',
+  color: 'var(--color-fg-primary)',
+  wordBreak: 'break-all',
+};

--- a/my-app/src/renderer/devtools/panels/ConsolePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ConsolePanel.tsx
@@ -1,0 +1,290 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+interface CdpPanelProps {
+  sendCdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  subscribeCdp: (listener: (method: string, params: unknown) => void) => () => void;
+}
+
+type LogLevel = 'log' | 'info' | 'warning' | 'error' | 'debug' | 'result';
+
+interface ConsoleEntry {
+  id: number;
+  level: LogLevel;
+  text: string;
+  source?: string;
+  timestamp: number;
+}
+
+const LEVEL_ICONS: Record<LogLevel, string> = {
+  log: ' ',
+  info: 'ℹ',
+  warning: '⚠',
+  error: '✕',
+  debug: '⊙',
+  result: '←',
+};
+
+let entryIdCounter = 0;
+
+export function ConsolePanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.ReactElement {
+  const [messages, setMessages] = useState<ConsoleEntry[]>([]);
+  const [input, setInput] = useState('');
+  const [filter, setFilter] = useState('');
+  const [activeLevels, setActiveLevels] = useState<Set<LogLevel>>(
+    new Set(['log', 'info', 'warning', 'error', 'debug', 'result']),
+  );
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    console.log('[ConsolePanel] enabling Runtime + Log domains');
+
+    void sendCdp('Runtime.enable');
+    void sendCdp('Log.enable');
+
+    const unsubscribe = subscribeCdp((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'Runtime.consoleAPICalled') {
+        const args = p.args as Array<{ type: string; value?: unknown; description?: string }>;
+        const text = args
+          .map((a) => {
+            if (a.value !== undefined) return String(a.value);
+            if (a.description) return a.description;
+            return `[${a.type}]`;
+          })
+          .join(' ');
+
+        const levelMap: Record<string, LogLevel> = {
+          log: 'log',
+          info: 'info',
+          warning: 'warning',
+          error: 'error',
+          debug: 'debug',
+          dir: 'log',
+          table: 'log',
+          trace: 'log',
+          assert: 'error',
+        };
+        const type = p.type as string;
+        const level = levelMap[type] ?? 'log';
+
+        const stackTrace = p.stackTrace as { callFrames?: Array<{ url?: string; lineNumber?: number }> } | undefined;
+        const frame = stackTrace?.callFrames?.[0];
+        const source = frame?.url ? `${frame.url}:${(frame.lineNumber ?? 0) + 1}` : undefined;
+
+        setMessages((prev) => [
+          ...prev,
+          { id: entryIdCounter++, level, text, source, timestamp: Date.now() },
+        ]);
+      }
+
+      if (method === 'Runtime.exceptionThrown') {
+        const detail = p.exceptionDetails as {
+          text?: string;
+          exception?: { description?: string };
+          url?: string;
+          lineNumber?: number;
+        };
+        const text = detail?.exception?.description ?? detail?.text ?? 'Unknown error';
+        const source = detail?.url ? `${detail.url}:${(detail.lineNumber ?? 0) + 1}` : undefined;
+
+        setMessages((prev) => [
+          ...prev,
+          { id: entryIdCounter++, level: 'error', text, source, timestamp: Date.now() },
+        ]);
+      }
+
+      if (method === 'Log.entryAdded') {
+        const entry = p.entry as { level?: string; text?: string; url?: string; lineNumber?: number };
+        const levelMap: Record<string, LogLevel> = {
+          verbose: 'debug',
+          info: 'info',
+          warning: 'warning',
+          error: 'error',
+        };
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: entryIdCounter++,
+            level: levelMap[entry.level ?? ''] ?? 'log',
+            text: entry.text ?? '',
+            source: entry.url ? `${entry.url}:${(entry.lineNumber ?? 0) + 1}` : undefined,
+            timestamp: Date.now(),
+          },
+        ]);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      void sendCdp('Runtime.disable').catch(() => {});
+      void sendCdp('Log.disable').catch(() => {});
+    };
+  }, [sendCdp, subscribeCdp]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  const handleEval = useCallback(async () => {
+    const expression = input.trim();
+    if (!expression) return;
+
+    setHistory((prev) => [...prev.filter((h) => h !== expression), expression]);
+    setHistoryIndex(-1);
+
+    setMessages((prev) => [
+      ...prev,
+      { id: entryIdCounter++, level: 'log', text: `> ${expression}`, timestamp: Date.now() },
+    ]);
+    setInput('');
+
+    try {
+      const result = (await sendCdp('Runtime.evaluate', {
+        expression,
+        generatePreview: true,
+        replMode: true,
+        awaitPromise: true,
+      })) as {
+        result?: { type?: string; value?: unknown; description?: string; subtype?: string };
+        exceptionDetails?: { text?: string; exception?: { description?: string } };
+      };
+
+      if (result.exceptionDetails) {
+        const errText =
+          result.exceptionDetails.exception?.description ??
+          result.exceptionDetails.text ??
+          'Evaluation error';
+        setMessages((prev) => [
+          ...prev,
+          { id: entryIdCounter++, level: 'error', text: errText, timestamp: Date.now() },
+        ]);
+      } else if (result.result) {
+        const r = result.result;
+        let text: string;
+        if (r.subtype === 'null') text = 'null';
+        else if (r.type === 'undefined') text = 'undefined';
+        else if (r.value !== undefined) text = JSON.stringify(r.value);
+        else if (r.description) text = r.description;
+        else text = `[${r.type}]`;
+
+        setMessages((prev) => [
+          ...prev,
+          { id: entryIdCounter++, level: 'result', text, timestamp: Date.now() },
+        ]);
+      }
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        { id: entryIdCounter++, level: 'error', text: String(err), timestamp: Date.now() },
+      ]);
+    }
+  }, [input, sendCdp]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        void handleEval();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (history.length > 0) {
+          const newIdx = historyIndex < 0 ? history.length - 1 : Math.max(0, historyIndex - 1);
+          setHistoryIndex(newIdx);
+          setInput(history[newIdx]);
+        }
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (historyIndex >= 0) {
+          const newIdx = historyIndex + 1;
+          if (newIdx >= history.length) {
+            setHistoryIndex(-1);
+            setInput('');
+          } else {
+            setHistoryIndex(newIdx);
+            setInput(history[newIdx]);
+          }
+        }
+      }
+    },
+    [handleEval, history, historyIndex],
+  );
+
+  const toggleLevel = (level: LogLevel): void => {
+    setActiveLevels((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  };
+
+  const clearMessages = (): void => {
+    setMessages([]);
+  };
+
+  const filteredMessages = messages.filter((m) => {
+    if (!activeLevels.has(m.level)) return false;
+    if (filter && !m.text.toLowerCase().includes(filter.toLowerCase())) return false;
+    return true;
+  });
+
+  return (
+    <div className="console-panel">
+      <div className="console-toolbar">
+        <input
+          className="console-filter-input"
+          type="text"
+          placeholder="Filter output..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        {(['error', 'warning', 'info', 'log', 'debug'] as LogLevel[]).map((level) => (
+          <button
+            key={level}
+            className="console-level-btn"
+            data-active={activeLevels.has(level) ? 'true' : 'false'}
+            onClick={() => toggleLevel(level)}
+          >
+            {level}
+          </button>
+        ))}
+        <button className="console-clear-btn" onClick={clearMessages}>
+          Clear
+        </button>
+      </div>
+
+      <div className="console-messages">
+        {filteredMessages.map((msg) => (
+          <div key={msg.id} className="console-message" data-level={msg.level}>
+            <span className="console-message-level">{LEVEL_ICONS[msg.level]}</span>
+            <span className="console-message-text">{msg.text}</span>
+            {msg.source && <span className="console-message-source">{msg.source}</span>}
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="console-input-row">
+        <span className="console-prompt-symbol">›</span>
+        <input
+          ref={inputRef}
+          className="console-input"
+          type="text"
+          placeholder="Evaluate JavaScript..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          autoFocus
+        />
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
@@ -280,6 +280,7 @@ function StylesPane({ nodeId, sendCdp }: StylesPaneProps): React.ReactElement {
       return;
     }
 
+    let stale = false;
     setLoading(true);
 
     if (activeTab === 'styles') {
@@ -289,14 +290,16 @@ function StylesPane({ nodeId, sendCdp }: StylesPaneProps): React.ReactElement {
           const result = (await sendCdp('CSS.getMatchedStylesForNode', { nodeId })) as {
             matchedCSSRules?: CdpRuleMatch[];
           };
+          if (stale) return;
           const rules = result?.matchedCSSRules ?? [];
           console.log('[ElementsPanel] matched rules count:', rules.length, 'nodeId:', nodeId);
           setMatchedRules(rules);
         } catch (err) {
+          if (stale) return;
           console.error('[ElementsPanel] CSS.getMatchedStylesForNode error nodeId:', nodeId, err);
           setMatchedRules([]);
         } finally {
-          setLoading(false);
+          if (!stale) setLoading(false);
         }
       })();
     } else if (activeTab === 'computed') {
@@ -306,14 +309,16 @@ function StylesPane({ nodeId, sendCdp }: StylesPaneProps): React.ReactElement {
           const result = (await sendCdp('CSS.getComputedStyleForNode', { nodeId })) as {
             computedStyle?: CdpComputedProperty[];
           };
+          if (stale) return;
           const props = result?.computedStyle ?? [];
           console.log('[ElementsPanel] computed props count:', props.length, 'nodeId:', nodeId);
           setComputedProps(props);
         } catch (err) {
+          if (stale) return;
           console.error('[ElementsPanel] CSS.getComputedStyleForNode error nodeId:', nodeId, err);
           setComputedProps([]);
         } finally {
-          setLoading(false);
+          if (!stale) setLoading(false);
         }
       })();
     } else if (activeTab === 'accessibility') {
@@ -323,17 +328,21 @@ function StylesPane({ nodeId, sendCdp }: StylesPaneProps): React.ReactElement {
           const result = (await sendCdp('Accessibility.getFullAXTree', { nodeId })) as {
             nodes?: AXNode[];
           };
+          if (stale) return;
           const nodes = result?.nodes ?? [];
           console.log('[ElementsPanel] AX nodes count:', nodes.length, 'nodeId:', nodeId);
           setAxNodes(nodes);
         } catch (err) {
+          if (stale) return;
           console.error('[ElementsPanel] Accessibility.getFullAXTree error nodeId:', nodeId, err);
           setAxNodes([]);
         } finally {
-          setLoading(false);
+          if (!stale) setLoading(false);
         }
       })();
     }
+
+    return () => { stale = true; };
   }, [nodeId, activeTab, sendCdp]);
 
   const emptyMsg = (msg: string): React.ReactElement => (

--- a/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
@@ -1,72 +1,568 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+// ── CDP type definitions ──────────────────────────────────────────────────────
 
 interface CdpPanelProps {
   sendCdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
   subscribeCdp: (listener: (method: string, params: unknown) => void) => () => void;
 }
 
-interface DomNode {
+interface CdpNode {
   nodeId: number;
-  nodeType: number;
+  parentId?: number;
+  backendNodeId?: number;
+  nodeType: number; // 1=Element, 3=Text, 8=Comment, 9=Document, 10=DocumentType
   nodeName: string;
   localName: string;
   nodeValue: string;
-  attributes?: string[];
-  children?: DomNode[];
   childNodeCount?: number;
+  children?: CdpNode[];
+  attributes?: string[]; // flat array [name, value, name, value, ...]
 }
 
-interface MatchedStyle {
-  selector: string;
-  properties: Array<{ name: string; value: string }>;
+interface CdpCssProperty {
+  name: string;
+  value: string;
+  disabled?: boolean;
+  implicit?: boolean;
 }
 
-interface ParsedAttrs {
-  [key: string]: string;
+interface CdpRuleMatch {
+  rule: {
+    selectorList: { selectors: Array<{ text: string }> };
+    style: { cssProperties: CdpCssProperty[] };
+  };
 }
 
-function parseAttributes(attrs?: string[]): ParsedAttrs {
-  if (!attrs) return {};
-  const result: ParsedAttrs = {};
-  for (let i = 0; i < attrs.length; i += 2) {
-    result[attrs[i]] = attrs[i + 1];
+interface CdpComputedProperty {
+  name: string;
+  value: string;
+}
+
+interface AXPropertyValue {
+  value: unknown;
+}
+
+interface AXNode {
+  nodeId: string;
+  role?: { value: string };
+  name?: { value: string };
+  description?: { value: string };
+  properties?: Array<{ name: string; value: AXPropertyValue }>;
+  childIds?: string[];
+}
+
+// ── Node type constants ───────────────────────────────────────────────────────
+
+const NODE_TYPE_ELEMENT = 1;
+const NODE_TYPE_TEXT = 3;
+const NODE_TYPE_COMMENT = 8;
+const NODE_TYPE_DOCUMENT = 9;
+const NODE_TYPE_DOCTYPE = 10;
+
+// ── Sub-tab types ─────────────────────────────────────────────────────────────
+
+type StylesSubTab = 'styles' | 'computed' | 'accessibility';
+const STYLES_SUB_TABS: StylesSubTab[] = ['styles', 'computed', 'accessibility'];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function parseAttributes(raw: string[] | undefined): Array<{ name: string; value: string }> {
+  if (!raw || raw.length === 0) return [];
+  const attrs: Array<{ name: string; value: string }> = [];
+  for (let i = 0; i + 1 < raw.length; i += 2) {
+    attrs.push({ name: raw[i], value: raw[i + 1] });
   }
-  return result;
+  return attrs;
 }
+
+function buildNodeMap(node: CdpNode, map: Map<number, CdpNode>): void {
+  map.set(node.nodeId, node);
+  if (node.children) {
+    for (const child of node.children) buildNodeMap(child, map);
+  }
+}
+
+function patchChildNodes(root: CdpNode, parentId: number, nodes: CdpNode[]): CdpNode {
+  if (root.nodeId === parentId) return { ...root, children: nodes };
+  if (!root.children) return root;
+  return { ...root, children: root.children.map((c) => patchChildNodes(c, parentId, nodes)) };
+}
+
+// ── DomTreeNode component ─────────────────────────────────────────────────────
+
+interface DomTreeNodeProps {
+  node: CdpNode;
+  depth: number;
+  selectedNodeId: number | null;
+  expandedNodeIds: Set<number>;
+  nodeMap: Map<number, CdpNode>;
+  onSelect: (nodeId: number) => void;
+  onToggle: (nodeId: number) => void;
+}
+
+function DomTreeNode({
+  node,
+  depth,
+  selectedNodeId,
+  expandedNodeIds,
+  nodeMap,
+  onSelect,
+  onToggle,
+}: DomTreeNodeProps): React.ReactElement | null {
+  const isSelected = node.nodeId === selectedNodeId;
+  const isExpanded = expandedNodeIds.has(node.nodeId);
+  const hasChildren =
+    (node.childNodeCount ?? 0) > 0 || (node.children && node.children.length > 0);
+  const indent: React.CSSProperties = { paddingLeft: depth * 16 };
+
+  // Document: render children directly, no wrapper row
+  if (node.nodeType === NODE_TYPE_DOCUMENT) {
+    return (
+      <>
+        {(node.children ?? []).map((child) => (
+          <DomTreeNode
+            key={child.nodeId}
+            node={child}
+            depth={depth}
+            selectedNodeId={selectedNodeId}
+            expandedNodeIds={expandedNodeIds}
+            nodeMap={nodeMap}
+            onSelect={onSelect}
+            onToggle={onToggle}
+          />
+        ))}
+      </>
+    );
+  }
+
+  // Text node
+  if (node.nodeType === NODE_TYPE_TEXT) {
+    const text = node.nodeValue.trim();
+    if (!text) return null;
+    const display = text.length > 120 ? text.slice(0, 120) + '…' : text;
+    return (
+      <div
+        className="elements-node"
+        style={indent}
+        data-selected={isSelected ? 'true' : 'false'}
+        onClick={() => onSelect(node.nodeId)}
+      >
+        <span className="elements-toggle" style={{ visibility: 'hidden' }}>▶</span>
+        <span className="elements-text-content">"{display}"</span>
+      </div>
+    );
+  }
+
+  // Comment node
+  if (node.nodeType === NODE_TYPE_COMMENT) {
+    const text = node.nodeValue.slice(0, 80);
+    return (
+      <div
+        className="elements-node"
+        style={indent}
+        data-selected={isSelected ? 'true' : 'false'}
+        onClick={() => onSelect(node.nodeId)}
+      >
+        <span className="elements-toggle" style={{ visibility: 'hidden' }}>▶</span>
+        <span className="elements-comment">{`<!-- ${text} -->`}</span>
+      </div>
+    );
+  }
+
+  // DOCTYPE node
+  if (node.nodeType === NODE_TYPE_DOCTYPE) {
+    return (
+      <div className="elements-node" style={indent}>
+        <span className="elements-toggle" style={{ visibility: 'hidden' }}>▶</span>
+        <span className="elements-comment">{`<!DOCTYPE ${node.nodeName}>`}</span>
+      </div>
+    );
+  }
+
+  // Skip unknown node types
+  if (node.nodeType !== NODE_TYPE_ELEMENT) return null;
+
+  const tagName = node.localName || node.nodeName.toLowerCase();
+  const attrs = parseAttributes(node.attributes);
+  const children = node.children ?? [];
+
+  return (
+    <>
+      {/* Opening tag */}
+      <div
+        className="elements-node"
+        style={indent}
+        data-selected={isSelected ? 'true' : 'false'}
+        onClick={() => onSelect(node.nodeId)}
+      >
+        {hasChildren ? (
+          <span
+            className="elements-toggle"
+            onClick={(e) => { e.stopPropagation(); onToggle(node.nodeId); }}
+          >
+            {isExpanded ? '▾' : '▸'}
+          </span>
+        ) : (
+          <span className="elements-toggle" style={{ visibility: 'hidden' }}>▶</span>
+        )}
+        <span className="elements-tag">{'<'}{tagName}</span>
+        {attrs.map((attr) => (
+          <span key={attr.name}>
+            {' '}
+            <span className="elements-attr-name">{attr.name}</span>
+            {'='}
+            <span className="elements-attr-value">
+              "{attr.value.length > 60 ? attr.value.slice(0, 60) + '…' : attr.value}"
+            </span>
+          </span>
+        ))}
+        {!hasChildren ? (
+          <span className="elements-tag">{' />'}</span>
+        ) : isExpanded ? (
+          <span className="elements-tag">{'>'}</span>
+        ) : (
+          <span className="elements-tag">
+            {'>'}<span style={{ color: 'var(--color-fg-tertiary)' }}> … </span>{'</'}{tagName}{'>'}
+          </span>
+        )}
+      </div>
+
+      {/* Children (rendered only when expanded) */}
+      {isExpanded && children.map((child) => (
+        <DomTreeNode
+          key={child.nodeId}
+          node={child}
+          depth={depth + 1}
+          selectedNodeId={selectedNodeId}
+          expandedNodeIds={expandedNodeIds}
+          nodeMap={nodeMap}
+          onSelect={onSelect}
+          onToggle={onToggle}
+        />
+      ))}
+
+      {/* Closing tag */}
+      {isExpanded && hasChildren && (
+        <div
+          className="elements-node"
+          style={indent}
+          data-selected={isSelected ? 'true' : 'false'}
+          onClick={() => onSelect(node.nodeId)}
+        >
+          <span className="elements-toggle" style={{ visibility: 'hidden' }}>▶</span>
+          <span className="elements-tag">{'</'}{tagName}{'>'}</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── StylesPane ────────────────────────────────────────────────────────────────
+
+interface StylesPaneProps {
+  nodeId: number | null;
+  sendCdp: CdpPanelProps['sendCdp'];
+}
+
+function StylesPane({ nodeId, sendCdp }: StylesPaneProps): React.ReactElement {
+  const [activeTab, setActiveTab] = useState<StylesSubTab>('styles');
+  const [matchedRules, setMatchedRules] = useState<CdpRuleMatch[]>([]);
+  const [computedProps, setComputedProps] = useState<CdpComputedProperty[]>([]);
+  const [axNodes, setAxNodes] = useState<AXNode[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (nodeId === null) {
+      setMatchedRules([]);
+      setComputedProps([]);
+      setAxNodes([]);
+      return;
+    }
+
+    setLoading(true);
+
+    if (activeTab === 'styles') {
+      console.log('[ElementsPanel] CSS.getMatchedStylesForNode nodeId:', nodeId);
+      void (async () => {
+        try {
+          const result = (await sendCdp('CSS.getMatchedStylesForNode', { nodeId })) as {
+            matchedCSSRules?: CdpRuleMatch[];
+          };
+          const rules = result?.matchedCSSRules ?? [];
+          console.log('[ElementsPanel] matched rules count:', rules.length, 'nodeId:', nodeId);
+          setMatchedRules(rules);
+        } catch (err) {
+          console.error('[ElementsPanel] CSS.getMatchedStylesForNode error nodeId:', nodeId, err);
+          setMatchedRules([]);
+        } finally {
+          setLoading(false);
+        }
+      })();
+    } else if (activeTab === 'computed') {
+      console.log('[ElementsPanel] CSS.getComputedStyleForNode nodeId:', nodeId);
+      void (async () => {
+        try {
+          const result = (await sendCdp('CSS.getComputedStyleForNode', { nodeId })) as {
+            computedStyle?: CdpComputedProperty[];
+          };
+          const props = result?.computedStyle ?? [];
+          console.log('[ElementsPanel] computed props count:', props.length, 'nodeId:', nodeId);
+          setComputedProps(props);
+        } catch (err) {
+          console.error('[ElementsPanel] CSS.getComputedStyleForNode error nodeId:', nodeId, err);
+          setComputedProps([]);
+        } finally {
+          setLoading(false);
+        }
+      })();
+    } else if (activeTab === 'accessibility') {
+      console.log('[ElementsPanel] Accessibility.getFullAXTree nodeId:', nodeId);
+      void (async () => {
+        try {
+          const result = (await sendCdp('Accessibility.getFullAXTree', { nodeId })) as {
+            nodes?: AXNode[];
+          };
+          const nodes = result?.nodes ?? [];
+          console.log('[ElementsPanel] AX nodes count:', nodes.length, 'nodeId:', nodeId);
+          setAxNodes(nodes);
+        } catch (err) {
+          console.error('[ElementsPanel] Accessibility.getFullAXTree error nodeId:', nodeId, err);
+          setAxNodes([]);
+        } finally {
+          setLoading(false);
+        }
+      })();
+    }
+  }, [nodeId, activeTab, sendCdp]);
+
+  const emptyMsg = (msg: string): React.ReactElement => (
+    <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>{msg}</div>
+  );
+
+  const renderStyles = (): React.ReactElement => {
+    if (nodeId === null) return emptyMsg('Select an element to view styles.');
+    if (loading) return emptyMsg('Loading…');
+    if (matchedRules.length === 0) return emptyMsg('No matched CSS rules.');
+    return (
+      <>
+        {matchedRules.map((rm, ruleIdx) => {
+          const selectors = rm.rule.selectorList.selectors.map((s) => s.text).join(', ');
+          const visibleProps = rm.rule.style.cssProperties.filter(
+            (p) => !p.disabled && !p.implicit && p.name && p.value,
+          );
+          if (visibleProps.length === 0) return null;
+          return (
+            <div key={ruleIdx} className="elements-style-rule">
+              <div className="elements-style-selector">{selectors} {'{'}</div>
+              {visibleProps.map((prop, propIdx) => (
+                <div key={propIdx} className="elements-style-prop">
+                  <span className="elements-style-prop-name">{prop.name}</span>
+                  {': '}
+                  <span className="elements-style-prop-value">{prop.value}</span>
+                  {';'}
+                </div>
+              ))}
+              <div className="elements-style-selector">{'}'}</div>
+            </div>
+          );
+        })}
+      </>
+    );
+  };
+
+  const renderComputed = (): React.ReactElement => {
+    if (nodeId === null) return emptyMsg('Select an element to view computed styles.');
+    if (loading) return emptyMsg('Loading…');
+    if (computedProps.length === 0) return emptyMsg('No computed style properties.');
+    return (
+      <>
+        {computedProps.map((prop, i) => (
+          <div key={i} className="elements-style-prop">
+            <span className="elements-style-prop-name">{prop.name}</span>
+            {': '}
+            <span className="elements-style-prop-value">{prop.value}</span>
+            {';'}
+          </div>
+        ))}
+      </>
+    );
+  };
+
+  const renderAccessibility = (): React.ReactElement => {
+    if (nodeId === null) return emptyMsg('Select an element to view accessibility info.');
+    if (loading) return emptyMsg('Loading…');
+    if (axNodes.length === 0) return emptyMsg('No accessibility data available.');
+    return (
+      <>
+        {axNodes.map((axNode) => (
+          <div
+            key={axNode.nodeId}
+            style={{
+              marginBottom: 'var(--space-4)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 'var(--font-size-2xs)',
+            }}
+          >
+            {axNode.role?.value && (
+              <div className="elements-style-prop">
+                <span className="elements-style-prop-name">role</span>
+                {': '}
+                <span className="elements-style-prop-value">{axNode.role.value}</span>
+              </div>
+            )}
+            {axNode.name?.value && (
+              <div className="elements-style-prop">
+                <span className="elements-style-prop-name">name</span>
+                {': '}
+                <span className="elements-style-prop-value">"{axNode.name.value}"</span>
+              </div>
+            )}
+            {axNode.description?.value && (
+              <div className="elements-style-prop">
+                <span className="elements-style-prop-name">description</span>
+                {': '}
+                <span className="elements-style-prop-value">"{axNode.description.value}"</span>
+              </div>
+            )}
+            {(axNode.properties ?? []).map((prop, i) => (
+              <div key={i} className="elements-style-prop">
+                <span className="elements-style-prop-name">{prop.name}</span>
+                {': '}
+                <span className="elements-style-prop-value">{String(prop.value.value)}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <div
+      className="elements-styles"
+      style={{ display: 'flex', flexDirection: 'column', padding: 0, overflow: 'hidden' }}
+    >
+      {/* Sub-tab bar */}
+      <div
+        style={{
+          display: 'flex',
+          borderBottom: '1px solid var(--color-border-default)',
+          flexShrink: 0,
+        }}
+      >
+        {STYLES_SUB_TABS.map((tab) => (
+          <button
+            key={tab}
+            style={{
+              padding: 'var(--space-2) var(--space-4)',
+              fontSize: 'var(--font-size-xs)',
+              fontWeight: 'var(--font-weight-medium)',
+              color: activeTab === tab ? 'var(--color-accent-default)' : 'var(--color-fg-secondary)',
+              cursor: 'pointer',
+              background: 'transparent',
+              border: 'none',
+              borderBottom: activeTab === tab
+                ? '2px solid var(--color-accent-default)'
+                : '2px solid transparent',
+              outline: 'none',
+            }}
+            onClick={() => {
+              console.log('[ElementsPanel] styles sub-tab changed:', tab, 'nodeId:', nodeId);
+              setActiveTab(tab);
+            }}
+          >
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Sub-tab content */}
+      <div style={{ flex: 1, overflow: 'auto', padding: 'var(--space-4)' }}>
+        {activeTab === 'styles' && (
+          <>
+            <div className="elements-styles-header">Matched Rules</div>
+            {renderStyles()}
+          </>
+        )}
+        {activeTab === 'computed' && (
+          <>
+            <div className="elements-styles-header">Computed Styles</div>
+            {renderComputed()}
+          </>
+        )}
+        {activeTab === 'accessibility' && (
+          <>
+            <div className="elements-styles-header">Accessibility</div>
+            {renderAccessibility()}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── ElementsPanel (main export) ───────────────────────────────────────────────
 
 export function ElementsPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.ReactElement {
-  const [rootNode, setRootNode] = useState<DomNode | null>(null);
-  const [expandedNodes, setExpandedNodes] = useState<Set<number>>(new Set());
+  const [rootNode, setRootNode] = useState<CdpNode | null>(null);
+  const [nodeMap, setNodeMap] = useState<Map<number, CdpNode>>(() => new Map());
+  const [expandedNodeIds, setExpandedNodeIds] = useState<Set<number>>(() => new Set());
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
-  const [styles, setStyles] = useState<MatchedStyle[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  // Stable ref so CDP event callbacks can read current root without stale closure
+  const rootNodeRef = useRef<CdpNode | null>(null);
+  rootNodeRef.current = rootNode;
 
   const fetchDocument = useCallback(async () => {
-    console.log('[ElementsPanel] fetching DOM document');
+    console.log('[ElementsPanel] DOM.enable + CSS.enable, calling DOM.getDocument');
     setLoading(true);
+    setFetchError(null);
+
     try {
       await sendCdp('DOM.enable');
       await sendCdp('CSS.enable');
 
-      const result = (await sendCdp('DOM.getDocument', { depth: 4 })) as {
-        root?: DomNode;
+      const result = (await sendCdp('DOM.getDocument', { depth: 2, pierce: true })) as {
+        root?: CdpNode;
       };
 
-      if (result?.root) {
-        console.log('[ElementsPanel] got DOM root, nodeId:', result.root.nodeId);
-        setRootNode(result.root);
-
-        const initialExpanded = new Set<number>();
-        const expandFirst = (node: DomNode, depth: number): void => {
-          if (depth > 2) return;
-          initialExpanded.add(node.nodeId);
-          node.children?.forEach((c) => expandFirst(c, depth + 1));
-        };
-        expandFirst(result.root, 0);
-        setExpandedNodes(initialExpanded);
+      const root = result?.root;
+      if (!root) {
+        console.warn('[ElementsPanel] DOM.getDocument returned no root');
+        setFetchError('No DOM data returned');
+        setLoading(false);
+        return;
       }
+
+      console.log('[ElementsPanel] DOM root nodeId:', root.nodeId, 'nodeName:', root.nodeName);
+
+      const map = new Map<number, CdpNode>();
+      buildNodeMap(root, map);
+
+      // Auto-expand document + first two levels of element children
+      const initialExpanded = new Set<number>();
+      initialExpanded.add(root.nodeId);
+      if (root.children) {
+        for (const child of root.children) {
+          if (child.nodeType === NODE_TYPE_ELEMENT) {
+            initialExpanded.add(child.nodeId);
+            if (child.children) {
+              for (const gc of child.children) {
+                if (gc.nodeType === NODE_TYPE_ELEMENT) initialExpanded.add(gc.nodeId);
+              }
+            }
+          }
+        }
+      }
+
+      setRootNode(root);
+      setNodeMap(map);
+      setExpandedNodeIds(initialExpanded);
     } catch (err) {
-      console.error('[ElementsPanel] fetchDocument failed:', err);
+      console.error('[ElementsPanel] fetchDocument error:', err);
+      setFetchError(String(err));
     } finally {
       setLoading(false);
     }
@@ -78,235 +574,140 @@ export function ElementsPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.R
     const unsubscribe = subscribeCdp((method, params) => {
       const p = params as Record<string, unknown>;
 
-      if (method === 'DOM.childNodeInserted' || method === 'DOM.childNodeRemoved') {
-        console.log('[ElementsPanel] DOM mutation:', method, p);
+      if (method === 'Page.loadEventFired' || method === 'DOM.documentUpdated') {
+        console.log('[ElementsPanel] page/document updated, re-fetching. method:', method);
         void fetchDocument();
+        return;
+      }
+
+      // Merge lazily-loaded child nodes pushed by CDP after DOM.requestChildNodes
+      if (method === 'DOM.setChildNodes') {
+        const parentId = p.parentId as number;
+        const nodes = p.nodes as CdpNode[];
+        console.log('[ElementsPanel] DOM.setChildNodes parentId:', parentId, 'count:', nodes.length);
+        setRootNode((prevRoot) => {
+          if (!prevRoot) return prevRoot;
+          const newRoot = patchChildNodes(prevRoot, parentId, nodes);
+          const newMap = new Map<number, CdpNode>();
+          buildNodeMap(newRoot, newMap);
+          setNodeMap(newMap);
+          return newRoot;
+        });
       }
     });
 
     return () => {
       unsubscribe();
-      void sendCdp('DOM.disable').catch(() => {});
       void sendCdp('CSS.disable').catch(() => {});
+      void sendCdp('DOM.disable').catch(() => {});
     };
-  }, [fetchDocument, sendCdp, subscribeCdp]);
+  }, [fetchDocument, subscribeCdp, sendCdp]);
 
-  const handleSelectNode = useCallback(
-    async (nodeId: number) => {
-      setSelectedNodeId(nodeId);
-      console.log('[ElementsPanel] selected node:', nodeId);
+  const handleToggle = useCallback(
+    async (nodeId: number): Promise<void> => {
+      const alreadyExpanded = expandedNodeIds.has(nodeId);
 
-      try {
-        const result = (await sendCdp('CSS.getMatchedStylesForNode', { nodeId })) as {
-          matchedCSSRules?: Array<{
-            rule?: {
-              selectorList?: { text?: string };
-              style?: {
-                cssProperties?: Array<{ name: string; value: string; disabled?: boolean }>;
-              };
-            };
-          }>;
-        };
-
-        const matched: MatchedStyle[] = [];
-        if (result?.matchedCSSRules) {
-          for (const entry of result.matchedCSSRules) {
-            const rule = entry.rule;
-            if (!rule?.style?.cssProperties) continue;
-            matched.push({
-              selector: rule.selectorList?.text ?? '(inline)',
-              properties: rule.style.cssProperties
-                .filter((p) => !p.disabled && p.value)
-                .slice(0, 20)
-                .map((p) => ({ name: p.name, value: p.value })),
-            });
-          }
-        }
-        setStyles(matched.slice(0, 10));
-      } catch (err) {
-        console.warn('[ElementsPanel] getMatchedStyles failed:', err);
-        setStyles([]);
-      }
-    },
-    [sendCdp],
-  );
-
-  const toggleExpand = useCallback(
-    async (nodeId: number) => {
-      setExpandedNodes((prev) => {
-        const next = new Set(prev);
-        if (next.has(nodeId)) {
+      if (alreadyExpanded) {
+        console.log('[ElementsPanel] collapsing nodeId:', nodeId);
+        setExpandedNodeIds((prev) => {
+          const next = new Set(prev);
           next.delete(nodeId);
-        } else {
-          next.add(nodeId);
+          return next;
+        });
+        return;
+      }
+
+      // Request children from CDP if they haven't been loaded yet
+      const node = nodeMap.get(nodeId);
+      const childrenLoaded = node?.children && node.children.length > 0;
+      if (node && !childrenLoaded && (node.childNodeCount ?? 0) > 0) {
+        console.log(
+          '[ElementsPanel] DOM.requestChildNodes nodeId:',
+          nodeId,
+          'childNodeCount:',
+          node.childNodeCount,
+        );
+        try {
+          await sendCdp('DOM.requestChildNodes', { nodeId, depth: 1, pierce: true });
+        } catch (err) {
+          console.error('[ElementsPanel] DOM.requestChildNodes error nodeId:', nodeId, err);
         }
+      }
+
+      console.log('[ElementsPanel] expanding nodeId:', nodeId);
+      setExpandedNodeIds((prev) => {
+        const next = new Set(prev);
+        next.add(nodeId);
         return next;
       });
-
-      try {
-        await sendCdp('DOM.requestChildNodes', { nodeId, depth: 2 });
-      } catch {
-        // Children may already be loaded
-      }
     },
-    [sendCdp],
+    [expandedNodeIds, nodeMap, sendCdp],
   );
 
-  const renderNode = (node: DomNode, depth: number): React.ReactElement | null => {
-    if (node.nodeType === 3) {
-      const text = (node.nodeValue ?? '').trim();
-      if (!text) return null;
-      return (
-        <div
-          key={node.nodeId}
-          className="elements-node"
-          style={{ paddingLeft: depth * 16 }}
-        >
-          <span className="elements-text-content">
-            {text.length > 120 ? text.slice(0, 120) + '...' : text}
-          </span>
-        </div>
-      );
-    }
-
-    if (node.nodeType === 8) {
-      return (
-        <div
-          key={node.nodeId}
-          className="elements-node"
-          style={{ paddingLeft: depth * 16 }}
-        >
-          <span className="elements-comment">
-            {'<!-- ' + (node.nodeValue ?? '').slice(0, 80) + ' -->'}
-          </span>
-        </div>
-      );
-    }
-
-    if (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 10) {
-      return null;
-    }
-
-    const hasChildren = (node.children && node.children.length > 0) || (node.childNodeCount ?? 0) > 0;
-    const isExpanded = expandedNodes.has(node.nodeId);
-    const attrs = parseAttributes(node.attributes);
-    const tagName = node.localName || node.nodeName?.toLowerCase() || '';
-
-    if (node.nodeType === 9) {
-      return (
-        <React.Fragment key={node.nodeId}>
-          {isExpanded && node.children?.map((c) => renderNode(c, depth))}
-        </React.Fragment>
-      );
-    }
-
-    if (node.nodeType === 10) {
-      return (
-        <div
-          key={node.nodeId}
-          className="elements-node"
-          style={{ paddingLeft: depth * 16 }}
-        >
-          <span className="elements-comment">
-            {'<!DOCTYPE ' + node.nodeName + '>'}
-          </span>
-        </div>
-      );
-    }
-
-    return (
-      <React.Fragment key={node.nodeId}>
-        <div
-          className="elements-node"
-          data-selected={selectedNodeId === node.nodeId ? 'true' : 'false'}
-          style={{ paddingLeft: depth * 16 }}
-          onClick={() => void handleSelectNode(node.nodeId)}
-        >
-          {hasChildren ? (
-            <span
-              className="elements-toggle"
-              onClick={(e) => {
-                e.stopPropagation();
-                void toggleExpand(node.nodeId);
-              }}
-            >
-              {isExpanded ? '▾' : '▸'}
-            </span>
-          ) : (
-            <span className="elements-toggle"> </span>
-          )}
-          <span className="elements-tag">{'<'}{tagName}</span>
-          {Object.entries(attrs).map(([name, value]) => (
-            <span key={name}>
-              {' '}
-              <span className="elements-attr-name">{name}</span>
-              {'="'}
-              <span className="elements-attr-value">{value.length > 60 ? value.slice(0, 60) + '...' : value}</span>
-              {'"'}
-            </span>
-          ))}
-          <span className="elements-tag">{'>'}</span>
-          {!hasChildren && <span className="elements-tag">{'</'}{tagName}{'>'}</span>}
-        </div>
-        {isExpanded && node.children?.map((child) => renderNode(child, depth + 1))}
-        {isExpanded && hasChildren && (
-          <div
-            className="elements-node"
-            style={{ paddingLeft: depth * 16 }}
-          >
-            <span className="elements-toggle"> </span>
-            <span className="elements-tag">{'</'}{tagName}{'>'}</span>
-          </div>
-        )}
-      </React.Fragment>
-    );
-  };
+  const handleSelect = useCallback((nodeId: number): void => {
+    console.log('[ElementsPanel] node selected nodeId:', nodeId);
+    setSelectedNodeId(nodeId);
+  }, []);
 
   if (loading) {
     return (
-      <div className="panel-placeholder">
-        <div className="panel-placeholder-title">Loading DOM...</div>
+      <div className="elements-panel" style={{ alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-sm)' }}>
+          Loading DOM…
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError || !rootNode) {
+    return (
+      <div
+        className="elements-panel"
+        style={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: 'var(--space-4)',
+        }}
+      >
+        <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-sm)' }}>
+          {fetchError ?? 'No DOM data'}
+        </div>
+        <button
+          style={{
+            padding: 'var(--space-2) var(--space-6)',
+            background: 'var(--color-accent-default)',
+            color: 'var(--color-fg-inverse)',
+            borderRadius: 'var(--radius-sm)',
+            fontSize: 'var(--font-size-xs)',
+            cursor: 'pointer',
+            border: 'none',
+          }}
+          onClick={() => void fetchDocument()}
+        >
+          Retry
+        </button>
       </div>
     );
   }
 
   return (
     <div className="elements-panel">
+      {/* Left pane: collapsible DOM tree */}
       <div className="elements-tree">
-        {rootNode ? renderNode(rootNode, 0) : (
-          <div className="panel-placeholder">
-            <div className="panel-placeholder-title">No DOM available</div>
-          </div>
-        )}
+        <DomTreeNode
+          node={rootNode}
+          depth={0}
+          selectedNodeId={selectedNodeId}
+          expandedNodeIds={expandedNodeIds}
+          nodeMap={nodeMap}
+          onSelect={handleSelect}
+          onToggle={(nodeId) => { void handleToggle(nodeId); }}
+        />
       </div>
 
-      <div className="elements-styles">
-        <div className="elements-styles-header">Styles</div>
-        {selectedNodeId === null ? (
-          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
-            Select an element to view styles
-          </div>
-        ) : styles.length === 0 ? (
-          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
-            No matched styles
-          </div>
-        ) : (
-          styles.map((rule, i) => (
-            <div key={i} className="elements-style-rule">
-              <div className="elements-style-selector">{rule.selector} {'{'}</div>
-              {rule.properties.map((prop, j) => (
-                <div key={j} className="elements-style-prop">
-                  <span className="elements-style-prop-name">{prop.name}</span>
-                  {': '}
-                  <span className="elements-style-prop-value">{prop.value}</span>
-                  {';'}
-                </div>
-              ))}
-              <div className="elements-style-selector">{'}'}</div>
-            </div>
-          ))
-        )}
-      </div>
+      {/* Right pane: Styles / Computed / Accessibility */}
+      <StylesPane nodeId={selectedNodeId} sendCdp={sendCdp} />
     </div>
   );
 }

--- a/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/ElementsPanel.tsx
@@ -1,0 +1,312 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface CdpPanelProps {
+  sendCdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  subscribeCdp: (listener: (method: string, params: unknown) => void) => () => void;
+}
+
+interface DomNode {
+  nodeId: number;
+  nodeType: number;
+  nodeName: string;
+  localName: string;
+  nodeValue: string;
+  attributes?: string[];
+  children?: DomNode[];
+  childNodeCount?: number;
+}
+
+interface MatchedStyle {
+  selector: string;
+  properties: Array<{ name: string; value: string }>;
+}
+
+interface ParsedAttrs {
+  [key: string]: string;
+}
+
+function parseAttributes(attrs?: string[]): ParsedAttrs {
+  if (!attrs) return {};
+  const result: ParsedAttrs = {};
+  for (let i = 0; i < attrs.length; i += 2) {
+    result[attrs[i]] = attrs[i + 1];
+  }
+  return result;
+}
+
+export function ElementsPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.ReactElement {
+  const [rootNode, setRootNode] = useState<DomNode | null>(null);
+  const [expandedNodes, setExpandedNodes] = useState<Set<number>>(new Set());
+  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
+  const [styles, setStyles] = useState<MatchedStyle[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchDocument = useCallback(async () => {
+    console.log('[ElementsPanel] fetching DOM document');
+    setLoading(true);
+    try {
+      await sendCdp('DOM.enable');
+      await sendCdp('CSS.enable');
+
+      const result = (await sendCdp('DOM.getDocument', { depth: 4 })) as {
+        root?: DomNode;
+      };
+
+      if (result?.root) {
+        console.log('[ElementsPanel] got DOM root, nodeId:', result.root.nodeId);
+        setRootNode(result.root);
+
+        const initialExpanded = new Set<number>();
+        const expandFirst = (node: DomNode, depth: number): void => {
+          if (depth > 2) return;
+          initialExpanded.add(node.nodeId);
+          node.children?.forEach((c) => expandFirst(c, depth + 1));
+        };
+        expandFirst(result.root, 0);
+        setExpandedNodes(initialExpanded);
+      }
+    } catch (err) {
+      console.error('[ElementsPanel] fetchDocument failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [sendCdp]);
+
+  useEffect(() => {
+    void fetchDocument();
+
+    const unsubscribe = subscribeCdp((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'DOM.childNodeInserted' || method === 'DOM.childNodeRemoved') {
+        console.log('[ElementsPanel] DOM mutation:', method, p);
+        void fetchDocument();
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      void sendCdp('DOM.disable').catch(() => {});
+      void sendCdp('CSS.disable').catch(() => {});
+    };
+  }, [fetchDocument, sendCdp, subscribeCdp]);
+
+  const handleSelectNode = useCallback(
+    async (nodeId: number) => {
+      setSelectedNodeId(nodeId);
+      console.log('[ElementsPanel] selected node:', nodeId);
+
+      try {
+        const result = (await sendCdp('CSS.getMatchedStylesForNode', { nodeId })) as {
+          matchedCSSRules?: Array<{
+            rule?: {
+              selectorList?: { text?: string };
+              style?: {
+                cssProperties?: Array<{ name: string; value: string; disabled?: boolean }>;
+              };
+            };
+          }>;
+        };
+
+        const matched: MatchedStyle[] = [];
+        if (result?.matchedCSSRules) {
+          for (const entry of result.matchedCSSRules) {
+            const rule = entry.rule;
+            if (!rule?.style?.cssProperties) continue;
+            matched.push({
+              selector: rule.selectorList?.text ?? '(inline)',
+              properties: rule.style.cssProperties
+                .filter((p) => !p.disabled && p.value)
+                .slice(0, 20)
+                .map((p) => ({ name: p.name, value: p.value })),
+            });
+          }
+        }
+        setStyles(matched.slice(0, 10));
+      } catch (err) {
+        console.warn('[ElementsPanel] getMatchedStyles failed:', err);
+        setStyles([]);
+      }
+    },
+    [sendCdp],
+  );
+
+  const toggleExpand = useCallback(
+    async (nodeId: number) => {
+      setExpandedNodes((prev) => {
+        const next = new Set(prev);
+        if (next.has(nodeId)) {
+          next.delete(nodeId);
+        } else {
+          next.add(nodeId);
+        }
+        return next;
+      });
+
+      try {
+        await sendCdp('DOM.requestChildNodes', { nodeId, depth: 2 });
+      } catch {
+        // Children may already be loaded
+      }
+    },
+    [sendCdp],
+  );
+
+  const renderNode = (node: DomNode, depth: number): React.ReactElement | null => {
+    if (node.nodeType === 3) {
+      const text = (node.nodeValue ?? '').trim();
+      if (!text) return null;
+      return (
+        <div
+          key={node.nodeId}
+          className="elements-node"
+          style={{ paddingLeft: depth * 16 }}
+        >
+          <span className="elements-text-content">
+            {text.length > 120 ? text.slice(0, 120) + '...' : text}
+          </span>
+        </div>
+      );
+    }
+
+    if (node.nodeType === 8) {
+      return (
+        <div
+          key={node.nodeId}
+          className="elements-node"
+          style={{ paddingLeft: depth * 16 }}
+        >
+          <span className="elements-comment">
+            {'<!-- ' + (node.nodeValue ?? '').slice(0, 80) + ' -->'}
+          </span>
+        </div>
+      );
+    }
+
+    if (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 10) {
+      return null;
+    }
+
+    const hasChildren = (node.children && node.children.length > 0) || (node.childNodeCount ?? 0) > 0;
+    const isExpanded = expandedNodes.has(node.nodeId);
+    const attrs = parseAttributes(node.attributes);
+    const tagName = node.localName || node.nodeName?.toLowerCase() || '';
+
+    if (node.nodeType === 9) {
+      return (
+        <React.Fragment key={node.nodeId}>
+          {isExpanded && node.children?.map((c) => renderNode(c, depth))}
+        </React.Fragment>
+      );
+    }
+
+    if (node.nodeType === 10) {
+      return (
+        <div
+          key={node.nodeId}
+          className="elements-node"
+          style={{ paddingLeft: depth * 16 }}
+        >
+          <span className="elements-comment">
+            {'<!DOCTYPE ' + node.nodeName + '>'}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <React.Fragment key={node.nodeId}>
+        <div
+          className="elements-node"
+          data-selected={selectedNodeId === node.nodeId ? 'true' : 'false'}
+          style={{ paddingLeft: depth * 16 }}
+          onClick={() => void handleSelectNode(node.nodeId)}
+        >
+          {hasChildren ? (
+            <span
+              className="elements-toggle"
+              onClick={(e) => {
+                e.stopPropagation();
+                void toggleExpand(node.nodeId);
+              }}
+            >
+              {isExpanded ? '▾' : '▸'}
+            </span>
+          ) : (
+            <span className="elements-toggle"> </span>
+          )}
+          <span className="elements-tag">{'<'}{tagName}</span>
+          {Object.entries(attrs).map(([name, value]) => (
+            <span key={name}>
+              {' '}
+              <span className="elements-attr-name">{name}</span>
+              {'="'}
+              <span className="elements-attr-value">{value.length > 60 ? value.slice(0, 60) + '...' : value}</span>
+              {'"'}
+            </span>
+          ))}
+          <span className="elements-tag">{'>'}</span>
+          {!hasChildren && <span className="elements-tag">{'</'}{tagName}{'>'}</span>}
+        </div>
+        {isExpanded && node.children?.map((child) => renderNode(child, depth + 1))}
+        {isExpanded && hasChildren && (
+          <div
+            className="elements-node"
+            style={{ paddingLeft: depth * 16 }}
+          >
+            <span className="elements-toggle"> </span>
+            <span className="elements-tag">{'</'}{tagName}{'>'}</span>
+          </div>
+        )}
+      </React.Fragment>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Loading DOM...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="elements-panel">
+      <div className="elements-tree">
+        {rootNode ? renderNode(rootNode, 0) : (
+          <div className="panel-placeholder">
+            <div className="panel-placeholder-title">No DOM available</div>
+          </div>
+        )}
+      </div>
+
+      <div className="elements-styles">
+        <div className="elements-styles-header">Styles</div>
+        {selectedNodeId === null ? (
+          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
+            Select an element to view styles
+          </div>
+        ) : styles.length === 0 ? (
+          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
+            No matched styles
+          </div>
+        ) : (
+          styles.map((rule, i) => (
+            <div key={i} className="elements-style-rule">
+              <div className="elements-style-selector">{rule.selector} {'{'}</div>
+              {rule.properties.map((prop, j) => (
+                <div key={j} className="elements-style-prop">
+                  <span className="elements-style-prop-name">{prop.name}</span>
+                  {': '}
+                  <span className="elements-style-prop-value">{prop.value}</span>
+                  {';'}
+                </div>
+              ))}
+              <div className="elements-style-selector">{'}'}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
@@ -85,23 +85,43 @@ export function LighthousePanel({ cdpSend, onCdpEvent: _onCdpEvent, isAttached }
     const paintJson = (await evalExpr(
       'JSON.stringify(performance.getEntriesByType("paint"))',
     )) as string;
+    await evalExpr(
+      `(function() {
+        if (!window.__lcp_observer_injected__) {
+          window.__lcp_observer_injected__ = true;
+          try {
+            new PerformanceObserver(function(list) {
+              var entries = list.getEntries();
+              if (entries.length > 0) window.__lcp_entry__ = entries[entries.length - 1];
+            }).observe({ type: 'largest-contentful-paint', buffered: true });
+          } catch(e) {}
+          try {
+            window.__cls_value__ = 0;
+            new PerformanceObserver(function(list) {
+              list.getEntries().forEach(function(e) { if (!e.hadRecentInput) window.__cls_value__ += e.value; });
+            }).observe({ type: 'layout-shift', buffered: true });
+          } catch(e) {}
+        }
+      })()`,
+    );
+    await new Promise((r) => setTimeout(r, 150));
     const lcpJson = (await evalExpr(
-      `JSON.stringify(
+      \`JSON.stringify(
         (() => {
           try {
             return window.__lcp_entry__ ? { startTime: window.__lcp_entry__.startTime } : null;
           } catch(e) { return null; }
         })()
-      )`,
+      )\`,
     )) as string;
     const clsJson = (await evalExpr(
-      `JSON.stringify(
+      \`JSON.stringify(
         (() => {
           try {
             return typeof window.__cls_value__ === 'number' ? { value: window.__cls_value__ } : null;
           } catch(e) { return null; }
         })()
-      )`,
+      )\`,
     )) as string;
     const resourceCountJson = (await evalExpr(
       'performance.getEntriesByType("resource").length',
@@ -207,7 +227,18 @@ export function LighthousePanel({ cdpSend, onCdpEvent: _onCdpEvent, isAttached }
       'document.querySelectorAll("img:not([alt])").length',
     )) as number;
     const inputsWithoutLabel = (await evalExpr(
-      `document.querySelectorAll("input:not([aria-label]):not([aria-labelledby]):not([id])").length`,
+      `(function() {
+        var inputs = document.querySelectorAll('input');
+        var unlabeled = 0;
+        inputs.forEach(function(input) {
+          var hasAriaLabel = input.hasAttribute('aria-label');
+          var hasAriaLabelledBy = input.hasAttribute('aria-labelledby');
+          var hasLabelFor = input.id && document.querySelector('label[for="' + input.id + '"]');
+          var hasWrappingLabel = input.closest('label') !== null;
+          if (!hasAriaLabel && !hasAriaLabelledBy && !hasLabelFor && !hasWrappingLabel) unlabeled++;
+        });
+        return unlabeled;
+      })()`,
     )) as number;
     const hasMainLandmark = (await evalExpr(
       `document.querySelector("main, [role='main']") !== null`,

--- a/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
@@ -106,22 +106,22 @@ export function LighthousePanel({ cdpSend, onCdpEvent: _onCdpEvent, isAttached }
     );
     await new Promise((r) => setTimeout(r, 150));
     const lcpJson = (await evalExpr(
-      \`JSON.stringify(
+      `JSON.stringify(
         (() => {
           try {
             return window.__lcp_entry__ ? { startTime: window.__lcp_entry__.startTime } : null;
           } catch(e) { return null; }
         })()
-      )\`,
+      )`,
     )) as string;
     const clsJson = (await evalExpr(
-      \`JSON.stringify(
+      `JSON.stringify(
         (() => {
           try {
             return typeof window.__cls_value__ === 'number' ? { value: window.__cls_value__ } : null;
           } catch(e) { return null; }
         })()
-      )\`,
+      )`,
     )) as string;
     const resourceCountJson = (await evalExpr(
       'performance.getEntriesByType("resource").length',

--- a/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/LighthousePanel.tsx
@@ -1,0 +1,753 @@
+import React, { useState, useCallback } from 'react';
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+interface AuditResult {
+  id: string;
+  title: string;
+  description: string;
+  passed: boolean;
+  score: number | null;
+  displayValue?: string;
+}
+
+interface CategoryResult {
+  id: string;
+  title: string;
+  score: number;
+  audits: AuditResult[];
+}
+
+interface MetricResult {
+  name: string;
+  value: string;
+  unit: string;
+  score: number;
+}
+
+interface LighthouseResults {
+  categories: CategoryResult[];
+  metrics: MetricResult[];
+  runAt: string;
+}
+
+const SCORE_COLOR = (score: number): string => {
+  if (score >= 90) return 'var(--color-status-success)';
+  if (score >= 50) return 'var(--color-status-warning)';
+  return 'var(--color-status-error)';
+};
+
+const SCORE_BG = (score: number): string => {
+  if (score >= 90) return 'rgba(74, 222, 128, 0.08)';
+  if (score >= 50) return 'rgba(245, 158, 11, 0.08)';
+  return 'rgba(248, 113, 113, 0.08)';
+};
+
+export function LighthousePanel({ cdpSend, onCdpEvent: _onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [results, setResults] = useState<LighthouseResults | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState('');
+
+  const evalExpr = useCallback(
+    async (expression: string): Promise<unknown> => {
+      const resp = await cdpSend('Runtime.evaluate', {
+        expression,
+        returnByValue: true,
+        awaitPromise: true,
+      });
+      if (!resp.success) throw new Error(resp.error ?? 'Runtime.evaluate failed');
+      const evalResult = resp.result as { result?: { value?: unknown }; exceptionDetails?: { text?: string } } | undefined;
+      if (evalResult?.exceptionDetails) {
+        throw new Error(evalResult.exceptionDetails.text ?? 'JS exception during eval');
+      }
+      return evalResult?.result?.value;
+    },
+    [cdpSend],
+  );
+
+  // ── Performance audit ─────────────────────────────────────────────────────
+
+  const runPerformanceAudit = useCallback(async (): Promise<{ audits: AuditResult[]; metrics: MetricResult[] }> => {
+    console.log('[LighthousePanel] running performance audit');
+    setProgress('Collecting performance metrics...');
+
+    const timingJson = (await evalExpr(
+      'JSON.stringify(performance.timing)',
+    )) as string;
+    const navJson = (await evalExpr(
+      'JSON.stringify(performance.getEntriesByType("navigation")[0] || null)',
+    )) as string;
+    const paintJson = (await evalExpr(
+      'JSON.stringify(performance.getEntriesByType("paint"))',
+    )) as string;
+    const lcpJson = (await evalExpr(
+      `JSON.stringify(
+        (() => {
+          try {
+            return window.__lcp_entry__ ? { startTime: window.__lcp_entry__.startTime } : null;
+          } catch(e) { return null; }
+        })()
+      )`,
+    )) as string;
+    const clsJson = (await evalExpr(
+      `JSON.stringify(
+        (() => {
+          try {
+            return typeof window.__cls_value__ === 'number' ? { value: window.__cls_value__ } : null;
+          } catch(e) { return null; }
+        })()
+      )`,
+    )) as string;
+    const resourceCountJson = (await evalExpr(
+      'performance.getEntriesByType("resource").length',
+    )) as number;
+
+    const timing = JSON.parse(timingJson) as Record<string, number>;
+    const nav = navJson !== 'null' ? JSON.parse(navJson) as Record<string, number> : null;
+    const paint = JSON.parse(paintJson) as Array<{ name: string; startTime: number }>;
+    const lcp = lcpJson !== 'null' ? JSON.parse(lcpJson) as { startTime: number } : null;
+    const cls = clsJson !== 'null' ? JSON.parse(clsJson) as { value: number } : null;
+
+    console.log('[LighthousePanel] performance timing:', { timing, nav, paint, lcp, cls, resourceCountJson });
+
+    const fcp = paint.find((p) => p.name === 'first-contentful-paint');
+    const fp = paint.find((p) => p.name === 'first-paint');
+
+    const fcpMs = fcp?.startTime ?? (nav ? nav.responseEnd : 0);
+    const domLoadMs = nav ? nav.domContentLoadedEventEnd : timing.domContentLoadedEventEnd - timing.navigationStart;
+    const loadMs = nav ? nav.loadEventEnd : timing.loadEventEnd - timing.navigationStart;
+
+    const metrics: MetricResult[] = [
+      {
+        name: 'First Contentful Paint',
+        value: fcpMs > 0 ? `${Math.round(fcpMs)}` : 'N/A',
+        unit: 'ms',
+        score: fcpMs <= 0 ? 50 : fcpMs <= 1800 ? 100 : fcpMs <= 3000 ? 60 : 30,
+      },
+      {
+        name: 'First Paint',
+        value: fp ? `${Math.round(fp.startTime)}` : 'N/A',
+        unit: 'ms',
+        score: fp ? (fp.startTime <= 2000 ? 100 : fp.startTime <= 4000 ? 60 : 30) : 50,
+      },
+      {
+        name: 'DOM Content Loaded',
+        value: domLoadMs > 0 ? `${Math.round(domLoadMs)}` : 'N/A',
+        unit: 'ms',
+        score: domLoadMs <= 0 ? 50 : domLoadMs <= 2000 ? 100 : domLoadMs <= 4000 ? 60 : 30,
+      },
+      {
+        name: 'Page Load',
+        value: loadMs > 0 ? `${Math.round(loadMs)}` : 'N/A',
+        unit: 'ms',
+        score: loadMs <= 0 ? 50 : loadMs <= 3000 ? 100 : loadMs <= 6000 ? 60 : 30,
+      },
+      {
+        name: 'LCP (approx.)',
+        value: lcp ? `${Math.round(lcp.startTime)}` : 'N/A',
+        unit: 'ms',
+        score: !lcp ? 50 : lcp.startTime <= 2500 ? 100 : lcp.startTime <= 4000 ? 60 : 30,
+      },
+      {
+        name: 'CLS (approx.)',
+        value: cls ? cls.value.toFixed(3) : 'N/A',
+        unit: '',
+        score: !cls ? 50 : cls.value <= 0.1 ? 100 : cls.value <= 0.25 ? 60 : 30,
+      },
+      {
+        name: 'Resource Count',
+        value: String(resourceCountJson),
+        unit: 'requests',
+        score: resourceCountJson <= 50 ? 100 : resourceCountJson <= 100 ? 60 : 30,
+      },
+    ];
+
+    const audits: AuditResult[] = [
+      {
+        id: 'fcp',
+        title: 'First Contentful Paint',
+        description: 'Time until the browser renders the first bit of content.',
+        passed: fcpMs > 0 && fcpMs <= 1800,
+        score: fcpMs > 0 ? Math.max(0, Math.min(100, Math.round(100 - ((fcpMs - 1800) / 120)))) : null,
+        displayValue: fcpMs > 0 ? `${Math.round(fcpMs)} ms` : undefined,
+      },
+      {
+        id: 'dcl',
+        title: 'DOM Content Loaded',
+        description: 'Time until the DOM is fully parsed.',
+        passed: domLoadMs > 0 && domLoadMs <= 2000,
+        score: domLoadMs > 0 ? Math.max(0, Math.min(100, Math.round(100 - ((domLoadMs - 2000) / 80)))) : null,
+        displayValue: domLoadMs > 0 ? `${Math.round(domLoadMs)} ms` : undefined,
+      },
+      {
+        id: 'resource-count',
+        title: 'Resource count',
+        description: 'Fewer network requests means faster page loads.',
+        passed: resourceCountJson <= 80,
+        score: Math.max(0, Math.min(100, Math.round(100 - (resourceCountJson - 20) * 0.8))),
+        displayValue: `${resourceCountJson} requests`,
+      },
+    ];
+
+    return { audits, metrics };
+  }, [evalExpr]);
+
+  // ── Accessibility audit ───────────────────────────────────────────────────
+
+  const runAccessibilityAudit = useCallback(async (): Promise<{ audits: AuditResult[] }> => {
+    console.log('[LighthousePanel] running accessibility audit');
+    setProgress('Checking accessibility...');
+
+    const imagesWithoutAlt = (await evalExpr(
+      'document.querySelectorAll("img:not([alt])").length',
+    )) as number;
+    const inputsWithoutLabel = (await evalExpr(
+      `document.querySelectorAll("input:not([aria-label]):not([aria-labelledby]):not([id])").length`,
+    )) as number;
+    const hasMainLandmark = (await evalExpr(
+      `document.querySelector("main, [role='main']") !== null`,
+    )) as boolean;
+    const hasNavLandmark = (await evalExpr(
+      `document.querySelector("nav, [role='navigation']") !== null`,
+    )) as boolean;
+    const headingOrder = (await evalExpr(
+      `JSON.stringify(Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6')).map(h => parseInt(h.tagName[1])))`,
+    )) as string;
+    const hasLangAttr = (await evalExpr(
+      `document.documentElement.hasAttribute('lang')`,
+    )) as boolean;
+    const hasTitle = (await evalExpr(
+      `document.title.trim().length > 0`,
+    )) as boolean;
+    const buttonsWithText = (await evalExpr(
+      `Array.from(document.querySelectorAll('button')).filter(b => !b.textContent?.trim() && !b.getAttribute('aria-label')).length`,
+    )) as number;
+
+    console.log('[LighthousePanel] a11y checks:', { imagesWithoutAlt, inputsWithoutLabel, hasMainLandmark, hasNavLandmark, hasLangAttr, hasTitle, buttonsWithText });
+
+    const headings: number[] = JSON.parse(headingOrder);
+    let headingOrderOk = true;
+    for (let i = 1; i < headings.length; i++) {
+      if (headings[i] > headings[i - 1] + 1) {
+        headingOrderOk = false;
+        break;
+      }
+    }
+
+    const audits: AuditResult[] = [
+      {
+        id: 'image-alt',
+        title: 'Images have alt text',
+        description: 'All images should have descriptive alt attributes for screen readers.',
+        passed: imagesWithoutAlt === 0,
+        score: imagesWithoutAlt === 0 ? 100 : Math.max(0, 100 - imagesWithoutAlt * 15),
+        displayValue: imagesWithoutAlt > 0 ? `${imagesWithoutAlt} image(s) missing alt` : undefined,
+      },
+      {
+        id: 'input-labels',
+        title: 'Form inputs have labels',
+        description: 'All form inputs must have an associated label.',
+        passed: inputsWithoutLabel === 0,
+        score: inputsWithoutLabel === 0 ? 100 : Math.max(0, 100 - inputsWithoutLabel * 20),
+        displayValue: inputsWithoutLabel > 0 ? `${inputsWithoutLabel} input(s) without label` : undefined,
+      },
+      {
+        id: 'landmark-main',
+        title: 'Page has a <main> landmark',
+        description: 'A <main> or role=main landmark helps users navigate to the primary content.',
+        passed: hasMainLandmark,
+        score: hasMainLandmark ? 100 : 0,
+      },
+      {
+        id: 'landmark-nav',
+        title: 'Page has a <nav> landmark',
+        description: 'A <nav> or role=navigation landmark helps users navigate between pages.',
+        passed: hasNavLandmark,
+        score: hasNavLandmark ? 100 : 0,
+      },
+      {
+        id: 'heading-order',
+        title: 'Heading levels are sequential',
+        description: 'Heading levels should increase by at most one to form a logical structure.',
+        passed: headingOrderOk,
+        score: headingOrderOk ? 100 : 30,
+        displayValue: headings.length > 0 ? `${headings.length} heading(s) found` : 'No headings',
+      },
+      {
+        id: 'html-lang',
+        title: 'Document has a lang attribute',
+        description: 'The html element should have a lang attribute to aid screen readers.',
+        passed: hasLangAttr,
+        score: hasLangAttr ? 100 : 0,
+      },
+      {
+        id: 'document-title',
+        title: 'Document has a title',
+        description: 'A descriptive document title helps users identify the page.',
+        passed: hasTitle,
+        score: hasTitle ? 100 : 0,
+      },
+      {
+        id: 'button-name',
+        title: 'Buttons have accessible names',
+        description: 'Buttons must have text content or an aria-label.',
+        passed: buttonsWithText === 0,
+        score: buttonsWithText === 0 ? 100 : Math.max(0, 100 - buttonsWithText * 20),
+        displayValue: buttonsWithText > 0 ? `${buttonsWithText} button(s) without name` : undefined,
+      },
+    ];
+
+    return { audits };
+  }, [evalExpr]);
+
+  // ── Best Practices audit ──────────────────────────────────────────────────
+
+  const runBestPracticesAudit = useCallback(async (): Promise<{ audits: AuditResult[] }> => {
+    console.log('[LighthousePanel] running best practices audit');
+    setProgress('Checking best practices...');
+
+    const isHttps = (await evalExpr(`location.protocol === 'https:'`)) as boolean;
+    const hasConsoleErrors = (await evalExpr(
+      `typeof window.__devtools_error_count__ === 'number' ? window.__devtools_error_count__ > 0 : false`,
+    )) as boolean;
+    const hasDoctype = (await evalExpr(
+      `document.doctype !== null`,
+    )) as boolean;
+    const hasCharset = (await evalExpr(
+      `document.querySelector('meta[charset]') !== null || document.characterSet.toLowerCase().includes('utf')`,
+    )) as boolean;
+    const hasXFrameOptions = (await evalExpr(
+      `document.querySelector('meta[http-equiv="X-Frame-Options"]') !== null`,
+    )) as boolean;
+    const listenersJson = (await evalExpr(
+      `JSON.stringify(typeof document.querySelectorAll === 'function' ? document.querySelectorAll('[onclick]').length : 0)`,
+    )) as string;
+    const inlineHandlerCount = JSON.parse(listenersJson) as number;
+    const hasViewport = (await evalExpr(
+      `document.querySelector('meta[name="viewport"]') !== null`,
+    )) as boolean;
+
+    console.log('[LighthousePanel] best practices checks:', { isHttps, hasConsoleErrors, hasDoctype, hasCharset, hasViewport, inlineHandlerCount });
+
+    const audits: AuditResult[] = [
+      {
+        id: 'https',
+        title: 'Page uses HTTPS',
+        description: 'HTTPS encrypts data in transit and improves security.',
+        passed: isHttps,
+        score: isHttps ? 100 : 0,
+      },
+      {
+        id: 'doctype',
+        title: 'Page has a doctype',
+        description: 'A doctype prevents the browser from switching to quirks mode.',
+        passed: hasDoctype,
+        score: hasDoctype ? 100 : 0,
+      },
+      {
+        id: 'charset',
+        title: 'Character encoding is specified',
+        description: 'Specifying a charset avoids potential XSS vectors and rendering bugs.',
+        passed: hasCharset,
+        score: hasCharset ? 100 : 40,
+      },
+      {
+        id: 'viewport',
+        title: 'Has a viewport meta tag',
+        description: 'A viewport meta tag ensures the page renders correctly on mobile.',
+        passed: hasViewport,
+        score: hasViewport ? 100 : 0,
+      },
+      {
+        id: 'inline-handlers',
+        title: 'No inline event handlers',
+        description: 'Inline event handlers (onclick="...") are harder to maintain and may violate CSP.',
+        passed: inlineHandlerCount === 0,
+        score: inlineHandlerCount === 0 ? 100 : Math.max(0, 100 - inlineHandlerCount * 10),
+        displayValue: inlineHandlerCount > 0 ? `${inlineHandlerCount} inline handler(s)` : undefined,
+      },
+      {
+        id: 'no-console-errors',
+        title: 'No console errors detected',
+        description: 'Console errors indicate JavaScript exceptions or failed resources.',
+        passed: !hasConsoleErrors,
+        score: hasConsoleErrors ? 50 : 100,
+      },
+    ];
+
+    return { audits };
+  }, [evalExpr]);
+
+  // ── SEO audit ─────────────────────────────────────────────────────────────
+
+  const runSeoAudit = useCallback(async (): Promise<{ audits: AuditResult[] }> => {
+    console.log('[LighthousePanel] running SEO audit');
+    setProgress('Checking SEO...');
+
+    const hasMetaDescription = (await evalExpr(
+      `document.querySelector('meta[name="description"]')?.content?.trim().length > 0`,
+    )) as boolean;
+    const hasTitle = (await evalExpr(`document.title.trim().length > 0`)) as boolean;
+    const titleLength = (await evalExpr(`document.title.trim().length`)) as number;
+    const hasViewport = (await evalExpr(
+      `document.querySelector('meta[name="viewport"]') !== null`,
+    )) as boolean;
+    const hasCanonical = (await evalExpr(
+      `document.querySelector('link[rel="canonical"]') !== null`,
+    )) as boolean;
+    const h1Count = (await evalExpr(`document.querySelectorAll('h1').length`)) as number;
+    const hasRobotsTag = (await evalExpr(
+      `document.querySelector('meta[name="robots"]') !== null`,
+    )) as boolean;
+    const imagesWithAlt = (await evalExpr(
+      `document.querySelectorAll('img[alt]').length`,
+    )) as number;
+    const totalImages = (await evalExpr(`document.querySelectorAll('img').length`)) as number;
+
+    console.log('[LighthousePanel] SEO checks:', { hasMetaDescription, hasTitle, titleLength, hasViewport, hasCanonical, h1Count, hasRobotsTag, imagesWithAlt, totalImages });
+
+    const audits: AuditResult[] = [
+      {
+        id: 'meta-description',
+        title: 'Document has a meta description',
+        description: 'A meta description helps search engines show a relevant snippet in search results.',
+        passed: hasMetaDescription,
+        score: hasMetaDescription ? 100 : 0,
+      },
+      {
+        id: 'title',
+        title: 'Document has a title tag',
+        description: 'The title tag is important for SEO and browser tabs.',
+        passed: hasTitle && titleLength >= 10 && titleLength <= 70,
+        score: !hasTitle ? 0 : titleLength < 10 ? 40 : titleLength > 70 ? 60 : 100,
+        displayValue: hasTitle ? `"${titleLength}" chars` : undefined,
+      },
+      {
+        id: 'viewport',
+        title: 'Has viewport meta tag',
+        description: 'Mobile-friendliness is a ranking factor.',
+        passed: hasViewport,
+        score: hasViewport ? 100 : 0,
+      },
+      {
+        id: 'canonical',
+        title: 'Page has a canonical link',
+        description: 'A canonical URL prevents duplicate content issues.',
+        passed: hasCanonical,
+        score: hasCanonical ? 100 : 50,
+      },
+      {
+        id: 'h1',
+        title: 'Page has exactly one H1',
+        description: 'A single H1 provides a clear primary heading for search engines.',
+        passed: h1Count === 1,
+        score: h1Count === 1 ? 100 : h1Count === 0 ? 0 : 60,
+        displayValue: `${h1Count} H1(s)`,
+      },
+      {
+        id: 'robots',
+        title: 'Has robots meta tag',
+        description: 'A robots meta tag controls indexing behavior.',
+        passed: hasRobotsTag,
+        score: hasRobotsTag ? 100 : 50,
+      },
+      {
+        id: 'image-alt-seo',
+        title: 'Images have descriptive alt text',
+        description: 'Alt text on images helps search engines understand page content.',
+        passed: totalImages === 0 || imagesWithAlt === totalImages,
+        score: totalImages === 0 ? 100 : Math.round((imagesWithAlt / totalImages) * 100),
+        displayValue: totalImages > 0 ? `${imagesWithAlt}/${totalImages} images` : undefined,
+      },
+    ];
+
+    return { audits };
+  }, [evalExpr]);
+
+  // ── Main run handler ──────────────────────────────────────────────────────
+
+  const runAudit = useCallback(async () => {
+    if (!isAttached) return;
+    console.log('[LighthousePanel] starting audit run');
+    setRunning(true);
+    setError(null);
+    setResults(null);
+    setProgress('Starting audit...');
+
+    try {
+      await cdpSend('Runtime.enable');
+
+      const [perfResult, a11yResult, bpResult, seoResult] = await Promise.all([
+        runPerformanceAudit(),
+        runAccessibilityAudit(),
+        runBestPracticesAudit(),
+        runSeoAudit(),
+      ]);
+
+      const calcScore = (audits: AuditResult[]): number => {
+        const scored = audits.filter((a) => a.score !== null);
+        if (scored.length === 0) return 0;
+        return Math.round(scored.reduce((sum, a) => sum + (a.score ?? 0), 0) / scored.length);
+      };
+
+      const categories: CategoryResult[] = [
+        { id: 'performance', title: 'Performance', score: calcScore(perfResult.audits), audits: perfResult.audits },
+        { id: 'accessibility', title: 'Accessibility', score: calcScore(a11yResult.audits), audits: a11yResult.audits },
+        { id: 'best-practices', title: 'Best Practices', score: calcScore(bpResult.audits), audits: bpResult.audits },
+        { id: 'seo', title: 'SEO', score: calcScore(seoResult.audits), audits: seoResult.audits },
+      ];
+
+      console.log('[LighthousePanel] audit complete, category scores:', categories.map((c) => `${c.title}: ${c.score}`));
+
+      setResults({
+        categories,
+        metrics: perfResult.metrics,
+        runAt: new Date().toLocaleTimeString(),
+      });
+      setProgress('');
+    } catch (err) {
+      console.error('[LighthousePanel] audit run failed:', err);
+      setError(String(err));
+      setProgress('');
+    } finally {
+      setRunning(false);
+    }
+  }, [isAttached, cdpSend, runPerformanceAudit, runAccessibilityAudit, runBestPracticesAudit, runSeoAudit]);
+
+  const clearResults = useCallback(() => {
+    console.log('[LighthousePanel] clearing results');
+    setResults(null);
+    setError(null);
+    setProgress('');
+  }, []);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not attached</div>
+        <div className="panel-placeholder-desc">Attach to a tab to run Lighthouse audits.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          padding: 'var(--space-2) var(--space-4)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          flexShrink: 0,
+          backgroundColor: 'var(--color-bg-elevated)',
+        }}
+      >
+        <button
+          className="devtools-connect-btn"
+          onClick={() => void runAudit()}
+          disabled={running}
+          style={{ padding: 'var(--space-2) var(--space-5)', fontSize: 'var(--font-size-xs)' }}
+        >
+          {running ? 'Running...' : 'Run Audit'}
+        </button>
+        {results && (
+          <button className="console-clear-btn" onClick={clearResults}>
+            Clear Results
+          </button>
+        )}
+        {progress && (
+          <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-tertiary)', fontFamily: 'var(--font-mono)' }}>
+            {progress}
+          </span>
+        )}
+        {results && (
+          <span style={{ marginLeft: 'auto', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)' }}>
+            Run at {results.runAt}
+          </span>
+        )}
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-4)' }}>
+        {error && (
+          <div style={{ color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)', fontFamily: 'var(--font-mono)', marginBottom: 'var(--space-4)' }}>
+            {error}
+          </div>
+        )}
+
+        {!results && !running && !error && (
+          <div className="panel-placeholder" style={{ height: '300px' }}>
+            <div className="panel-placeholder-icon">☆</div>
+            <div className="panel-placeholder-title">Lighthouse Audit</div>
+            <div className="panel-placeholder-desc">
+              Click "Run Audit" to analyze performance, accessibility, best practices, and SEO.
+            </div>
+          </div>
+        )}
+
+        {results && (
+          <>
+            {/* Category scores */}
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, 1fr)',
+                gap: 'var(--space-3)',
+                marginBottom: 'var(--space-6)',
+              }}
+            >
+              {results.categories.map((cat) => (
+                <div
+                  key={cat.id}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 'var(--space-2)',
+                    padding: 'var(--space-4)',
+                    borderRadius: 'var(--radius-md)',
+                    border: `1px solid ${SCORE_COLOR(cat.score)}`,
+                    backgroundColor: SCORE_BG(cat.score),
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '28px',
+                      fontWeight: 'var(--font-weight-semibold)',
+                      color: SCORE_COLOR(cat.score),
+                      lineHeight: 1,
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  >
+                    {cat.score}
+                  </div>
+                  <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-secondary)', textAlign: 'center' }}>
+                    {cat.title}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Metrics */}
+            <div style={{ marginBottom: 'var(--space-6)' }}>
+              <div
+                style={{
+                  fontSize: 'var(--font-size-xs)',
+                  fontWeight: 'var(--font-weight-semibold)',
+                  color: 'var(--color-fg-secondary)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  marginBottom: 'var(--space-3)',
+                  paddingBottom: 'var(--space-2)',
+                  borderBottom: '1px solid var(--color-border-subtle)',
+                }}
+              >
+                Metrics
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-3)' }}>
+                {results.metrics.map((metric, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      padding: 'var(--space-3)',
+                      borderRadius: 'var(--radius-sm)',
+                      border: '1px solid var(--color-border-subtle)',
+                      backgroundColor: 'var(--color-bg-elevated)',
+                    }}
+                  >
+                    <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-tertiary)', marginBottom: 'var(--space-1)' }}>
+                      {metric.name}
+                    </div>
+                    <div style={{ fontSize: 'var(--font-size-sm)', fontWeight: 'var(--font-weight-semibold)', color: SCORE_COLOR(metric.score), fontFamily: 'var(--font-mono)' }}>
+                      {metric.value} {metric.unit && <span style={{ fontSize: 'var(--font-size-2xs)', fontWeight: 'normal' }}>{metric.unit}</span>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Per-category audit details */}
+            {results.categories.map((cat) => (
+              <div key={cat.id} style={{ marginBottom: 'var(--space-6)' }}>
+                <div
+                  style={{
+                    fontSize: 'var(--font-size-xs)',
+                    fontWeight: 'var(--font-weight-semibold)',
+                    color: 'var(--color-fg-secondary)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    marginBottom: 'var(--space-3)',
+                    paddingBottom: 'var(--space-2)',
+                    borderBottom: '1px solid var(--color-border-subtle)',
+                  }}
+                >
+                  {cat.title} Audits
+                </div>
+                {cat.audits.map((audit) => (
+                  <div
+                    key={audit.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 'var(--space-3)',
+                      padding: 'var(--space-2) 0',
+                      borderBottom: '1px solid var(--color-border-subtle)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        flexShrink: 0,
+                        fontSize: 'var(--font-size-xs)',
+                        color: audit.passed ? 'var(--color-status-success)' : 'var(--color-status-error)',
+                        width: '16px',
+                        textAlign: 'center',
+                      }}
+                    >
+                      {audit.passed ? '✓' : '✕'}
+                    </span>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-primary)', fontWeight: 'var(--font-weight-medium)' }}>
+                        {audit.title}
+                        {audit.displayValue && (
+                          <span style={{ marginLeft: 'var(--space-2)', color: 'var(--color-fg-tertiary)', fontWeight: 'normal', fontFamily: 'var(--font-mono)' }}>
+                            — {audit.displayValue}
+                          </span>
+                        )}
+                      </div>
+                      <div style={{ fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)', marginTop: 'var(--space-1)', lineHeight: 'var(--line-height-relaxed)' }}>
+                        {audit.description}
+                      </div>
+                    </div>
+                    {audit.score !== null && (
+                      <span
+                        style={{
+                          flexShrink: 0,
+                          fontSize: 'var(--font-size-2xs)',
+                          fontFamily: 'var(--font-mono)',
+                          color: SCORE_COLOR(audit.score),
+                          width: '32px',
+                          textAlign: 'right',
+                        }}
+                      >
+                        {audit.score}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/MemoryPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/MemoryPanel.tsx
@@ -139,10 +139,11 @@ export function MemoryPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): Re
           totalSize += statsUpdate[i + 2] ?? 0;
         }
         console.log(PANEL_TAG, 'heapStatsUpdate, size:', totalSize, 'count:', totalCount);
-        setAllocationSamples((prev) => [
-          ...prev,
-          { id: allocationSampleIdCounter++, size: totalSize, count: totalCount, ts: Date.now() },
-        ]);
+        const MAX_ALLOCATION_SAMPLES = 5000;
+        setAllocationSamples((prev) => {
+          const next = [...prev, { id: allocationSampleIdCounter++, size: totalSize, count: totalCount, ts: Date.now() }];
+          return next.length > MAX_ALLOCATION_SAMPLES ? next.slice(-MAX_ALLOCATION_SAMPLES) : next;
+        });
       }
 
       if (method === 'HeapProfiler.lastSeenObjectId') {
@@ -192,14 +193,14 @@ export function MemoryPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): Re
       console.log(PANEL_TAG, 'takeHeapSnapshot command sent');
       // Finalization happens in the reportHeapSnapshotProgress finished=true handler,
       // but some implementations never send finished=true, so also finalize after command resolves.
-      if (chunkBufferRef.current.length > 0 && snapshotProgress !== null) {
+      if (chunkBufferRef.current.length > 0) {
         finalizeSnapshot();
       }
     } catch (err) {
       console.error(PANEL_TAG, 'takeHeapSnapshot failed:', err);
       setSnapshotProgress(null);
     }
-  }, [cdpSend, finalizeSnapshot, snapshotProgress]);
+  }, [cdpSend, finalizeSnapshot]);
 
   const handleStartTracking = useCallback(async () => {
     console.log(PANEL_TAG, 'starting heap allocation tracking');

--- a/my-app/src/renderer/devtools/panels/MemoryPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/MemoryPanel.tsx
@@ -1,0 +1,503 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+// ---- Types ----------------------------------------------------------------
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+interface SnapshotSummary {
+  id: number;
+  takenAt: number;
+  totalBytes: number;
+  nodeCountsByType: Record<string, number>;
+  rawChunkCount: number;
+}
+
+interface AllocationSample {
+  id: number;
+  size: number;
+  count: number;
+  ts: number;
+}
+
+interface GcStat {
+  lastSeenObjectId: number;
+  timestamp: number;
+}
+
+// ---- Constants ------------------------------------------------------------
+
+const PANEL_TAG = '[MemoryPanel]';
+let snapshotIdCounter = 0;
+let allocationSampleIdCounter = 0;
+
+// ---- Helpers ---------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GB`;
+  if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+function parseSnapshotNodes(raw: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  try {
+    const data = JSON.parse(raw) as {
+      snapshot?: { meta?: { node_types?: unknown[] } };
+      nodes?: number[];
+      strings?: string[];
+    };
+    const meta = data.snapshot?.meta;
+    const nodeTypes = meta?.node_types as string[][] | undefined;
+    const nodeTypeList = nodeTypes?.[0] ?? [];
+    const nodes = data.nodes ?? [];
+    const strings = data.strings ?? [];
+    // node fields: type, name, id, self_size, edge_count, trace_node_id, detachedness (7 fields per node)
+    const NODE_FIELDS = 7;
+    for (let i = 0; i < nodes.length; i += NODE_FIELDS) {
+      const typeIndex = nodes[i];
+      const typeName = nodeTypeList[typeIndex] ?? String(typeIndex);
+      counts[typeName] = (counts[typeName] ?? 0) + 1;
+    }
+  } catch {
+    // snapshot format not parseable — return empty
+  }
+  return counts;
+}
+
+// ---- Component -------------------------------------------------------------
+
+export function MemoryPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [snapshots, setSnapshots] = useState<SnapshotSummary[]>([]);
+  const [snapshotProgress, setSnapshotProgress] = useState<number | null>(null);
+  const [isTracking, setIsTracking] = useState(false);
+  const [allocationSamples, setAllocationSamples] = useState<AllocationSample[]>([]);
+  const [gcStats, setGcStats] = useState<GcStat[]>([]);
+  const chunkBufferRef = useRef<string>('');
+  const chunkCountRef = useRef<number>(0);
+  const currentSnapshotStartRef = useRef<number>(0);
+
+  // Enable HeapProfiler on mount
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log(PANEL_TAG, 'enabling HeapProfiler domain');
+    void cdpSend('HeapProfiler.enable').then((r) => {
+      console.log(PANEL_TAG, 'HeapProfiler.enable result:', r);
+    });
+
+    return () => {
+      console.log(PANEL_TAG, 'disabling HeapProfiler domain');
+      void cdpSend('HeapProfiler.disable');
+    };
+  }, [isAttached, cdpSend]);
+
+  // Subscribe to HeapProfiler events
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log(PANEL_TAG, 'subscribing to HeapProfiler events');
+
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'HeapProfiler.addHeapSnapshotChunk') {
+        const chunk = p.chunk as string;
+        chunkBufferRef.current += chunk;
+        chunkCountRef.current += 1;
+        // Estimate progress by chunk size growth (rough heuristic)
+        const approxProgress = Math.min(99, Math.floor((chunkBufferRef.current.length / 5000000) * 100));
+        setSnapshotProgress(approxProgress);
+        console.log(PANEL_TAG, 'snapshot chunk received, total chars:', chunkBufferRef.current.length);
+      }
+
+      if (method === 'HeapProfiler.reportHeapSnapshotProgress') {
+        const done = p.done as number;
+        const total = p.total as number;
+        const finished = p.finished as boolean | undefined;
+        if (total > 0) {
+          const pct = Math.floor((done / total) * 100);
+          setSnapshotProgress(pct);
+          console.log(PANEL_TAG, 'snapshot progress:', pct, '%');
+        }
+        if (finished) {
+          console.log(PANEL_TAG, 'snapshot complete, processing', chunkBufferRef.current.length, 'chars');
+          finalizeSnapshot();
+        }
+      }
+
+      if (method === 'HeapProfiler.heapStatsUpdate') {
+        const statsUpdate = p.statsUpdate as number[] | undefined;
+        if (!statsUpdate) return;
+        // statsUpdate is an array: [startPosition, count, size, startPosition2, count2, size2, ...]
+        let totalSize = 0;
+        let totalCount = 0;
+        for (let i = 0; i < statsUpdate.length; i += 3) {
+          totalCount += statsUpdate[i + 1] ?? 0;
+          totalSize += statsUpdate[i + 2] ?? 0;
+        }
+        console.log(PANEL_TAG, 'heapStatsUpdate, size:', totalSize, 'count:', totalCount);
+        setAllocationSamples((prev) => [
+          ...prev,
+          { id: allocationSampleIdCounter++, size: totalSize, count: totalCount, ts: Date.now() },
+        ]);
+      }
+
+      if (method === 'HeapProfiler.lastSeenObjectId') {
+        const lastSeenObjectId = p.lastSeenObjectId as number;
+        const timestamp = p.timestamp as number;
+        console.log(PANEL_TAG, 'lastSeenObjectId:', lastSeenObjectId, 'ts:', timestamp);
+        setGcStats((prev) => [...prev.slice(-99), { lastSeenObjectId, timestamp }]);
+      }
+    });
+
+    return unsubscribe;
+  }, [isAttached, onCdpEvent]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const finalizeSnapshot = useCallback(() => {
+    const raw = chunkBufferRef.current;
+    const chunkCount = chunkCountRef.current;
+    const totalBytes = raw.length * 2; // rough UTF-16 estimate
+
+    console.log(PANEL_TAG, 'finalizing snapshot, raw length:', raw.length, 'chunk count:', chunkCount);
+
+    const nodeCountsByType = parseSnapshotNodes(raw);
+    const summary: SnapshotSummary = {
+      id: snapshotIdCounter++,
+      takenAt: currentSnapshotStartRef.current,
+      totalBytes,
+      nodeCountsByType,
+      rawChunkCount: chunkCount,
+    };
+
+    setSnapshots((prev) => [...prev, summary]);
+    setSnapshotProgress(null);
+
+    // Reset buffer for next snapshot
+    chunkBufferRef.current = '';
+    chunkCountRef.current = 0;
+  }, []);
+
+  const handleTakeSnapshot = useCallback(async () => {
+    console.log(PANEL_TAG, 'taking heap snapshot');
+    chunkBufferRef.current = '';
+    chunkCountRef.current = 0;
+    currentSnapshotStartRef.current = Date.now();
+    setSnapshotProgress(0);
+
+    try {
+      await cdpSend('HeapProfiler.takeHeapSnapshot', { reportProgress: true, treatGlobalObjectsAsRoots: true });
+      console.log(PANEL_TAG, 'takeHeapSnapshot command sent');
+      // Finalization happens in the reportHeapSnapshotProgress finished=true handler,
+      // but some implementations never send finished=true, so also finalize after command resolves.
+      if (chunkBufferRef.current.length > 0 && snapshotProgress !== null) {
+        finalizeSnapshot();
+      }
+    } catch (err) {
+      console.error(PANEL_TAG, 'takeHeapSnapshot failed:', err);
+      setSnapshotProgress(null);
+    }
+  }, [cdpSend, finalizeSnapshot, snapshotProgress]);
+
+  const handleStartTracking = useCallback(async () => {
+    console.log(PANEL_TAG, 'starting heap allocation tracking');
+    setAllocationSamples([]);
+    setIsTracking(true);
+    try {
+      await cdpSend('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true });
+      console.log(PANEL_TAG, 'startTrackingHeapObjects OK');
+    } catch (err) {
+      console.error(PANEL_TAG, 'startTrackingHeapObjects failed:', err);
+      setIsTracking(false);
+    }
+  }, [cdpSend]);
+
+  const handleStopTracking = useCallback(async () => {
+    console.log(PANEL_TAG, 'stopping heap allocation tracking');
+    try {
+      await cdpSend('HeapProfiler.stopTrackingHeapObjects', { reportProgress: false });
+      console.log(PANEL_TAG, 'stopTrackingHeapObjects OK');
+    } catch (err) {
+      console.error(PANEL_TAG, 'stopTrackingHeapObjects failed:', err);
+    } finally {
+      setIsTracking(false);
+    }
+  }, [cdpSend]);
+
+  const handleCollectGarbage = useCallback(async () => {
+    console.log(PANEL_TAG, 'requesting garbage collection');
+    try {
+      await cdpSend('HeapProfiler.collectGarbage');
+      console.log(PANEL_TAG, 'collectGarbage OK');
+    } catch (err) {
+      console.error(PANEL_TAG, 'collectGarbage failed:', err);
+    }
+  }, [cdpSend]);
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not connected</div>
+        <div className="panel-placeholder-desc">Attach to a tab to use the Memory panel.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', fontSize: 'var(--font-size-xs)' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          padding: 'var(--space-2) var(--space-4)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          flexShrink: 0,
+          flexWrap: 'wrap',
+        }}
+      >
+        <button
+          onClick={() => void handleTakeSnapshot()}
+          disabled={snapshotProgress !== null}
+          style={actionBtnStyle}
+        >
+          {snapshotProgress !== null ? `Snapshotting... ${snapshotProgress}%` : 'Take Heap Snapshot'}
+        </button>
+        {!isTracking ? (
+          <button onClick={() => void handleStartTracking()} style={actionBtnStyle}>
+            Start Allocation Tracking
+          </button>
+        ) : (
+          <button
+            onClick={() => void handleStopTracking()}
+            style={{ ...actionBtnStyle, background: 'var(--color-status-error)', color: '#fff' }}
+          >
+            Stop Allocation Tracking
+          </button>
+        )}
+        <button onClick={() => void handleCollectGarbage()} style={secondaryBtnStyle}>
+          Collect Garbage
+        </button>
+      </div>
+
+      {/* Snapshot progress bar */}
+      {snapshotProgress !== null && (
+        <div style={{ flexShrink: 0, padding: '0 var(--space-4)', paddingTop: 'var(--space-2)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 'var(--space-1)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-secondary)' }}>
+            <span>Taking snapshot...</span>
+            <span>{snapshotProgress}%</span>
+          </div>
+          <div style={{ height: '4px', background: 'var(--color-bg-elevated)', borderRadius: 'var(--radius-full)', overflow: 'hidden' }}>
+            <div
+              style={{
+                height: '100%',
+                width: `${snapshotProgress}%`,
+                background: 'var(--color-accent-default)',
+                borderRadius: 'var(--radius-full)',
+                transition: 'width 0.2s ease',
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Scrollable content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-4)', display: 'flex', flexDirection: 'column', gap: 'var(--space-6)' }}>
+
+        {/* Heap Snapshots */}
+        <section>
+          <div style={sectionHeaderStyle}>Heap Snapshots ({snapshots.length})</div>
+          {snapshots.length === 0 ? (
+            <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+              No snapshots yet. Click "Take Heap Snapshot" to capture one.
+            </div>
+          ) : (
+            snapshots.map((snap) => (
+              <div
+                key={snap.id}
+                style={{
+                  background: 'var(--color-bg-sunken)',
+                  border: '1px solid var(--color-border-subtle)',
+                  borderRadius: 'var(--radius-sm)',
+                  padding: 'var(--space-3)',
+                  marginBottom: 'var(--space-3)',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 'var(--space-2)' }}>
+                  <span style={{ fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-primary)' }}>
+                    Snapshot #{snap.id + 1}
+                  </span>
+                  <span style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+                    {new Date(snap.takenAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: 'var(--space-6)', marginBottom: 'var(--space-3)', flexWrap: 'wrap' }}>
+                  <div>
+                    <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>Total Size</div>
+                    <div style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)' }}>
+                      {formatBytes(snap.totalBytes)}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>Chunks Received</div>
+                    <div style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)' }}>
+                      {snap.rawChunkCount}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>Node Types</div>
+                    <div style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)' }}>
+                      {Object.keys(snap.nodeCountsByType).length}
+                    </div>
+                  </div>
+                </div>
+                {Object.keys(snap.nodeCountsByType).length > 0 && (
+                  <div>
+                    <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)', marginBottom: 'var(--space-2)' }}>
+                      Node Counts by Type
+                    </div>
+                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-2xs)', fontFamily: 'var(--font-mono)' }}>
+                      <thead>
+                        <tr>
+                          <th style={thStyle}>Type</th>
+                          <th style={{ ...thStyle, textAlign: 'right' }}>Count</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(snap.nodeCountsByType)
+                          .sort((a, b) => b[1] - a[1])
+                          .slice(0, 15)
+                          .map(([type, count]) => (
+                            <tr key={type} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                              <td style={tdStyle}>{type}</td>
+                              <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--color-fg-secondary)' }}>{count.toLocaleString()}</td>
+                            </tr>
+                          ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </section>
+
+        {/* Allocation Timeline */}
+        {(isTracking || allocationSamples.length > 0) && (
+          <section>
+            <div style={sectionHeaderStyle}>
+              Allocation Timeline {isTracking && <span style={{ color: 'var(--color-status-error)' }}>● recording</span>}
+            </div>
+            {allocationSamples.length === 0 ? (
+              <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+                Waiting for allocation data...
+              </div>
+            ) : (
+              <div style={{ border: '1px solid var(--color-border-subtle)', borderRadius: 'var(--radius-sm)', overflow: 'hidden', maxHeight: '240px', overflowY: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-2xs)', fontFamily: 'var(--font-mono)' }}>
+                  <thead>
+                    <tr style={{ background: 'var(--color-bg-elevated)', position: 'sticky', top: 0 }}>
+                      <th style={thStyle}>Time</th>
+                      <th style={{ ...thStyle, textAlign: 'right' }}>Total Size</th>
+                      <th style={{ ...thStyle, textAlign: 'right' }}>Object Count</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {allocationSamples.slice(-100).map((sample) => (
+                      <tr key={sample.id} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                        <td style={tdStyle}>{new Date(sample.ts).toLocaleTimeString()}</td>
+                        <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--color-fg-secondary)' }}>
+                          {formatBytes(sample.size)}
+                        </td>
+                        <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--color-fg-secondary)' }}>
+                          {sample.count.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* GC Stats */}
+        {gcStats.length > 0 && (
+          <section>
+            <div style={sectionHeaderStyle}>Garbage Collection ({gcStats.length} events)</div>
+            <div style={{ border: '1px solid var(--color-border-subtle)', borderRadius: 'var(--radius-sm)', overflow: 'hidden', maxHeight: '200px', overflowY: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-2xs)', fontFamily: 'var(--font-mono)' }}>
+                <thead>
+                  <tr style={{ background: 'var(--color-bg-elevated)', position: 'sticky', top: 0 }}>
+                    <th style={thStyle}>Last Object ID</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Timestamp (ms)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {gcStats.slice(-50).map((stat, i) => (
+                    <tr key={i} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                      <td style={tdStyle}>{stat.lastSeenObjectId.toLocaleString()}</td>
+                      <td style={{ ...tdStyle, textAlign: 'right', color: 'var(--color-fg-secondary)' }}>
+                        {stat.timestamp.toFixed(3)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Shared styles ---------------------------------------------------------
+
+const actionBtnStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-4)',
+  background: 'var(--color-accent-default)',
+  color: 'var(--color-fg-inverse)',
+  borderRadius: 'var(--radius-sm)',
+  fontSize: 'var(--font-size-xs)',
+  fontWeight: 'var(--font-weight-medium)',
+  cursor: 'pointer',
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-3)',
+  background: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-subtle)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--color-fg-primary)',
+  fontSize: 'var(--font-size-xs)',
+  cursor: 'pointer',
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+  fontSize: 'var(--font-size-2xs)',
+  fontWeight: 'var(--font-weight-semibold)',
+  color: 'var(--color-fg-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginBottom: 'var(--space-3)',
+};
+
+const thStyle: React.CSSProperties = {
+  padding: 'var(--space-2) var(--space-3)',
+  textAlign: 'left',
+  fontWeight: 'var(--font-weight-medium)',
+  color: 'var(--color-fg-secondary)',
+  borderBottom: '1px solid var(--color-border-default)',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-3)',
+  color: 'var(--color-fg-primary)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};

--- a/my-app/src/renderer/devtools/panels/NetworkPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/NetworkPanel.tsx
@@ -178,8 +178,9 @@ export function NetworkPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.Re
   // ── CDP domain lifecycle ───────────────────────────────────────────────────
 
   useEffect(() => {
-    console.log(LOG_PREFIX, 'enabling Network domain');
+    console.log(LOG_PREFIX, 'enabling Network + Page domains');
     void sendCdp('Network.enable', { maxTotalBufferSize: 10485760, maxResourceBufferSize: 5242880 });
+    void sendCdp('Page.enable');
 
     const unsubscribe = subscribeCdp((method, params) => {
       if (!isRecordingRef.current) return;
@@ -305,6 +306,7 @@ export function NetworkPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.Re
       console.log(LOG_PREFIX, 'disabling Network domain');
       unsubscribe();
       void sendCdp('Network.disable').catch(() => {});
+      void sendCdp('Page.disable').catch(() => {});
     };
   }, [sendCdp, subscribeCdp]);
 
@@ -375,18 +377,20 @@ export function NetworkPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.Re
         const result = (await sendCdp('Network.getResponseBody', { requestId })) as
           | { body?: string; base64Encoded?: boolean }
           | undefined;
+        if (requestId !== selectedId) return;
         const body = result?.body ?? '';
         const display = result?.base64Encoded ? `(base64)\n${body}` : body || '(empty)';
         console.log(LOG_PREFIX, 'response body fetched, length:', body.length);
         setResponseBody(display);
       } catch (err) {
+        if (requestId !== selectedId) return;
         console.warn(LOG_PREFIX, 'getResponseBody failed:', err);
         setResponseBody('(body not available)');
       } finally {
         setLoadingBody(false);
       }
     },
-    [sendCdp],
+    [sendCdp, selectedId],
   );
 
   const handleDetailTabChange = useCallback(

--- a/my-app/src/renderer/devtools/panels/NetworkPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/NetworkPanel.tsx
@@ -1,0 +1,742 @@
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LOG_PREFIX = '[NetworkPanel]';
+
+type TypeFilter = 'All' | 'XHR' | 'JS' | 'CSS' | 'Img' | 'Media' | 'Font' | 'Doc' | 'WS' | 'Other';
+
+const TYPE_FILTERS: TypeFilter[] = [
+  'All', 'XHR', 'JS', 'CSS', 'Img', 'Media', 'Font', 'Doc', 'WS', 'Other',
+];
+
+/** Maps CDP Network.ResourceType to our filter categories */
+const RESOURCE_TYPE_TO_FILTER: Record<string, TypeFilter> = {
+  Document: 'Doc',
+  Stylesheet: 'CSS',
+  Image: 'Img',
+  Media: 'Media',
+  Font: 'Font',
+  Script: 'JS',
+  TextTrack: 'Other',
+  XHR: 'XHR',
+  Fetch: 'XHR',
+  EventSource: 'XHR',
+  WebSocket: 'WS',
+  Manifest: 'Other',
+  SignedExchange: 'Other',
+  Ping: 'Other',
+  CSPViolationReport: 'Other',
+  Preflight: 'Other',
+  Other: 'Other',
+};
+
+/** Maps CDP resourceType to waterfall bar data-type attribute */
+const RESOURCE_TYPE_TO_BAR_TYPE: Record<string, string> = {
+  Document: 'document',
+  Stylesheet: 'stylesheet',
+  Image: 'image',
+  Media: 'other',
+  Font: 'font',
+  Script: 'script',
+  TextTrack: 'other',
+  XHR: 'xhr',
+  Fetch: 'fetch',
+  EventSource: 'fetch',
+  WebSocket: 'other',
+  Manifest: 'other',
+  SignedExchange: 'other',
+  Ping: 'other',
+  CSPViolationReport: 'other',
+  Preflight: 'other',
+  Other: 'other',
+};
+
+const DETAIL_TABS = ['Headers', 'Preview', 'Response'] as const;
+type DetailTab = (typeof DETAIL_TABS)[number];
+
+// ─── Interfaces ───────────────────────────────────────────────────────────────
+
+interface CdpPanelProps {
+  sendCdp: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  subscribeCdp: (listener: (method: string, params: unknown) => void) => () => void;
+}
+
+interface FlatHeaders {
+  [name: string]: string;
+}
+
+interface NetworkRequest {
+  requestId: string;
+  url: string;
+  method: string;
+  resourceType: string;
+  filterCategory: TypeFilter;
+  barType: string;
+  status: number | null;
+  statusText: string;
+  mimeType: string;
+  encodedDataLength: number | null;
+  startTime: number;   // CDP monotonic timestamp (seconds)
+  endTime: number | null;
+  failed: boolean;
+  failureText: string;
+  requestHeaders: FlatHeaders;
+  responseHeaders: FlatHeaders;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatSize(bytes: number | null): string {
+  if (bytes === null) return '—';
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(2)} MB`;
+}
+
+function formatTime(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function extractFilename(url: string): string {
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split('/').filter(Boolean);
+    const last = parts[parts.length - 1];
+    return last || u.hostname || url;
+  } catch {
+    const parts = url.split('/').filter(Boolean);
+    return parts[parts.length - 1] || url;
+  }
+}
+
+function flattenHeaders(
+  raw: Array<{ name: string; value: string }> | Record<string, string> | undefined,
+): FlatHeaders {
+  if (!raw) return {};
+  if (Array.isArray(raw)) {
+    const out: FlatHeaders = {};
+    for (const h of raw) out[h.name] = h.value;
+    return out;
+  }
+  return { ...raw };
+}
+
+// ─── Body preview (defined outside component to avoid re-creation on render) ──
+
+function renderBodyPreview(mimeType: string, body: string): React.ReactElement {
+  const lower = mimeType.toLowerCase();
+
+  if (lower.includes('json')) {
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      return (
+        <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all', color: 'var(--color-fg-primary)' }}>
+          {JSON.stringify(parsed, null, 2)}
+        </pre>
+      );
+    } catch {
+      // fall through to raw
+    }
+  }
+
+  return (
+    <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all', color: 'var(--color-fg-primary)', fontSize: 'var(--font-size-2xs)' }}>
+      {body}
+    </pre>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function NetworkPanel({ sendCdp, subscribeCdp }: CdpPanelProps): React.ReactElement {
+  const [requests, setRequests] = useState<NetworkRequest[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<TypeFilter>('All');
+  const [textFilter, setTextFilter] = useState('');
+  const [isRecording, setIsRecording] = useState(true);
+  const [detailTab, setDetailTab] = useState<DetailTab>('Headers');
+  const [responseBody, setResponseBody] = useState<string | null>(null);
+  const [loadingBody, setLoadingBody] = useState(false);
+
+  // CDP monotonic timestamp of the first request — used to anchor waterfall
+  const pageStartTimeRef = useRef<number | null>(null);
+  // Mutable map for patching in-flight entries without triggering extra renders
+  const requestMapRef = useRef<Map<string, NetworkRequest>>(new Map());
+  // Track recording state in a ref so the event handler closure stays current
+  const isRecordingRef = useRef(true);
+
+  // ── Sync recording ref with state ─────────────────────────────────────────
+
+  useEffect(() => {
+    isRecordingRef.current = isRecording;
+  }, [isRecording]);
+
+  // ── CDP domain lifecycle ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    console.log(LOG_PREFIX, 'enabling Network domain');
+    void sendCdp('Network.enable', { maxTotalBufferSize: 10485760, maxResourceBufferSize: 5242880 });
+
+    const unsubscribe = subscribeCdp((method, params) => {
+      if (!isRecordingRef.current) return;
+
+      const p = params as Record<string, unknown>;
+
+      // ── requestWillBeSent ──────────────────────────────────────────────────
+      if (method === 'Network.requestWillBeSent') {
+        const reqId = p.requestId as string;
+        const req = p.request as Record<string, unknown>;
+        const timestamp = p.timestamp as number;
+        const rawType = (p.type as string | undefined) ?? 'Other';
+        const filterCategory = RESOURCE_TYPE_TO_FILTER[rawType] ?? 'Other';
+        const barType = RESOURCE_TYPE_TO_BAR_TYPE[rawType] ?? 'other';
+
+        if (pageStartTimeRef.current === null) {
+          pageStartTimeRef.current = timestamp;
+          console.log(LOG_PREFIX, 'page start time anchored at', timestamp);
+        }
+
+        const entry: NetworkRequest = {
+          requestId: reqId,
+          url: req.url as string,
+          method: req.method as string,
+          resourceType: rawType,
+          filterCategory,
+          barType,
+          status: null,
+          statusText: '',
+          mimeType: '',
+          encodedDataLength: null,
+          startTime: timestamp,
+          endTime: null,
+          failed: false,
+          failureText: '',
+          requestHeaders: flattenHeaders(req.headers as Array<{ name: string; value: string }> | Record<string, string>),
+          responseHeaders: {},
+        };
+
+        console.log(LOG_PREFIX, 'requestWillBeSent', reqId, entry.method, entry.url, 'type:', rawType);
+
+        requestMapRef.current.set(reqId, entry);
+        setRequests((prev) => {
+          const idx = prev.findIndex((r) => r.requestId === reqId);
+          if (idx !== -1) {
+            const next = [...prev];
+            next[idx] = entry;
+            return next;
+          }
+          return [...prev, entry];
+        });
+      }
+
+      // ── responseReceived ───────────────────────────────────────────────────
+      if (method === 'Network.responseReceived') {
+        const reqId = p.requestId as string;
+        const response = p.response as Record<string, unknown>;
+        const status = response.status as number;
+        const statusText = (response.statusText as string) || '';
+        const mimeType = (response.mimeType as string) || '';
+        const responseHeaders = flattenHeaders(
+          response.headers as Array<{ name: string; value: string }> | Record<string, string>,
+        );
+
+        console.log(LOG_PREFIX, 'responseReceived', reqId, status, mimeType);
+
+        const existing = requestMapRef.current.get(reqId);
+        if (existing) {
+          const updated = { ...existing, status, statusText, mimeType, responseHeaders };
+          requestMapRef.current.set(reqId, updated);
+          setRequests((prev) =>
+            prev.map((r) => (r.requestId === reqId ? updated : r)),
+          );
+        }
+      }
+
+      // ── loadingFinished ────────────────────────────────────────────────────
+      if (method === 'Network.loadingFinished') {
+        const reqId = p.requestId as string;
+        const timestamp = p.timestamp as number;
+        const encodedDataLength = (p.encodedDataLength as number | undefined) ?? 0;
+
+        console.log(LOG_PREFIX, 'loadingFinished', reqId, 'size:', encodedDataLength, 'bytes');
+
+        const existing = requestMapRef.current.get(reqId);
+        if (existing) {
+          const updated = { ...existing, endTime: timestamp, encodedDataLength };
+          requestMapRef.current.set(reqId, updated);
+          setRequests((prev) =>
+            prev.map((r) => (r.requestId === reqId ? updated : r)),
+          );
+        }
+      }
+
+      // ── loadingFailed ──────────────────────────────────────────────────────
+      if (method === 'Network.loadingFailed') {
+        const reqId = p.requestId as string;
+        const timestamp = p.timestamp as number;
+        const errorText = (p.errorText as string | undefined) ?? 'Failed';
+        const canceled = (p.canceled as boolean | undefined) ?? false;
+        const failureText = canceled ? 'Canceled' : errorText;
+
+        console.log(LOG_PREFIX, 'loadingFailed', reqId, failureText);
+
+        const existing = requestMapRef.current.get(reqId);
+        if (existing) {
+          const updated = { ...existing, endTime: timestamp, failed: true, failureText };
+          requestMapRef.current.set(reqId, updated);
+          setRequests((prev) =>
+            prev.map((r) => (r.requestId === reqId ? updated : r)),
+          );
+        }
+      }
+
+      // ── Page navigation resets waterfall reference ─────────────────────────
+      if (method === 'Page.frameNavigated') {
+        console.log(LOG_PREFIX, 'Page.frameNavigated — resetting waterfall anchor');
+        pageStartTimeRef.current = null;
+      }
+    });
+
+    return () => {
+      console.log(LOG_PREFIX, 'disabling Network domain');
+      unsubscribe();
+      void sendCdp('Network.disable').catch(() => {});
+    };
+  }, [sendCdp, subscribeCdp]);
+
+  // ── Filtered list ──────────────────────────────────────────────────────────
+
+  const filteredRequests = useMemo(() => {
+    const lower = textFilter.toLowerCase();
+    return requests.filter((r) => {
+      if (activeFilter !== 'All' && r.filterCategory !== activeFilter) return false;
+      if (lower && !r.url.toLowerCase().includes(lower)) return false;
+      return true;
+    });
+  }, [requests, activeFilter, textFilter]);
+
+  // ── Summary stats ──────────────────────────────────────────────────────────
+
+  const { totalSize } = useMemo(() => {
+    const totalSize = filteredRequests.reduce((acc, r) => acc + (r.encodedDataLength ?? 0), 0);
+    return { totalSize };
+  }, [filteredRequests]);
+
+  // ── Waterfall scale ────────────────────────────────────────────────────────
+
+  const waterfallDurationMs = useMemo(() => {
+    if (requests.length === 0) return 1000;
+    const pageStart = pageStartTimeRef.current ?? requests[0].startTime;
+    let maxEnd = pageStart;
+    for (const r of requests) {
+      const end = r.endTime ?? r.startTime;
+      if (end > maxEnd) maxEnd = end;
+    }
+    return Math.max((maxEnd - pageStart) * 1000, 100);
+  }, [requests]);
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  const handleClear = useCallback(() => {
+    console.log(LOG_PREFIX, 'clearing all requests');
+    requestMapRef.current.clear();
+    pageStartTimeRef.current = null;
+    setRequests([]);
+    setSelectedId(null);
+    setResponseBody(null);
+  }, []);
+
+  const handleToggleRecord = useCallback(() => {
+    setIsRecording((prev) => {
+      console.log(LOG_PREFIX, 'recording toggled to:', !prev);
+      return !prev;
+    });
+  }, []);
+
+  const handleSelectRequest = useCallback((requestId: string) => {
+    console.log(LOG_PREFIX, 'selected request:', requestId);
+    setSelectedId(requestId);
+    setDetailTab('Headers');
+    setResponseBody(null);
+  }, []);
+
+  // ── Response body fetch ────────────────────────────────────────────────────
+
+  const fetchResponseBody = useCallback(
+    async (requestId: string) => {
+      console.log(LOG_PREFIX, 'fetching response body for', requestId);
+      setLoadingBody(true);
+      setResponseBody(null);
+      try {
+        const result = (await sendCdp('Network.getResponseBody', { requestId })) as
+          | { body?: string; base64Encoded?: boolean }
+          | undefined;
+        const body = result?.body ?? '';
+        const display = result?.base64Encoded ? `(base64)\n${body}` : body || '(empty)';
+        console.log(LOG_PREFIX, 'response body fetched, length:', body.length);
+        setResponseBody(display);
+      } catch (err) {
+        console.warn(LOG_PREFIX, 'getResponseBody failed:', err);
+        setResponseBody('(body not available)');
+      } finally {
+        setLoadingBody(false);
+      }
+    },
+    [sendCdp],
+  );
+
+  const handleDetailTabChange = useCallback(
+    (tab: DetailTab) => {
+      setDetailTab(tab);
+      if ((tab === 'Response' || tab === 'Preview') && selectedId && responseBody === null) {
+        void fetchResponseBody(selectedId);
+      }
+    },
+    [selectedId, responseBody, fetchResponseBody],
+  );
+
+  // ── Derived: selected request ──────────────────────────────────────────────
+
+  const selectedRequest = useMemo(
+    () => (selectedId ? (requests.find((r) => r.requestId === selectedId) ?? null) : null),
+    [requests, selectedId],
+  );
+
+  // ── Waterfall bar positioning ──────────────────────────────────────────────
+
+  const computeWaterfallBar = useCallback(
+    (req: NetworkRequest): { left: string; width: string } => {
+      const pageStart = pageStartTimeRef.current ?? req.startTime;
+      const startOffsetMs = (req.startTime - pageStart) * 1000;
+      const endMs = req.endTime != null ? (req.endTime - pageStart) * 1000 : startOffsetMs + 10;
+      const durationMs = Math.max(endMs - startOffsetMs, 2);
+
+      const leftPct = Math.max(0, (startOffsetMs / waterfallDurationMs) * 100);
+      const widthPct = Math.min((durationMs / waterfallDurationMs) * 100, 100 - leftPct);
+
+      return {
+        left: `${leftPct.toFixed(2)}%`,
+        width: `${Math.max(widthPct, 0.5).toFixed(2)}%`,
+      };
+    },
+    [waterfallDurationMs],
+  );
+
+  // ── Render: status cell ────────────────────────────────────────────────────
+
+  const renderStatusCell = (req: NetworkRequest): React.ReactElement => {
+    if (req.failed) {
+      return (
+        <td>
+          <span className="network-status" data-ok="false">{req.failureText || 'Failed'}</span>
+        </td>
+      );
+    }
+    if (req.status === null) {
+      return (
+        <td>
+          <span className="network-status" style={{ color: 'var(--color-fg-tertiary)' }}>pending</span>
+        </td>
+      );
+    }
+    const isOk = req.status >= 200 && req.status < 400;
+    return (
+      <td>
+        <span className="network-status" data-ok={isOk ? 'true' : 'false'}>{req.status}</span>
+      </td>
+    );
+  };
+
+  // ── Render: detail pane ────────────────────────────────────────────────────
+
+  const renderDetailPane = (): React.ReactElement | null => {
+    if (!selectedRequest) return null;
+
+    return (
+      <div
+        style={{
+          borderTop: '1px solid var(--color-border-default)',
+          height: '240px',
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Tab strip */}
+        <div
+          style={{
+            display: 'flex',
+            borderBottom: '1px solid var(--color-border-subtle)',
+            background: 'var(--color-bg-elevated)',
+            flexShrink: 0,
+          }}
+        >
+          {DETAIL_TABS.map((tab) => (
+            <button
+              key={tab}
+              style={{
+                padding: 'var(--space-2) var(--space-5)',
+                fontSize: 'var(--font-size-xs)',
+                color: detailTab === tab ? 'var(--color-accent-default)' : 'var(--color-fg-secondary)',
+                borderBottom: detailTab === tab ? '2px solid var(--color-accent-default)' : '2px solid transparent',
+                background: 'transparent',
+              }}
+              onClick={() => handleDetailTabChange(tab)}
+            >
+              {tab}
+            </button>
+          ))}
+          <button
+            style={{ marginLeft: 'auto', padding: 'var(--space-1) var(--space-4)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)' }}
+            onClick={() => { setSelectedId(null); setResponseBody(null); }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Tab content */}
+        <div
+          style={{
+            flex: 1,
+            overflow: 'auto',
+            padding: 'var(--space-3) var(--space-4)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--font-size-xs)',
+          }}
+        >
+          {detailTab === 'Headers' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-5)' }}>
+              {/* General */}
+              <section>
+                <div style={{ fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-secondary)', marginBottom: 'var(--space-2)', textTransform: 'uppercase', fontSize: 'var(--font-size-2xs)', letterSpacing: '0.05em' }}>
+                  General
+                </div>
+                <div style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: 'var(--space-1) var(--space-4)' }}>
+                  <span style={{ color: 'var(--color-fg-tertiary)' }}>Request URL</span>
+                  <span style={{ color: 'var(--color-fg-primary)', wordBreak: 'break-all' }}>{selectedRequest.url}</span>
+                  <span style={{ color: 'var(--color-fg-tertiary)' }}>Request Method</span>
+                  <span>{selectedRequest.method}</span>
+                  {selectedRequest.status !== null && (
+                    <>
+                      <span style={{ color: 'var(--color-fg-tertiary)' }}>Status Code</span>
+                      <span>{selectedRequest.status} {selectedRequest.statusText}</span>
+                    </>
+                  )}
+                  <span style={{ color: 'var(--color-fg-tertiary)' }}>Resource Type</span>
+                  <span>{selectedRequest.resourceType}</span>
+                </div>
+              </section>
+
+              {/* Response Headers */}
+              {Object.keys(selectedRequest.responseHeaders).length > 0 && (
+                <section>
+                  <div style={{ fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-secondary)', marginBottom: 'var(--space-2)', textTransform: 'uppercase', fontSize: 'var(--font-size-2xs)', letterSpacing: '0.05em' }}>
+                    Response Headers
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: 'var(--space-1) var(--space-4)' }}>
+                    {Object.entries(selectedRequest.responseHeaders).map(([name, value]) => (
+                      <React.Fragment key={name}>
+                        <span style={{ color: 'var(--color-fg-tertiary)', whiteSpace: 'nowrap' }}>{name}</span>
+                        <span style={{ color: 'var(--color-fg-primary)', wordBreak: 'break-all' }}>{value}</span>
+                      </React.Fragment>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Request Headers */}
+              {Object.keys(selectedRequest.requestHeaders).length > 0 && (
+                <section>
+                  <div style={{ fontWeight: 'var(--font-weight-semibold)', color: 'var(--color-fg-secondary)', marginBottom: 'var(--space-2)', textTransform: 'uppercase', fontSize: 'var(--font-size-2xs)', letterSpacing: '0.05em' }}>
+                    Request Headers
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: 'var(--space-1) var(--space-4)' }}>
+                    {Object.entries(selectedRequest.requestHeaders).map(([name, value]) => (
+                      <React.Fragment key={name}>
+                        <span style={{ color: 'var(--color-fg-tertiary)', whiteSpace: 'nowrap' }}>{name}</span>
+                        <span style={{ color: 'var(--color-fg-primary)', wordBreak: 'break-all' }}>{value}</span>
+                      </React.Fragment>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </div>
+          )}
+
+          {(detailTab === 'Response' || detailTab === 'Preview') && (
+            <>
+              {loadingBody && (
+                <span style={{ color: 'var(--color-fg-tertiary)' }}>Loading...</span>
+              )}
+              {!loadingBody && responseBody === null && (
+                <span style={{ color: 'var(--color-fg-tertiary)' }}>No body available</span>
+              )}
+              {!loadingBody && responseBody !== null && (
+                detailTab === 'Preview'
+                  ? renderBodyPreview(selectedRequest.mimeType, responseBody)
+                  : (
+                    <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all', color: 'var(--color-fg-primary)' }}>
+                      {responseBody}
+                    </pre>
+                  )
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  // ── Main render ────────────────────────────────────────────────────────────
+
+  return (
+    <div className="network-panel">
+
+      {/* Toolbar */}
+      <div className="network-toolbar">
+        <button
+          style={{
+            padding: 'var(--space-1) var(--space-3)',
+            fontSize: 'var(--font-size-2xs)',
+            borderRadius: 'var(--radius-sm)',
+            color: isRecording ? 'var(--color-status-error)' : 'var(--color-fg-secondary)',
+            fontWeight: 'var(--font-weight-medium)',
+          }}
+          title={isRecording ? 'Pause recording' : 'Resume recording'}
+          onClick={handleToggleRecord}
+        >
+          {isRecording ? '● Record' : '○ Paused'}
+        </button>
+
+        <button
+          style={{
+            padding: 'var(--space-1) var(--space-3)',
+            fontSize: 'var(--font-size-2xs)',
+            color: 'var(--color-fg-tertiary)',
+            borderRadius: 'var(--radius-sm)',
+          }}
+          onClick={handleClear}
+        >
+          Clear
+        </button>
+
+        <input
+          className="network-filter-input"
+          type="text"
+          placeholder="Filter by URL..."
+          value={textFilter}
+          onChange={(e) => {
+            console.log(LOG_PREFIX, 'text filter:', e.target.value);
+            setTextFilter(e.target.value);
+          }}
+        />
+
+        <div className="network-type-filters">
+          {TYPE_FILTERS.map((type) => (
+            <button
+              key={type}
+              className="network-type-btn"
+              data-active={activeFilter === type ? 'true' : 'false'}
+              onClick={() => {
+                console.log(LOG_PREFIX, 'type filter:', type);
+                setActiveFilter(type);
+              }}
+            >
+              {type}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Request table */}
+      <div className="network-table-wrapper">
+        <table className="network-table">
+          <thead>
+            <tr>
+              <th style={{ width: '200px' }}>Name</th>
+              <th style={{ width: '60px' }}>Method</th>
+              <th style={{ width: '70px' }}>Status</th>
+              <th style={{ width: '70px' }}>Type</th>
+              <th style={{ width: '80px' }}>Size</th>
+              <th style={{ width: '80px' }}>Time</th>
+              <th>Waterfall</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredRequests.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  style={{ textAlign: 'center', color: 'var(--color-fg-tertiary)', padding: 'var(--space-8)' }}
+                >
+                  {requests.length === 0
+                    ? 'No requests captured. Navigate to a page to begin.'
+                    : 'No requests match current filters.'}
+                </td>
+              </tr>
+            ) : (
+              filteredRequests.map((req) => {
+                const durationMs = req.endTime !== null ? (req.endTime - req.startTime) * 1000 : null;
+                const bar = computeWaterfallBar(req);
+
+                return (
+                  <tr
+                    key={req.requestId}
+                    data-selected={selectedId === req.requestId ? 'true' : 'false'}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleSelectRequest(req.requestId)}
+                  >
+                    <td title={req.url}>
+                      <span className="network-url">{extractFilename(req.url)}</span>
+                    </td>
+                    <td>
+                      <span className="network-method">{req.method}</span>
+                    </td>
+                    {renderStatusCell(req)}
+                    <td style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+                      {req.filterCategory}
+                    </td>
+                    <td>
+                      <span className="network-size">{formatSize(req.encodedDataLength)}</span>
+                    </td>
+                    <td>
+                      <span className="network-time">{formatTime(durationMs)}</span>
+                    </td>
+                    <td>
+                      <div className="network-waterfall">
+                        <div
+                          className="network-waterfall-bar"
+                          data-type={req.barType}
+                          style={{ left: bar.left, width: bar.width }}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Detail pane (shown when a row is selected) */}
+      {renderDetailPane()}
+
+      {/* Summary bar */}
+      <div className="network-summary">
+        <span>
+          {filteredRequests.length} request{filteredRequests.length !== 1 ? 's' : ''}
+        </span>
+        <span>{formatSize(totalSize)} transferred</span>
+        {!isRecording && (
+          <span style={{ color: 'var(--color-status-warning)' }}>Recording paused</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/PerformancePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/PerformancePanel.tsx
@@ -213,30 +213,37 @@ export function PerformancePanel({ cdpSend, onCdpEvent, isAttached }: PanelProps
     console.log(PANEL_TAG, 'fetching Web Vitals via Runtime.evaluate');
     try {
       const expression = `(function() {
-        const entries = performance.getEntriesByType('paint');
-        const nav = performance.getEntriesByType('navigation')[0];
-        const lcp = performance.getEntriesByName ? null : null;
-        const result = {};
-        entries.forEach(e => {
-          if (e.name === 'first-contentful-paint') result.FCP = e.startTime;
-          if (e.name === 'first-paint') result.FP = e.startTime;
+        return new Promise(function(resolve) {
+          var result = {};
+          var entries = performance.getEntriesByType('paint');
+          entries.forEach(function(e) {
+            if (e.name === 'first-contentful-paint') result.FCP = e.startTime;
+            if (e.name === 'first-paint') result.FP = e.startTime;
+          });
+          try {
+            new PerformanceObserver(function(list) {
+              var lcpEntries = list.getEntries();
+              if (lcpEntries.length > 0) result.LCP = lcpEntries[lcpEntries.length - 1].startTime;
+            }).observe({ type: 'largest-contentful-paint', buffered: true });
+          } catch(e) {}
+          try {
+            var clsValue = 0;
+            new PerformanceObserver(function(list) {
+              list.getEntries().forEach(function(e) { if (!e.hadRecentInput) clsValue += e.value; });
+              result.CLS = clsValue;
+            }).observe({ type: 'layout-shift', buffered: true });
+          } catch(e) {}
+          try {
+            new PerformanceObserver(function(list) {
+              var fidEntries = list.getEntries();
+              if (fidEntries.length > 0) result.FID = fidEntries[0].processingStart - fidEntries[0].startTime;
+            }).observe({ type: 'first-input', buffered: true });
+          } catch(e) {}
+          setTimeout(function() { resolve(result); }, 100);
         });
-        const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
-        if (lcpEntries && lcpEntries.length > 0) {
-          result.LCP = lcpEntries[lcpEntries.length - 1].startTime;
-        }
-        const layoutShifts = performance.getEntriesByType('layout-shift');
-        if (layoutShifts && layoutShifts.length > 0) {
-          result.CLS = layoutShifts.reduce((sum, e) => sum + (e.value || 0), 0);
-        }
-        const fidEntries = performance.getEntriesByType('first-input');
-        if (fidEntries && fidEntries.length > 0) {
-          result.FID = fidEntries[0].processingStart - fidEntries[0].startTime;
-        }
-        return result;
       })()`;
 
-      const r = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: false });
+      const r = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
       const res = r.result as { result?: { value?: Record<string, number> }; exceptionDetails?: unknown };
       if (res.result?.value) {
         const vals = res.result.value;

--- a/my-app/src/renderer/devtools/panels/PerformancePanel.tsx
+++ b/my-app/src/renderer/devtools/panels/PerformancePanel.tsx
@@ -1,0 +1,515 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+// ---- Types ----------------------------------------------------------------
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+interface MetricEntry {
+  name: string;
+  value: number;
+}
+
+interface WebVital {
+  name: string;
+  value: string;
+  rating: 'good' | 'needs-improvement' | 'poor' | 'unknown';
+}
+
+interface TraceEvent {
+  id: number;
+  name: string;
+  cat: string;
+  ph: string;
+  ts: number;
+  dur?: number;
+  pid: number;
+  tid: number;
+  args?: Record<string, unknown>;
+}
+
+interface MetricSnapshot {
+  ts: number;
+  metrics: MetricEntry[];
+}
+
+// ---- Constants ------------------------------------------------------------
+
+const PANEL_TAG = '[PerformancePanel]';
+
+const DISPLAY_METRICS: string[] = [
+  'JSHeapUsedSize',
+  'JSHeapTotalSize',
+  'Documents',
+  'Frames',
+  'JSEventListeners',
+  'Nodes',
+  'LayoutCount',
+  'RecalcStyleCount',
+  'TaskDuration',
+  'ScriptDuration',
+  'LayoutDuration',
+  'RecalcStyleDuration',
+];
+
+const METRIC_UNITS: Record<string, string> = {
+  JSHeapUsedSize: 'bytes',
+  JSHeapTotalSize: 'bytes',
+  TaskDuration: 's',
+  ScriptDuration: 's',
+  LayoutDuration: 's',
+  RecalcStyleDuration: 's',
+};
+
+// ---- Helpers ---------------------------------------------------------------
+
+function formatMetricValue(name: string, value: number): string {
+  const unit = METRIC_UNITS[name];
+  if (unit === 'bytes') {
+    if (value >= 1048576) return `${(value / 1048576).toFixed(2)} MB`;
+    if (value >= 1024) return `${(value / 1024).toFixed(1)} KB`;
+    return `${value} B`;
+  }
+  if (unit === 's') {
+    return `${(value * 1000).toFixed(1)} ms`;
+  }
+  return String(value);
+}
+
+function vitalRating(name: string, value: number): 'good' | 'needs-improvement' | 'poor' | 'unknown' {
+  // Thresholds from web.dev/vitals
+  if (name === 'FCP') {
+    if (value <= 1800) return 'good';
+    if (value <= 3000) return 'needs-improvement';
+    return 'poor';
+  }
+  if (name === 'LCP') {
+    if (value <= 2500) return 'good';
+    if (value <= 4000) return 'needs-improvement';
+    return 'poor';
+  }
+  if (name === 'CLS') {
+    if (value <= 0.1) return 'good';
+    if (value <= 0.25) return 'needs-improvement';
+    return 'poor';
+  }
+  if (name === 'FID' || name === 'INP') {
+    if (value <= 100) return 'good';
+    if (value <= 300) return 'needs-improvement';
+    return 'poor';
+  }
+  return 'unknown';
+}
+
+const RATING_COLORS: Record<string, string> = {
+  good: 'var(--color-status-success)',
+  'needs-improvement': 'var(--color-status-warning)',
+  poor: 'var(--color-status-error)',
+  unknown: 'var(--color-fg-tertiary)',
+};
+
+let traceEventIdCounter = 0;
+
+// ---- Component -------------------------------------------------------------
+
+export function PerformancePanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [metrics, setMetrics] = useState<MetricEntry[]>([]);
+  const [webVitals, setWebVitals] = useState<WebVital[]>([]);
+  const [isRecording, setIsRecording] = useState(false);
+  const [traceEvents, setTraceEvents] = useState<TraceEvent[]>([]);
+  const [snapshot, setSnapshot] = useState<MetricSnapshot | null>(null);
+  const [loadingMetrics, setLoadingMetrics] = useState(false);
+  const [loadingVitals, setLoadingVitals] = useState(false);
+  const metricsIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Enable Performance domain on mount
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log(PANEL_TAG, 'enabling Performance domain');
+    void cdpSend('Performance.enable', { timeDomain: 'timeTicks' }).then((r) => {
+      console.log(PANEL_TAG, 'Performance.enable result:', r);
+      void fetchMetrics();
+    });
+
+    return () => {
+      console.log(PANEL_TAG, 'disabling Performance domain');
+      void cdpSend('Performance.disable');
+      if (metricsIntervalRef.current !== null) {
+        clearInterval(metricsIntervalRef.current);
+        metricsIntervalRef.current = null;
+      }
+    };
+  }, [isAttached]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Poll metrics every 3 seconds when connected
+  useEffect(() => {
+    if (!isAttached) return;
+    metricsIntervalRef.current = setInterval(() => {
+      void fetchMetrics();
+    }, 3000);
+    return () => {
+      if (metricsIntervalRef.current !== null) {
+        clearInterval(metricsIntervalRef.current);
+        metricsIntervalRef.current = null;
+      }
+    };
+  }, [isAttached]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Subscribe to Tracing events
+  useEffect(() => {
+    if (!isAttached) return;
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'Tracing.dataCollected') {
+        const value = p.value as Array<Record<string, unknown>> | undefined;
+        if (!value) return;
+        console.log(PANEL_TAG, 'Tracing.dataCollected, events:', value.length);
+        setTraceEvents((prev) => [
+          ...prev,
+          ...value.map((ev) => ({
+            id: traceEventIdCounter++,
+            name: (ev.name as string) ?? '',
+            cat: (ev.cat as string) ?? '',
+            ph: (ev.ph as string) ?? '',
+            ts: (ev.ts as number) ?? 0,
+            dur: ev.dur as number | undefined,
+            pid: (ev.pid as number) ?? 0,
+            tid: (ev.tid as number) ?? 0,
+            args: ev.args as Record<string, unknown> | undefined,
+          })),
+        ]);
+      }
+
+      if (method === 'Tracing.tracingComplete') {
+        console.log(PANEL_TAG, 'Tracing.tracingComplete');
+        setIsRecording(false);
+      }
+    });
+
+    return unsubscribe;
+  }, [isAttached, onCdpEvent]);
+
+  const fetchMetrics = useCallback(async () => {
+    console.log(PANEL_TAG, 'fetching performance metrics');
+    try {
+      const r = await cdpSend('Performance.getMetrics');
+      const result = r.result as { metrics?: MetricEntry[] };
+      if (result?.metrics) {
+        const filtered = result.metrics.filter((m) => DISPLAY_METRICS.includes(m.name));
+        console.log(PANEL_TAG, 'got', filtered.length, 'metrics');
+        setMetrics(filtered);
+      }
+    } catch (err) {
+      console.error(PANEL_TAG, 'getMetrics failed:', err);
+    }
+  }, [cdpSend]);
+
+  const fetchWebVitals = useCallback(async () => {
+    setLoadingVitals(true);
+    console.log(PANEL_TAG, 'fetching Web Vitals via Runtime.evaluate');
+    try {
+      const expression = `(function() {
+        const entries = performance.getEntriesByType('paint');
+        const nav = performance.getEntriesByType('navigation')[0];
+        const lcp = performance.getEntriesByName ? null : null;
+        const result = {};
+        entries.forEach(e => {
+          if (e.name === 'first-contentful-paint') result.FCP = e.startTime;
+          if (e.name === 'first-paint') result.FP = e.startTime;
+        });
+        const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+        if (lcpEntries && lcpEntries.length > 0) {
+          result.LCP = lcpEntries[lcpEntries.length - 1].startTime;
+        }
+        const layoutShifts = performance.getEntriesByType('layout-shift');
+        if (layoutShifts && layoutShifts.length > 0) {
+          result.CLS = layoutShifts.reduce((sum, e) => sum + (e.value || 0), 0);
+        }
+        const fidEntries = performance.getEntriesByType('first-input');
+        if (fidEntries && fidEntries.length > 0) {
+          result.FID = fidEntries[0].processingStart - fidEntries[0].startTime;
+        }
+        return result;
+      })()`;
+
+      const r = await cdpSend('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: false });
+      const res = r.result as { result?: { value?: Record<string, number> }; exceptionDetails?: unknown };
+      if (res.result?.value) {
+        const vals = res.result.value;
+        console.log(PANEL_TAG, 'web vitals raw:', vals);
+        const vitals: WebVital[] = Object.entries(vals).map(([name, value]) => ({
+          name,
+          value: name === 'CLS' ? value.toFixed(4) : `${value.toFixed(1)} ms`,
+          rating: vitalRating(name, value),
+        }));
+        setWebVitals(vitals);
+      }
+    } catch (err) {
+      console.error(PANEL_TAG, 'fetchWebVitals failed:', err);
+    } finally {
+      setLoadingVitals(false);
+    }
+  }, [cdpSend]);
+
+  const handleTakeSnapshot = useCallback(async () => {
+    setLoadingMetrics(true);
+    console.log(PANEL_TAG, 'taking metrics snapshot');
+    try {
+      const r = await cdpSend('Performance.getMetrics');
+      const result = r.result as { metrics?: MetricEntry[] };
+      if (result?.metrics) {
+        const filtered = result.metrics.filter((m) => DISPLAY_METRICS.includes(m.name));
+        setSnapshot({ ts: Date.now(), metrics: filtered });
+        console.log(PANEL_TAG, 'snapshot taken with', filtered.length, 'metrics');
+      }
+    } catch (err) {
+      console.error(PANEL_TAG, 'snapshot failed:', err);
+    } finally {
+      setLoadingMetrics(false);
+    }
+  }, [cdpSend]);
+
+  const handleStartRecording = useCallback(async () => {
+    console.log(PANEL_TAG, 'starting Tracing session');
+    setTraceEvents([]);
+    setIsRecording(true);
+    try {
+      await cdpSend('Tracing.start', {
+        transferMode: 'ReportEvents',
+        traceConfig: {
+          recordMode: 'recordUntilFull',
+          includedCategories: ['devtools.timeline', 'v8', 'blink', 'cc'],
+        },
+      });
+      console.log(PANEL_TAG, 'Tracing.start OK');
+    } catch (err) {
+      console.error(PANEL_TAG, 'Tracing.start failed:', err);
+      setIsRecording(false);
+    }
+  }, [cdpSend]);
+
+  const handleStopRecording = useCallback(async () => {
+    console.log(PANEL_TAG, 'stopping Tracing session');
+    try {
+      await cdpSend('Tracing.end');
+      console.log(PANEL_TAG, 'Tracing.end OK, waiting for dataCollected events');
+    } catch (err) {
+      console.error(PANEL_TAG, 'Tracing.end failed:', err);
+      setIsRecording(false);
+    }
+  }, [cdpSend]);
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not connected</div>
+        <div className="panel-placeholder-desc">Attach to a tab to use the Performance panel.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', fontSize: 'var(--font-size-xs)' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          padding: 'var(--space-2) var(--space-4)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        {!isRecording ? (
+          <button onClick={() => void handleStartRecording()} style={actionBtnStyle}>
+            ● Record
+          </button>
+        ) : (
+          <button
+            onClick={() => void handleStopRecording()}
+            style={{ ...actionBtnStyle, background: 'var(--color-status-error)', color: '#fff' }}
+          >
+            ■ Stop
+          </button>
+        )}
+        <button onClick={() => void handleTakeSnapshot()} disabled={loadingMetrics} style={actionBtnStyle}>
+          {loadingMetrics ? 'Snapping...' : 'Take Snapshot'}
+        </button>
+        <button onClick={() => void fetchWebVitals()} disabled={loadingVitals} style={actionBtnStyle}>
+          {loadingVitals ? 'Loading...' : 'Load Web Vitals'}
+        </button>
+        <button onClick={() => void fetchMetrics()} style={secondaryBtnStyle}>
+          Refresh Metrics
+        </button>
+      </div>
+
+      {/* Main scrollable content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-4)', display: 'flex', flexDirection: 'column', gap: 'var(--space-6)' }}>
+
+        {/* Metrics Dashboard */}
+        <section>
+          <div style={sectionHeaderStyle}>Runtime Metrics</div>
+          {metrics.length === 0 ? (
+            <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>Loading metrics...</div>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 'var(--space-3)' }}>
+              {metrics.map((m) => (
+                <div key={m.name} style={metricCardStyle}>
+                  <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)', marginBottom: 'var(--space-1)' }}>{m.name}</div>
+                  <div style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)' }}>
+                    {formatMetricValue(m.name, m.value)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Web Vitals */}
+        {webVitals.length > 0 && (
+          <section>
+            <div style={sectionHeaderStyle}>Web Vitals</div>
+            <div style={{ display: 'flex', gap: 'var(--space-4)', flexWrap: 'wrap' }}>
+              {webVitals.map((v) => (
+                <div key={v.name} style={{ ...metricCardStyle, minWidth: '120px' }}>
+                  <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)', marginBottom: 'var(--space-1)' }}>{v.name}</div>
+                  <div style={{ color: RATING_COLORS[v.rating], fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)', fontSize: 'var(--font-size-sm)' }}>
+                    {v.value}
+                  </div>
+                  <div style={{ color: RATING_COLORS[v.rating], fontSize: 'var(--font-size-2xs)', marginTop: 'var(--space-1)' }}>
+                    {v.rating}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Snapshot */}
+        {snapshot && (
+          <section>
+            <div style={sectionHeaderStyle}>
+              Snapshot — {new Date(snapshot.ts).toLocaleTimeString()}
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 'var(--space-3)' }}>
+              {snapshot.metrics.map((m) => (
+                <div key={m.name} style={{ ...metricCardStyle, background: 'var(--color-bg-elevated)' }}>
+                  <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)', marginBottom: 'var(--space-1)' }}>{m.name}</div>
+                  <div style={{ color: 'var(--color-fg-primary)', fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-weight-semibold)' }}>
+                    {formatMetricValue(m.name, m.value)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Trace Events */}
+        {traceEvents.length > 0 && (
+          <section>
+            <div style={sectionHeaderStyle}>
+              Trace Events ({traceEvents.length})
+            </div>
+            <div style={{ overflowY: 'auto', maxHeight: '300px', border: '1px solid var(--color-border-subtle)', borderRadius: 'var(--radius-sm)' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--font-size-2xs)', fontFamily: 'var(--font-mono)' }}>
+                <thead>
+                  <tr style={{ background: 'var(--color-bg-elevated)', position: 'sticky', top: 0 }}>
+                    <th style={thStyle}>Name</th>
+                    <th style={thStyle}>Cat</th>
+                    <th style={thStyle}>Ph</th>
+                    <th style={thStyle}>ts (μs)</th>
+                    <th style={thStyle}>dur (μs)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {traceEvents.slice(0, 500).map((ev) => (
+                    <tr key={ev.id} style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+                      <td style={tdStyle}>{ev.name}</td>
+                      <td style={{ ...tdStyle, color: 'var(--color-fg-tertiary)' }}>{ev.cat}</td>
+                      <td style={{ ...tdStyle, color: 'var(--color-accent-default)' }}>{ev.ph}</td>
+                      <td style={tdStyle}>{ev.ts}</td>
+                      <td style={tdStyle}>{ev.dur ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {traceEvents.length > 500 && (
+                <div style={{ padding: 'var(--space-2) var(--space-4)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+                  Showing first 500 of {traceEvents.length} events
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {isRecording && traceEvents.length === 0 && (
+          <section>
+            <div style={{ color: 'var(--color-status-warning)', fontSize: 'var(--font-size-2xs)', display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <span>●</span> Recording... interact with the page, then click Stop.
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Shared styles ---------------------------------------------------------
+
+const actionBtnStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-4)',
+  background: 'var(--color-accent-default)',
+  color: 'var(--color-fg-inverse)',
+  borderRadius: 'var(--radius-sm)',
+  fontSize: 'var(--font-size-xs)',
+  fontWeight: 'var(--font-weight-medium)',
+  cursor: 'pointer',
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-3)',
+  background: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-subtle)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--color-fg-primary)',
+  fontSize: 'var(--font-size-xs)',
+  cursor: 'pointer',
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+  fontSize: 'var(--font-size-2xs)',
+  fontWeight: 'var(--font-weight-semibold)',
+  color: 'var(--color-fg-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginBottom: 'var(--space-3)',
+};
+
+const metricCardStyle: React.CSSProperties = {
+  background: 'var(--color-bg-sunken)',
+  border: '1px solid var(--color-border-subtle)',
+  borderRadius: 'var(--radius-sm)',
+  padding: 'var(--space-3)',
+};
+
+const thStyle: React.CSSProperties = {
+  padding: 'var(--space-2) var(--space-3)',
+  textAlign: 'left',
+  fontWeight: 'var(--font-weight-medium)',
+  color: 'var(--color-fg-secondary)',
+  borderBottom: '1px solid var(--color-border-default)',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-3)',
+  color: 'var(--color-fg-primary)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '200px',
+};

--- a/my-app/src/renderer/devtools/panels/PlaceholderPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/PlaceholderPanel.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface PlaceholderPanelProps {
+  name: string;
+  description: string;
+}
+
+export function PlaceholderPanel({ name, description }: PlaceholderPanelProps): React.ReactElement {
+  return (
+    <div className="panel-placeholder">
+      <div className="panel-placeholder-icon">🔧</div>
+      <div className="panel-placeholder-title">{name}</div>
+      <div className="panel-placeholder-desc">
+        {description || `The ${name} panel is not yet implemented.`}
+      </div>
+      <div className="panel-placeholder-desc" style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+        Coming soon
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/RecorderPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/RecorderPanel.tsx
@@ -185,12 +185,15 @@ export function RecorderPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): 
 
   // Poll for click/input events from the page
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingInProgressRef = useRef(false);
   const lastClickTsRef = useRef<number>(0);
   const lastInputTsRef = useRef<number>(0);
   const lastKeyTsRef = useRef<number>(0);
   const lastScrollTsRef = useRef<number>(0);
 
   const pollPageEvents = useCallback(async () => {
+    if (pollingInProgressRef.current) return;
+    pollingInProgressRef.current = true;
     try {
       const clickResp = await cdpSend('Runtime.evaluate', {
         expression: 'window.__recorder_last_click__ ? JSON.stringify(window.__recorder_last_click__) : null',
@@ -282,6 +285,8 @@ export function RecorderPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): 
       }
     } catch {
       // Page may have navigated — silently ignore
+    } finally {
+      pollingInProgressRef.current = false;
     }
   }, [cdpSend]);
 
@@ -298,10 +303,10 @@ export function RecorderPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): 
       console.log('[RecorderPanel] DOM + Page domains enabled');
 
       recordingStartRef.current = Date.now();
-      lastClickTsRef.current = 0;
-      lastInputTsRef.current = 0;
-      lastKeyTsRef.current = 0;
-      lastScrollTsRef.current = 0;
+      lastClickTsRef.current = recordingStartRef.current;
+      lastInputTsRef.current = recordingStartRef.current;
+      lastKeyTsRef.current = recordingStartRef.current;
+      lastScrollTsRef.current = recordingStartRef.current;
 
       setIsRecording(true);
       startListening();

--- a/my-app/src/renderer/devtools/panels/RecorderPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/RecorderPanel.tsx
@@ -1,0 +1,760 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+type StepType = 'navigate' | 'click' | 'type' | 'wait' | 'scroll' | 'keypress';
+
+interface RecordedStep {
+  id: string;
+  type: StepType;
+  target?: string;
+  value?: string;
+  timestamp: number;
+  elapsedMs: number;
+}
+
+const STEP_ICONS: Record<StepType, string> = {
+  navigate: '⇢',
+  click: '◎',
+  type: '⌨',
+  wait: '◔',
+  scroll: '↕',
+  keypress: '⌥',
+};
+
+const STEP_COLOR: Record<StepType, string> = {
+  navigate: '#7cacf8',
+  click: '#4ade80',
+  type: '#f7c948',
+  wait: 'var(--color-fg-tertiary)',
+  scroll: '#c792ea',
+  keypress: '#f87171',
+};
+
+let stepIdCounter = 0;
+
+function generateStepId(): string {
+  return `step-${Date.now()}-${stepIdCounter++}`;
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? str.slice(0, max) + '…' : str;
+}
+
+export function RecorderPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [isRecording, setIsRecording] = useState(false);
+  const [steps, setSteps] = useState<RecordedStep[]>([]);
+  const [replaying, setReplaying] = useState(false);
+  const [replayIndex, setReplayIndex] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  const recordingStartRef = useRef<number>(0);
+  const elapsedIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const listenerActiveRef = useRef(false);
+
+  // ── elapsed timer ─────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (isRecording) {
+      elapsedIntervalRef.current = setInterval(() => {
+        setElapsed(Date.now() - recordingStartRef.current);
+      }, 100);
+    } else {
+      if (elapsedIntervalRef.current) {
+        clearInterval(elapsedIntervalRef.current);
+        elapsedIntervalRef.current = null;
+      }
+    }
+    return () => {
+      if (elapsedIntervalRef.current) {
+        clearInterval(elapsedIntervalRef.current);
+      }
+    };
+  }, [isRecording]);
+
+  // ── CDP event listener for recording ─────────────────────────────────────
+
+  const startListening = useCallback(() => {
+    if (listenerActiveRef.current) return;
+    listenerActiveRef.current = true;
+
+    console.log('[RecorderPanel] subscribing to CDP events for recording');
+    const unsubscribe = onCdpEvent((method, params) => {
+      if (!listenerActiveRef.current) return;
+      const p = params as Record<string, unknown>;
+      const now = Date.now();
+      const elapsed = now - recordingStartRef.current;
+
+      if (method === 'Page.frameNavigated') {
+        const frame = p.frame as Record<string, unknown> | undefined;
+        const url = (frame?.url as string) ?? '';
+        console.log('[RecorderPanel] Page.frameNavigated:', url);
+
+        setSteps((prev) => [
+          ...prev,
+          {
+            id: generateStepId(),
+            type: 'navigate',
+            value: url,
+            timestamp: now,
+            elapsedMs: elapsed,
+          },
+        ]);
+      }
+    });
+
+    unsubscribeRef.current = unsubscribe;
+  }, [onCdpEvent]);
+
+  const stopListening = useCallback(() => {
+    listenerActiveRef.current = false;
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    console.log('[RecorderPanel] unsubscribed from CDP events');
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopListening();
+    };
+  }, [stopListening]);
+
+  // ── inject DOM listeners into the page via Runtime.evaluate ───────────────
+
+  const injectPageListeners = useCallback(async () => {
+    console.log('[RecorderPanel] injecting page-side event listeners');
+
+    const injectionScript = `
+      (function() {
+        if (window.__recorderInjected__) return;
+        window.__recorderInjected__ = true;
+
+        function getSelector(el) {
+          if (!el || el === document.body) return 'body';
+          if (el.id) return '#' + el.id;
+          const tag = el.tagName.toLowerCase();
+          const cls = Array.from(el.classList).slice(0, 2).join('.');
+          return cls ? tag + '.' + cls : tag;
+        }
+
+        document.addEventListener('click', function(e) {
+          const sel = getSelector(e.target);
+          window.__recorder_last_click__ = { selector: sel, ts: Date.now() };
+          console.debug('[Recorder:click]', sel);
+        }, true);
+
+        document.addEventListener('input', function(e) {
+          const sel = getSelector(e.target);
+          const val = e.target.value;
+          window.__recorder_last_input__ = { selector: sel, value: val, ts: Date.now() };
+          console.debug('[Recorder:input]', sel, val);
+        }, true);
+
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter' || e.key === 'Tab' || e.key === 'Escape') {
+            window.__recorder_last_key__ = { key: e.key, ts: Date.now() };
+            console.debug('[Recorder:keydown]', e.key);
+          }
+        }, true);
+
+        document.addEventListener('scroll', function(e) {
+          window.__recorder_last_scroll__ = { x: window.scrollX, y: window.scrollY, ts: Date.now() };
+        }, { passive: true, capture: true });
+      })();
+    `;
+
+    try {
+      await cdpSend('Runtime.evaluate', { expression: injectionScript });
+      console.log('[RecorderPanel] page listeners injected');
+    } catch (err) {
+      console.warn('[RecorderPanel] injectPageListeners failed:', err);
+    }
+  }, [cdpSend]);
+
+  // Poll for click/input events from the page
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastClickTsRef = useRef<number>(0);
+  const lastInputTsRef = useRef<number>(0);
+  const lastKeyTsRef = useRef<number>(0);
+  const lastScrollTsRef = useRef<number>(0);
+
+  const pollPageEvents = useCallback(async () => {
+    try {
+      const clickResp = await cdpSend('Runtime.evaluate', {
+        expression: 'window.__recorder_last_click__ ? JSON.stringify(window.__recorder_last_click__) : null',
+        returnByValue: true,
+      });
+      const clickJson = (clickResp.result as any)?.result?.value as string | null;
+      if (clickJson) {
+        const click = JSON.parse(clickJson) as { selector: string; ts: number };
+        if (click.ts > lastClickTsRef.current) {
+          lastClickTsRef.current = click.ts;
+          const elapsed = click.ts - recordingStartRef.current;
+          console.log('[RecorderPanel] captured click:', click.selector);
+          setSteps((prev) => [
+            ...prev,
+            { id: generateStepId(), type: 'click', target: click.selector, timestamp: click.ts, elapsedMs: elapsed },
+          ]);
+        }
+      }
+
+      const inputResp = await cdpSend('Runtime.evaluate', {
+        expression: 'window.__recorder_last_input__ ? JSON.stringify(window.__recorder_last_input__) : null',
+        returnByValue: true,
+      });
+      const inputJson = (inputResp.result as any)?.result?.value as string | null;
+      if (inputJson) {
+        const input = JSON.parse(inputJson) as { selector: string; value: string; ts: number };
+        if (input.ts > lastInputTsRef.current) {
+          lastInputTsRef.current = input.ts;
+          const elapsed = input.ts - recordingStartRef.current;
+          console.log('[RecorderPanel] captured input:', input.selector, 'value:', input.value);
+          setSteps((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.type === 'type' && last.target === input.selector) {
+              return [
+                ...prev.slice(0, -1),
+                { ...last, value: input.value, timestamp: input.ts, elapsedMs: elapsed },
+              ];
+            }
+            return [
+              ...prev,
+              { id: generateStepId(), type: 'type', target: input.selector, value: input.value, timestamp: input.ts, elapsedMs: elapsed },
+            ];
+          });
+        }
+      }
+
+      const keyResp = await cdpSend('Runtime.evaluate', {
+        expression: 'window.__recorder_last_key__ ? JSON.stringify(window.__recorder_last_key__) : null',
+        returnByValue: true,
+      });
+      const keyJson = (keyResp.result as any)?.result?.value as string | null;
+      if (keyJson) {
+        const key = JSON.parse(keyJson) as { key: string; ts: number };
+        if (key.ts > lastKeyTsRef.current) {
+          lastKeyTsRef.current = key.ts;
+          const elapsed = key.ts - recordingStartRef.current;
+          console.log('[RecorderPanel] captured keypress:', key.key);
+          setSteps((prev) => [
+            ...prev,
+            { id: generateStepId(), type: 'keypress', value: key.key, timestamp: key.ts, elapsedMs: elapsed },
+          ]);
+        }
+      }
+
+      const scrollResp = await cdpSend('Runtime.evaluate', {
+        expression: 'window.__recorder_last_scroll__ ? JSON.stringify(window.__recorder_last_scroll__) : null',
+        returnByValue: true,
+      });
+      const scrollJson = (scrollResp.result as any)?.result?.value as string | null;
+      if (scrollJson) {
+        const scroll = JSON.parse(scrollJson) as { x: number; y: number; ts: number };
+        if (scroll.ts > lastScrollTsRef.current) {
+          lastScrollTsRef.current = scroll.ts;
+          const elapsed = scroll.ts - recordingStartRef.current;
+          setSteps((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.type === 'scroll') {
+              return [
+                ...prev.slice(0, -1),
+                { ...last, value: `${scroll.x},${scroll.y}`, timestamp: scroll.ts, elapsedMs: elapsed },
+              ];
+            }
+            return [
+              ...prev,
+              { id: generateStepId(), type: 'scroll', value: `${scroll.x},${scroll.y}`, timestamp: scroll.ts, elapsedMs: elapsed },
+            ];
+          });
+        }
+      }
+    } catch {
+      // Page may have navigated — silently ignore
+    }
+  }, [cdpSend]);
+
+  // ── start / stop recording ────────────────────────────────────────────────
+
+  const startRecording = useCallback(async () => {
+    if (!isAttached) return;
+    console.log('[RecorderPanel] starting recording');
+    setError(null);
+
+    try {
+      await cdpSend('DOM.enable');
+      await cdpSend('Page.enable');
+      console.log('[RecorderPanel] DOM + Page domains enabled');
+
+      recordingStartRef.current = Date.now();
+      lastClickTsRef.current = 0;
+      lastInputTsRef.current = 0;
+      lastKeyTsRef.current = 0;
+      lastScrollTsRef.current = 0;
+
+      setIsRecording(true);
+      startListening();
+      await injectPageListeners();
+
+      pollingIntervalRef.current = setInterval(() => {
+        void pollPageEvents();
+      }, 500);
+    } catch (err) {
+      console.error('[RecorderPanel] startRecording failed:', err);
+      setError(String(err));
+    }
+  }, [isAttached, cdpSend, startListening, injectPageListeners, pollPageEvents]);
+
+  const stopRecording = useCallback(() => {
+    console.log('[RecorderPanel] stopping recording');
+    setIsRecording(false);
+    stopListening();
+
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+
+    void cdpSend('DOM.disable').catch(() => {});
+    void cdpSend('Page.disable').catch(() => {});
+  }, [cdpSend, stopListening]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+      }
+    };
+  }, []);
+
+  // ── replay ─────────────────────────────────────────────────────────────────
+
+  const replaySteps = useCallback(async () => {
+    if (steps.length === 0 || replaying) return;
+    console.log('[RecorderPanel] starting replay of', steps.length, 'steps');
+    setReplaying(true);
+    setError(null);
+
+    try {
+      for (let i = 0; i < steps.length; i++) {
+        const step = steps[i];
+        setReplayIndex(i);
+        console.log('[RecorderPanel] replaying step', i, step.type, step.target ?? step.value ?? '');
+
+        switch (step.type) {
+          case 'navigate': {
+            const url = step.value ?? '';
+            if (url) {
+              const resp = await cdpSend('Page.navigate', { url });
+              if (!resp.success) console.warn('[RecorderPanel] Page.navigate failed:', resp.error);
+              // Wait for load
+              await new Promise((res) => setTimeout(res, 1500));
+              // Re-inject listeners after navigation
+              await injectPageListeners();
+            }
+            break;
+          }
+
+          case 'click': {
+            const selector = step.target ?? '';
+            if (selector) {
+              // Use Runtime.evaluate to click the element
+              const resp = await cdpSend('Runtime.evaluate', {
+                expression: `
+                  (function() {
+                    const el = document.querySelector(${JSON.stringify(selector)});
+                    if (el) {
+                      el.click();
+                      return true;
+                    }
+                    return false;
+                  })()
+                `,
+                returnByValue: true,
+              });
+              const clicked = (resp.result as any)?.result?.value as boolean;
+              console.log('[RecorderPanel] click replay result:', clicked, 'for selector:', selector);
+            }
+            break;
+          }
+
+          case 'type': {
+            const selector = step.target ?? '';
+            const value = step.value ?? '';
+            if (selector && value) {
+              await cdpSend('Runtime.evaluate', {
+                expression: `
+                  (function() {
+                    const el = document.querySelector(${JSON.stringify(selector)});
+                    if (el) {
+                      el.focus();
+                      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+                      if (nativeInputValueSetter) {
+                        nativeInputValueSetter.call(el, ${JSON.stringify(value)});
+                        el.dispatchEvent(new Event('input', { bubbles: true }));
+                        el.dispatchEvent(new Event('change', { bubbles: true }));
+                      } else {
+                        el.value = ${JSON.stringify(value)};
+                      }
+                      return true;
+                    }
+                    return false;
+                  })()
+                `,
+                returnByValue: true,
+              });
+              console.log('[RecorderPanel] type replay done for selector:', selector);
+            }
+            break;
+          }
+
+          case 'keypress': {
+            const key = step.value ?? '';
+            if (key) {
+              await cdpSend('Input.dispatchKeyEvent', {
+                type: 'keyDown',
+                key,
+                code: key === 'Enter' ? 'Enter' : key === 'Tab' ? 'Tab' : key === 'Escape' ? 'Escape' : key,
+                windowsVirtualKeyCode: key === 'Enter' ? 13 : key === 'Tab' ? 9 : key === 'Escape' ? 27 : 0,
+              });
+              await cdpSend('Input.dispatchKeyEvent', {
+                type: 'keyUp',
+                key,
+                code: key === 'Enter' ? 'Enter' : key === 'Tab' ? 'Tab' : key === 'Escape' ? 'Escape' : key,
+                windowsVirtualKeyCode: key === 'Enter' ? 13 : key === 'Tab' ? 9 : key === 'Escape' ? 27 : 0,
+              });
+              console.log('[RecorderPanel] keypress replay done:', key);
+            }
+            break;
+          }
+
+          case 'scroll': {
+            const parts = (step.value ?? '0,0').split(',');
+            const x = parseInt(parts[0] ?? '0', 10);
+            const y = parseInt(parts[1] ?? '0', 10);
+            await cdpSend('Runtime.evaluate', { expression: `window.scrollTo(${x}, ${y})` });
+            console.log('[RecorderPanel] scroll replay done:', x, y);
+            break;
+          }
+
+          case 'wait':
+            await new Promise((res) => setTimeout(res, parseInt(step.value ?? '500', 10)));
+            break;
+        }
+
+        // Small delay between steps
+        await new Promise((res) => setTimeout(res, 200));
+      }
+
+      console.log('[RecorderPanel] replay complete');
+    } catch (err) {
+      console.error('[RecorderPanel] replay failed:', err);
+      setError(String(err));
+    } finally {
+      setReplaying(false);
+      setReplayIndex(null);
+    }
+  }, [steps, replaying, cdpSend, injectPageListeners]);
+
+  // ── export ────────────────────────────────────────────────────────────────
+
+  const exportRecording = useCallback(() => {
+    console.log('[RecorderPanel] exporting recording as JSON');
+    const data = JSON.stringify({ version: 1, steps, exportedAt: new Date().toISOString() }, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `recording-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [steps]);
+
+  // ── step management ────────────────────────────────────────────────────────
+
+  const deleteStep = useCallback((id: string) => {
+    console.log('[RecorderPanel] deleting step:', id);
+    setSteps((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const moveStep = useCallback((id: string, direction: 'up' | 'down') => {
+    console.log('[RecorderPanel] moving step', id, direction);
+    setSteps((prev) => {
+      const idx = prev.findIndex((s) => s.id === id);
+      if (idx < 0) return prev;
+      const next = [...prev];
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (swapIdx < 0 || swapIdx >= next.length) return prev;
+      [next[idx], next[swapIdx]] = [next[swapIdx]!, next[idx]!];
+      return next;
+    });
+  }, []);
+
+  const clearSteps = useCallback(() => {
+    console.log('[RecorderPanel] clearing all steps');
+    setSteps([]);
+    setError(null);
+  }, []);
+
+  // ── render ────────────────────────────────────────────────────────────────
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not attached</div>
+        <div className="panel-placeholder-desc">Attach to a tab to start recording user flows.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          padding: 'var(--space-2) var(--space-4)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          flexShrink: 0,
+          backgroundColor: 'var(--color-bg-elevated)',
+        }}
+      >
+        {!isRecording ? (
+          <button
+            className="devtools-connect-btn"
+            onClick={() => void startRecording()}
+            disabled={replaying}
+            style={{
+              padding: 'var(--space-2) var(--space-5)',
+              fontSize: 'var(--font-size-xs)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+            }}
+          >
+            <span style={{ color: 'var(--color-status-error)', fontSize: '10px' }}>●</span>
+            Start Recording
+          </button>
+        ) : (
+          <button
+            onClick={stopRecording}
+            style={{
+              padding: 'var(--space-2) var(--space-5)',
+              fontSize: 'var(--font-size-xs)',
+              fontWeight: 'var(--font-weight-semibold)',
+              color: 'var(--color-status-error)',
+              border: '1px solid var(--color-status-error)',
+              borderRadius: 'var(--radius-md)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+              cursor: 'pointer',
+            }}
+          >
+            <span style={{ fontSize: '10px' }}>■</span>
+            Stop Recording
+          </button>
+        )}
+
+        {steps.length > 0 && (
+          <>
+            <button
+              className="devtools-connect-btn"
+              onClick={() => void replaySteps()}
+              disabled={replaying || isRecording}
+              style={{ padding: 'var(--space-2) var(--space-5)', fontSize: 'var(--font-size-xs)' }}
+            >
+              {replaying ? 'Replaying...' : 'Replay'}
+            </button>
+            <button className="console-clear-btn" onClick={exportRecording} disabled={isRecording || replaying}>
+              Export
+            </button>
+            <button className="console-clear-btn" onClick={clearSteps} disabled={isRecording || replaying}>
+              Clear
+            </button>
+          </>
+        )}
+
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 'var(--space-4)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)', fontFamily: 'var(--font-mono)' }}>
+          {isRecording && (
+            <span style={{ color: 'var(--color-status-error)' }}>
+              ● {formatElapsed(elapsed)}
+            </span>
+          )}
+          <span>{steps.length} step{steps.length !== 1 ? 's' : ''}</span>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div style={{ padding: 'var(--space-3) var(--space-4)', color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)', fontFamily: 'var(--font-mono)', borderBottom: '1px solid var(--color-border-subtle)', flexShrink: 0 }}>
+          {error}
+        </div>
+      )}
+
+      {/* Recording indicator */}
+      {isRecording && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-2)',
+            padding: 'var(--space-2) var(--space-4)',
+            backgroundColor: 'rgba(248, 113, 113, 0.08)',
+            borderBottom: '1px solid rgba(248, 113, 113, 0.2)',
+            flexShrink: 0,
+            fontSize: 'var(--font-size-xs)',
+            color: 'var(--color-status-error)',
+          }}
+        >
+          <span style={{ animation: 'none' }}>●</span>
+          Recording in progress — interact with the page to capture steps
+        </div>
+      )}
+
+      {/* Steps list */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {steps.length === 0 ? (
+          <div className="panel-placeholder" style={{ height: '300px' }}>
+            <div className="panel-placeholder-icon">●</div>
+            <div className="panel-placeholder-title">No steps recorded</div>
+            <div className="panel-placeholder-desc">
+              Click "Start Recording" then interact with the page. Navigation, clicks, and typing will be captured.
+            </div>
+          </div>
+        ) : (
+          steps.map((step, i) => (
+            <div
+              key={step.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 'var(--space-3)',
+                padding: 'var(--space-2) var(--space-4)',
+                borderBottom: '1px solid var(--color-border-subtle)',
+                backgroundColor: replayIndex === i ? 'var(--color-accent-muted)' : 'transparent',
+              }}
+            >
+              {/* Step number */}
+              <span
+                style={{
+                  flexShrink: 0,
+                  width: '24px',
+                  textAlign: 'right',
+                  fontSize: 'var(--font-size-2xs)',
+                  color: 'var(--color-fg-tertiary)',
+                  fontFamily: 'var(--font-mono)',
+                  paddingTop: '1px',
+                }}
+              >
+                {i + 1}
+              </span>
+
+              {/* Step icon */}
+              <span
+                style={{
+                  flexShrink: 0,
+                  fontSize: 'var(--font-size-sm)',
+                  color: STEP_COLOR[step.type],
+                  width: '20px',
+                  textAlign: 'center',
+                }}
+              >
+                {STEP_ICONS[step.type]}
+              </span>
+
+              {/* Step content */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+                  <span
+                    style={{
+                      fontSize: 'var(--font-size-2xs)',
+                      fontWeight: 'var(--font-weight-semibold)',
+                      color: STEP_COLOR[step.type],
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                    }}
+                  >
+                    {step.type}
+                  </span>
+                  {step.target && (
+                    <span
+                      style={{
+                        fontSize: 'var(--font-size-xs)',
+                        fontFamily: 'var(--font-mono)',
+                        color: '#c792ea',
+                      }}
+                    >
+                      {truncate(step.target, 60)}
+                    </span>
+                  )}
+                </div>
+                {step.value && (
+                  <div
+                    style={{
+                      marginTop: 'var(--space-1)',
+                      fontSize: 'var(--font-size-xs)',
+                      fontFamily: 'var(--font-mono)',
+                      color: 'var(--color-fg-secondary)',
+                      wordBreak: 'break-all',
+                    }}
+                  >
+                    {truncate(step.value, 120)}
+                  </div>
+                )}
+                <div style={{ marginTop: 'var(--space-1)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-tertiary)', fontFamily: 'var(--font-mono)' }}>
+                  +{formatElapsed(step.elapsedMs)}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div style={{ display: 'flex', gap: 'var(--space-1)', flexShrink: 0 }}>
+                <button
+                  className="console-clear-btn"
+                  onClick={() => moveStep(step.id, 'up')}
+                  disabled={i === 0 || replaying}
+                  style={{ padding: 'var(--space-1) var(--space-2)', fontSize: 'var(--font-size-2xs)' }}
+                  title="Move up"
+                >
+                  ↑
+                </button>
+                <button
+                  className="console-clear-btn"
+                  onClick={() => moveStep(step.id, 'down')}
+                  disabled={i === steps.length - 1 || replaying}
+                  style={{ padding: 'var(--space-1) var(--space-2)', fontSize: 'var(--font-size-2xs)' }}
+                  title="Move down"
+                >
+                  ↓
+                </button>
+                <button
+                  className="console-clear-btn"
+                  onClick={() => deleteStep(step.id)}
+                  disabled={replaying || isRecording}
+                  style={{ padding: 'var(--space-1) var(--space-2)', fontSize: 'var(--font-size-2xs)', color: 'var(--color-status-error)' }}
+                  title="Delete step"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/SecurityPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/SecurityPanel.tsx
@@ -103,7 +103,7 @@ export function SecurityPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): 
   const fetchIsolationStatus = useCallback(async () => {
     console.log('[SecurityPanel] fetching Network.getSecurityIsolationStatus');
     try {
-      const resp = await cdpSend('Network.getSecurityIsolationStatus', { frameId: null as unknown as undefined });
+      const resp = await cdpSend('Network.getSecurityIsolationStatus', {});
       if (resp.success && resp.result) {
         const status = resp.result as Record<string, unknown>;
         console.log('[SecurityPanel] isolation status:', status);

--- a/my-app/src/renderer/devtools/panels/SecurityPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/SecurityPanel.tsx
@@ -1,0 +1,460 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+type SecurityState = 'secure' | 'neutral' | 'insecure' | 'info' | 'unknown';
+
+interface ConnectionInfo {
+  protocol: string;
+  cipher: string;
+  keyExchange: string;
+  certificateId?: number;
+}
+
+interface CertificateInfo {
+  subject: string;
+  issuer: string;
+  validFrom: string;
+  validTo: string;
+  subjectAlternativeNames: string[];
+}
+
+interface MixedContentStatus {
+  displayedMixedContent: boolean;
+  ranMixedContent: boolean;
+  displayedMixedContentType?: string;
+  ranMixedContentType?: string;
+}
+
+interface SecurityDetails {
+  state: SecurityState;
+  connection: ConnectionInfo | null;
+  certificate: CertificateInfo | null;
+  mixedContent: MixedContentStatus | null;
+  explanations: Array<{ securityState: string; title: string; description: string; hasCert: boolean }>;
+}
+
+const SECURITY_STATE_COLOR: Record<SecurityState, string> = {
+  secure: 'var(--color-status-success)',
+  neutral: 'var(--color-fg-secondary)',
+  insecure: 'var(--color-status-error)',
+  info: 'var(--color-status-warning)',
+  unknown: 'var(--color-fg-tertiary)',
+};
+
+const SECURITY_STATE_ICON: Record<SecurityState, string> = {
+  secure: '⊡',
+  neutral: '◯',
+  insecure: '⊗',
+  info: '⊙',
+  unknown: '◌',
+};
+
+const SECTION_HEADER_STYLE: React.CSSProperties = {
+  fontSize: 'var(--font-size-xs)',
+  fontWeight: 'var(--font-weight-semibold)',
+  color: 'var(--color-fg-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginBottom: 'var(--space-3)',
+  paddingBottom: 'var(--space-2)',
+  borderBottom: '1px solid var(--color-border-subtle)',
+};
+
+const FIELD_ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: 'var(--space-4)',
+  padding: 'var(--space-2) 0',
+  borderBottom: '1px solid var(--color-border-subtle)',
+  fontSize: 'var(--font-size-xs)',
+};
+
+const FIELD_LABEL_STYLE: React.CSSProperties = {
+  width: '160px',
+  flexShrink: 0,
+  color: 'var(--color-fg-tertiary)',
+  fontFamily: 'var(--font-mono)',
+};
+
+const FIELD_VALUE_STYLE: React.CSSProperties = {
+  flex: 1,
+  color: 'var(--color-fg-primary)',
+  fontFamily: 'var(--font-mono)',
+  wordBreak: 'break-all',
+};
+
+export function SecurityPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [securityDetails, setSecurityDetails] = useState<SecurityDetails>({
+    state: 'unknown',
+    connection: null,
+    certificate: null,
+    mixedContent: null,
+    explanations: [],
+  });
+  const [isolationStatus, setIsolationStatus] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchIsolationStatus = useCallback(async () => {
+    console.log('[SecurityPanel] fetching Network.getSecurityIsolationStatus');
+    try {
+      const resp = await cdpSend('Network.getSecurityIsolationStatus', { frameId: null as unknown as undefined });
+      if (resp.success && resp.result) {
+        const status = resp.result as Record<string, unknown>;
+        console.log('[SecurityPanel] isolation status:', status);
+        setIsolationStatus(status);
+      }
+    } catch (err) {
+      console.warn('[SecurityPanel] getSecurityIsolationStatus failed (may not be supported):', err);
+    }
+  }, [cdpSend]);
+
+  useEffect(() => {
+    if (!isAttached) return;
+
+    console.log('[SecurityPanel] enabling Security domain');
+    setLoading(true);
+    setError(null);
+
+    void (async () => {
+      try {
+        const resp = await cdpSend('Security.enable');
+        if (!resp.success) throw new Error(resp.error ?? 'Security.enable failed');
+        console.log('[SecurityPanel] Security domain enabled');
+        await fetchIsolationStatus();
+      } catch (err) {
+        console.error('[SecurityPanel] enable failed:', err);
+        setError(String(err));
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'Security.securityStateChanged') {
+        console.log('[SecurityPanel] Security.securityStateChanged:', p);
+
+        const rawState = (p.securityState as string) ?? 'unknown';
+        const state: SecurityState = (
+          ['secure', 'neutral', 'insecure', 'info'].includes(rawState) ? rawState : 'unknown'
+        ) as SecurityState;
+
+        const explanations = (p.explanations as Array<{ securityState: string; title: string; description: string; hasCert: boolean }>) ?? [];
+
+        // Extract connection details from explanations and summary
+        const summary = p.summary as string | undefined;
+        console.log('[SecurityPanel] security summary:', summary, 'state:', state);
+
+        setSecurityDetails((prev) => ({
+          ...prev,
+          state,
+          explanations,
+        }));
+      }
+
+      if (method === 'Network.responseReceivedExtraInfo') {
+        // Extract headers that may carry security info
+        const headers = p.headers as Record<string, string> | undefined;
+        console.log('[SecurityPanel] Network.responseReceivedExtraInfo headers available:', !!headers);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      console.log('[SecurityPanel] cleanup: disabling Security domain');
+      void cdpSend('Security.disable').catch(() => {});
+    };
+  }, [isAttached, cdpSend, onCdpEvent, fetchIsolationStatus]);
+
+  // Listen for Network events to collect TLS info
+  useEffect(() => {
+    if (!isAttached) return;
+
+    void cdpSend('Network.enable').catch(() => {});
+
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'Network.responseReceived') {
+        const response = p.response as Record<string, unknown> | undefined;
+        if (!response) return;
+
+        const securityDetails = response.securityDetails as Record<string, unknown> | undefined;
+        if (!securityDetails) return;
+
+        console.log('[SecurityPanel] Network.responseReceived securityDetails:', securityDetails);
+
+        const protocol = (securityDetails.protocol as string) ?? '';
+        const cipher = (securityDetails.cipher as string) ?? '';
+        const keyExchange = (securityDetails.keyExchange as string) ?? '';
+        const certificateId = securityDetails.certificateId as number | undefined;
+
+        const subject = (securityDetails.subjectName as string) ?? '';
+        const issuer = (securityDetails.issuer as string) ?? '';
+        const validFrom = securityDetails.validFrom !== undefined
+          ? new Date((securityDetails.validFrom as number) * 1000).toLocaleDateString()
+          : '';
+        const validTo = securityDetails.validTo !== undefined
+          ? new Date((securityDetails.validTo as number) * 1000).toLocaleDateString()
+          : '';
+        const sans = (securityDetails.sanList as string[]) ?? [];
+
+        setSecurityDetails((prev) => ({
+          ...prev,
+          connection: { protocol, cipher, keyExchange, certificateId },
+          certificate: { subject, issuer, validFrom, validTo, subjectAlternativeNames: sans },
+        }));
+      }
+
+      if (method === 'Security.visibleSecurityStateChanged') {
+        console.log('[SecurityPanel] Security.visibleSecurityStateChanged:', p);
+        const visibleState = p.visibleSecurityState as Record<string, unknown> | undefined;
+        if (!visibleState) return;
+
+        const rawState = (visibleState.securityState as string) ?? 'unknown';
+        const state: SecurityState = (
+          ['secure', 'neutral', 'insecure', 'info'].includes(rawState) ? rawState : 'unknown'
+        ) as SecurityState;
+
+        const secDetails = visibleState.securityStateIssueIds as string[] | undefined;
+
+        const mixedContentInfo = visibleState.certificateSecurityState as Record<string, unknown> | undefined;
+        if (mixedContentInfo) {
+          const protocol = (mixedContentInfo.protocol as string) ?? '';
+          const cipher = (mixedContentInfo.cipher as string) ?? '';
+          const keyExchange = (mixedContentInfo.keyExchange as string) ?? '';
+
+          const subject = (mixedContentInfo.subjectName as string) ?? '';
+          const issuer = (mixedContentInfo.issuer as string) ?? '';
+          const validFrom = mixedContentInfo.validFrom !== undefined
+            ? new Date((mixedContentInfo.validFrom as number) * 1000).toLocaleDateString()
+            : '';
+          const validTo = mixedContentInfo.validTo !== undefined
+            ? new Date((mixedContentInfo.validTo as number) * 1000).toLocaleDateString()
+            : '';
+          const sans = (mixedContentInfo.sanList as string[]) ?? [];
+
+          setSecurityDetails((prev) => ({
+            ...prev,
+            state,
+            connection: { protocol, cipher, keyExchange },
+            certificate: { subject, issuer, validFrom, validTo, subjectAlternativeNames: sans },
+            mixedContent: {
+              displayedMixedContent: secDetails?.includes('displayed-mixed-content') ?? false,
+              ranMixedContent: secDetails?.includes('ran-mixed-content') ?? false,
+            },
+          }));
+        } else {
+          setSecurityDetails((prev) => ({ ...prev, state }));
+        }
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [isAttached, cdpSend, onCdpEvent]);
+
+  const stateColor = SECURITY_STATE_COLOR[securityDetails.state];
+  const stateIcon = SECURITY_STATE_ICON[securityDetails.state];
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not attached</div>
+        <div className="panel-placeholder-desc">Attach to a tab to view security information.</div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Loading security info...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflowY: 'auto', padding: 'var(--space-6)' }}>
+      {error && (
+        <div style={{ color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)', marginBottom: 'var(--space-4)', fontFamily: 'var(--font-mono)' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Overview banner */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-4)',
+          padding: 'var(--space-4) var(--space-6)',
+          borderRadius: 'var(--radius-md)',
+          border: `1px solid ${stateColor}`,
+          backgroundColor: 'var(--color-bg-elevated)',
+          marginBottom: 'var(--space-6)',
+        }}
+      >
+        <span style={{ fontSize: '28px', color: stateColor, lineHeight: 1 }}>{stateIcon}</span>
+        <div>
+          <div style={{ fontSize: 'var(--font-size-md)', fontWeight: 'var(--font-weight-semibold)', color: stateColor, textTransform: 'capitalize' }}>
+            {securityDetails.state === 'unknown' ? 'Unknown' : securityDetails.state}
+          </div>
+          <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-fg-secondary)', marginTop: 'var(--space-1)' }}>
+            {securityDetails.state === 'secure' && 'This page is using a secure connection.'}
+            {securityDetails.state === 'neutral' && 'This page has a neutral security state.'}
+            {securityDetails.state === 'insecure' && 'This page is using an insecure connection.'}
+            {securityDetails.state === 'info' && 'Security info available.'}
+            {securityDetails.state === 'unknown' && 'Security state has not been determined yet.'}
+          </div>
+        </div>
+      </div>
+
+      {/* Connection section */}
+      <div style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={SECTION_HEADER_STYLE}>Connection</div>
+        {securityDetails.connection ? (
+          <>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Protocol</span>
+              <span style={{ ...FIELD_VALUE_STYLE, color: 'var(--color-status-success)' }}>{securityDetails.connection.protocol || '—'}</span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Cipher Suite</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.connection.cipher || '—'}</span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Key Exchange</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.connection.keyExchange || '—'}</span>
+            </div>
+          </>
+        ) : (
+          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
+            No connection data — navigate to a page to populate.
+          </div>
+        )}
+      </div>
+
+      {/* Certificate section */}
+      <div style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={SECTION_HEADER_STYLE}>Certificate</div>
+        {securityDetails.certificate ? (
+          <>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Subject</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.certificate.subject || '—'}</span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Issuer</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.certificate.issuer || '—'}</span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Valid From</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.certificate.validFrom || '—'}</span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Valid To</span>
+              <span style={FIELD_VALUE_STYLE}>{securityDetails.certificate.validTo || '—'}</span>
+            </div>
+            {securityDetails.certificate.subjectAlternativeNames.length > 0 && (
+              <div style={FIELD_ROW_STYLE}>
+                <span style={FIELD_LABEL_STYLE}>SANs</span>
+                <span style={FIELD_VALUE_STYLE}>{securityDetails.certificate.subjectAlternativeNames.join(', ')}</span>
+              </div>
+            )}
+          </>
+        ) : (
+          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
+            No certificate data — navigate to an HTTPS page to populate.
+          </div>
+        )}
+      </div>
+
+      {/* Resources / Mixed content section */}
+      <div style={{ marginBottom: 'var(--space-6)' }}>
+        <div style={SECTION_HEADER_STYLE}>Resources</div>
+        {securityDetails.mixedContent ? (
+          <>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Displayed Mixed</span>
+              <span
+                style={{
+                  ...FIELD_VALUE_STYLE,
+                  color: securityDetails.mixedContent.displayedMixedContent
+                    ? 'var(--color-status-warning)'
+                    : 'var(--color-status-success)',
+                }}
+              >
+                {securityDetails.mixedContent.displayedMixedContent ? 'Yes (passive)' : 'None'}
+              </span>
+            </div>
+            <div style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>Active Mixed</span>
+              <span
+                style={{
+                  ...FIELD_VALUE_STYLE,
+                  color: securityDetails.mixedContent.ranMixedContent
+                    ? 'var(--color-status-error)'
+                    : 'var(--color-status-success)',
+                }}
+              >
+                {securityDetails.mixedContent.ranMixedContent ? 'Yes (active — blocked)' : 'None'}
+              </span>
+            </div>
+          </>
+        ) : (
+          <div style={{ color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-xs)' }}>
+            Mixed content analysis unavailable.
+          </div>
+        )}
+      </div>
+
+      {/* Isolation status (COEP/COOP) */}
+      {isolationStatus && (
+        <div style={{ marginBottom: 'var(--space-6)' }}>
+          <div style={SECTION_HEADER_STYLE}>Isolation</div>
+          {Object.entries(isolationStatus).map(([key, value], i) => (
+            <div key={i} style={FIELD_ROW_STYLE}>
+              <span style={FIELD_LABEL_STYLE}>{key}</span>
+              <span style={FIELD_VALUE_STYLE}>{JSON.stringify(value)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Explanations */}
+      {securityDetails.explanations.length > 0 && (
+        <div style={{ marginBottom: 'var(--space-6)' }}>
+          <div style={SECTION_HEADER_STYLE}>Details</div>
+          {securityDetails.explanations.map((exp, i) => (
+            <div
+              key={i}
+              style={{
+                padding: 'var(--space-3)',
+                marginBottom: 'var(--space-2)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--color-border-subtle)',
+                backgroundColor: 'var(--color-bg-elevated)',
+              }}
+            >
+              <div style={{ fontSize: 'var(--font-size-xs)', fontWeight: 'var(--font-weight-semibold)', color: SECURITY_STATE_COLOR[(exp.securityState as SecurityState) ?? 'unknown'], marginBottom: 'var(--space-1)' }}>
+                {exp.title}
+              </div>
+              <div style={{ fontSize: 'var(--font-size-2xs)', color: 'var(--color-fg-secondary)', lineHeight: 'var(--line-height-relaxed)' }}>
+                {exp.description}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/my-app/src/renderer/devtools/panels/SourcesPanel.tsx
+++ b/my-app/src/renderer/devtools/panels/SourcesPanel.tsx
@@ -1,0 +1,627 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+// ---- Types ----------------------------------------------------------------
+
+interface PanelProps {
+  cdpSend: (method: string, params?: Record<string, unknown>) => Promise<{ success: boolean; result?: any; error?: string }>;
+  onCdpEvent: (cb: (method: string, params: unknown) => void) => () => void;
+  isAttached: boolean;
+}
+
+interface ScriptInfo {
+  scriptId: string;
+  url: string;
+  sourceMapURL?: string;
+}
+
+interface Breakpoint {
+  scriptId: string;
+  lineNumber: number;
+  breakpointId: string;
+  url: string;
+}
+
+interface CallFrame {
+  callFrameId: string;
+  functionName: string;
+  url: string;
+  lineNumber: number;
+  columnNumber: number;
+  scopeChain: ScopeEntry[];
+}
+
+interface ScopeEntry {
+  type: string;
+  name?: string;
+  object: { objectId?: string; description?: string; value?: unknown };
+}
+
+interface ScopeVariable {
+  name: string;
+  value: string;
+}
+
+interface WatchExpression {
+  id: number;
+  expression: string;
+  result: string;
+}
+
+interface PausedState {
+  callFrames: CallFrame[];
+  reason: string;
+}
+
+// ---- Constants ------------------------------------------------------------
+
+const PANEL_TAG = '[SourcesPanel]';
+let watchIdCounter = 0;
+
+// ---- Helpers ---------------------------------------------------------------
+
+function displayUrl(url: string): string {
+  if (!url) return '(anonymous)';
+  try {
+    const u = new URL(url);
+    return u.pathname.split('/').pop() || u.pathname || url;
+  } catch {
+    return url.split('/').pop() || url;
+  }
+}
+
+// ---- Component -------------------------------------------------------------
+
+export function SourcesPanel({ cdpSend, onCdpEvent, isAttached }: PanelProps): React.ReactElement {
+  const [scripts, setScripts] = useState<ScriptInfo[]>([]);
+  const [selectedScript, setSelectedScript] = useState<ScriptInfo | null>(null);
+  const [sourceLines, setSourceLines] = useState<string[]>([]);
+  const [loadingSource, setLoadingSource] = useState(false);
+  const [breakpoints, setBreakpoints] = useState<Breakpoint[]>([]);
+  const [paused, setPaused] = useState<PausedState | null>(null);
+  const [watchExpressions, setWatchExpressions] = useState<WatchExpression[]>([]);
+  const [newWatchExpr, setNewWatchExpr] = useState('');
+  const [scopeVars, setScopeVars] = useState<ScopeVariable[]>([]);
+  const sourceViewRef = useRef<HTMLDivElement>(null);
+
+  // Enable Debugger domain on mount
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log(PANEL_TAG, 'enabling Debugger domain');
+    void cdpSend('Debugger.enable').then((r) => {
+      console.log(PANEL_TAG, 'Debugger.enable result:', r);
+    });
+    void cdpSend('Runtime.enable').then((r) => {
+      console.log(PANEL_TAG, 'Runtime.enable result:', r);
+    });
+
+    return () => {
+      console.log(PANEL_TAG, 'disabling Debugger domain');
+      void cdpSend('Debugger.disable');
+    };
+  }, [isAttached, cdpSend]);
+
+  // Subscribe to CDP events
+  useEffect(() => {
+    if (!isAttached) return;
+    console.log(PANEL_TAG, 'subscribing to CDP events');
+
+    const unsubscribe = onCdpEvent((method, params) => {
+      const p = params as Record<string, unknown>;
+
+      if (method === 'Debugger.scriptParsed') {
+        const url = (p.url as string) ?? '';
+        const scriptId = p.scriptId as string;
+        // Skip internal / extension scripts and empty URLs
+        if (!url || url.startsWith('extensions::') || url.includes('chrome-extension://')) return;
+        console.log(PANEL_TAG, 'scriptParsed:', scriptId, url);
+        setScripts((prev) => {
+          if (prev.some((s) => s.scriptId === scriptId)) return prev;
+          return [...prev, { scriptId, url, sourceMapURL: p.sourceMapURL as string | undefined }];
+        });
+      }
+
+      if (method === 'Debugger.paused') {
+        const frames = (p.callFrames as CallFrame[]) ?? [];
+        const reason = (p.reason as string) ?? 'breakpoint';
+        console.log(PANEL_TAG, 'paused, reason:', reason, 'frames:', frames.length);
+        setPaused({ callFrames: frames, reason });
+
+        // Load scope variables from top frame
+        const topFrame = frames[0];
+        if (topFrame) {
+          loadScopeVars(topFrame.scopeChain);
+        }
+      }
+
+      if (method === 'Debugger.resumed') {
+        console.log(PANEL_TAG, 'resumed');
+        setPaused(null);
+        setScopeVars([]);
+      }
+    });
+
+    return unsubscribe;
+  }, [isAttached, onCdpEvent]);
+
+  const loadScopeVars = useCallback(
+    async (scopeChain: ScopeEntry[]) => {
+      const vars: ScopeVariable[] = [];
+      for (const scope of scopeChain.slice(0, 3)) {
+        if (!scope.object.objectId) continue;
+        try {
+          const r = await cdpSend('Runtime.getProperties', {
+            objectId: scope.object.objectId,
+            ownProperties: true,
+          });
+          const props = (r.result as { result?: Array<{ name: string; value?: { type: string; value?: unknown; description?: string } }> })?.result ?? [];
+          for (const prop of props.slice(0, 20)) {
+            const val = prop.value;
+            if (!val) continue;
+            const display = val.value !== undefined ? JSON.stringify(val.value) : val.description ?? `[${val.type}]`;
+            vars.push({ name: prop.name, value: display });
+          }
+        } catch (err) {
+          console.warn(PANEL_TAG, 'getProperties failed:', err);
+        }
+      }
+      console.log(PANEL_TAG, 'loaded', vars.length, 'scope vars');
+      setScopeVars(vars);
+    },
+    [cdpSend],
+  );
+
+  const handleSelectScript = useCallback(
+    async (script: ScriptInfo) => {
+      console.log(PANEL_TAG, 'selecting script:', script.scriptId, script.url);
+      setSelectedScript(script);
+      setLoadingSource(true);
+      setSourceLines([]);
+      try {
+        const r = await cdpSend('Debugger.getScriptSource', { scriptId: script.scriptId });
+        const src = (r.result as { scriptSource?: string })?.scriptSource ?? '';
+        console.log(PANEL_TAG, 'loaded source, length:', src.length);
+        setSourceLines(src.split('\n'));
+      } catch (err) {
+        console.error(PANEL_TAG, 'getScriptSource failed:', err);
+        setSourceLines(['// Failed to load source']);
+      } finally {
+        setLoadingSource(false);
+      }
+    },
+    [cdpSend],
+  );
+
+  const handleLineClick = useCallback(
+    async (lineNumber: number) => {
+      if (!selectedScript) return;
+      const existing = breakpoints.find(
+        (bp) => bp.scriptId === selectedScript.scriptId && bp.lineNumber === lineNumber,
+      );
+      if (existing) {
+        console.log(PANEL_TAG, 'removing breakpoint:', existing.breakpointId);
+        try {
+          await cdpSend('Debugger.removeBreakpoint', { breakpointId: existing.breakpointId });
+          setBreakpoints((prev) => prev.filter((bp) => bp.breakpointId !== existing.breakpointId));
+        } catch (err) {
+          console.error(PANEL_TAG, 'removeBreakpoint failed:', err);
+        }
+      } else {
+        console.log(PANEL_TAG, 'setting breakpoint at line:', lineNumber, 'url:', selectedScript.url);
+        try {
+          const r = await cdpSend('Debugger.setBreakpointByUrl', {
+            lineNumber,
+            url: selectedScript.url,
+            columnNumber: 0,
+          });
+          const bpId = (r.result as { breakpointId?: string })?.breakpointId;
+          if (bpId) {
+            setBreakpoints((prev) => [
+              ...prev,
+              { scriptId: selectedScript.scriptId, lineNumber, breakpointId: bpId, url: selectedScript.url },
+            ]);
+          }
+        } catch (err) {
+          console.error(PANEL_TAG, 'setBreakpointByUrl failed:', err);
+        }
+      }
+    },
+    [selectedScript, breakpoints, cdpSend],
+  );
+
+  const handleAddWatch = useCallback(async () => {
+    const expr = newWatchExpr.trim();
+    if (!expr) return;
+    console.log(PANEL_TAG, 'evaluating watch expression:', expr);
+    let result = '—';
+    try {
+      const r = await cdpSend('Runtime.evaluate', { expression: expr, returnByValue: true });
+      const res = (r.result as { result?: { value?: unknown; description?: string; type?: string }; exceptionDetails?: { text?: string } });
+      if (res.exceptionDetails) {
+        result = `Error: ${res.exceptionDetails.text ?? 'unknown'}`;
+      } else if (res.result) {
+        result = res.result.value !== undefined ? JSON.stringify(res.result.value) : res.result.description ?? `[${res.result.type}]`;
+      }
+    } catch (err) {
+      result = String(err);
+    }
+    setWatchExpressions((prev) => [...prev, { id: watchIdCounter++, expression: expr, result }]);
+    setNewWatchExpr('');
+  }, [newWatchExpr, cdpSend]);
+
+  const handleRemoveWatch = (id: number): void => {
+    setWatchExpressions((prev) => prev.filter((w) => w.id !== id));
+  };
+
+  const handleResume = useCallback(async () => {
+    console.log(PANEL_TAG, 'resuming execution');
+    await cdpSend('Debugger.resume');
+  }, [cdpSend]);
+
+  const handleStepOver = useCallback(async () => {
+    console.log(PANEL_TAG, 'step over');
+    await cdpSend('Debugger.stepOver');
+  }, [cdpSend]);
+
+  const handleStepInto = useCallback(async () => {
+    console.log(PANEL_TAG, 'step into');
+    await cdpSend('Debugger.stepInto');
+  }, [cdpSend]);
+
+  const isBreakpointLine = (lineNumber: number): boolean => {
+    if (!selectedScript) return false;
+    return breakpoints.some((bp) => bp.scriptId === selectedScript.scriptId && bp.lineNumber === lineNumber);
+  };
+
+  if (!isAttached) {
+    return (
+      <div className="panel-placeholder">
+        <div className="panel-placeholder-title">Not connected</div>
+        <div className="panel-placeholder-desc">Attach to a tab to use the Sources panel.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden', fontFamily: 'var(--font-mono)', fontSize: 'var(--font-size-xs)' }}>
+      {/* Left pane: file tree + sidebar controls */}
+      <div
+        style={{
+          width: '220px',
+          flexShrink: 0,
+          borderRight: '1px solid var(--color-border-default)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Script list */}
+        <div
+          style={{
+            padding: 'var(--space-2) var(--space-3)',
+            borderBottom: '1px solid var(--color-border-subtle)',
+            fontSize: 'var(--font-size-2xs)',
+            fontWeight: 'var(--font-weight-semibold)',
+            color: 'var(--color-fg-secondary)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}
+        >
+          Scripts ({scripts.length})
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {scripts.length === 0 ? (
+            <div style={{ padding: 'var(--space-4)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+              Waiting for scripts...
+            </div>
+          ) : (
+            scripts.map((s) => (
+              <div
+                key={s.scriptId}
+                onClick={() => void handleSelectScript(s)}
+                style={{
+                  padding: 'var(--space-1) var(--space-3)',
+                  cursor: 'pointer',
+                  color: selectedScript?.scriptId === s.scriptId ? 'var(--color-accent-default)' : 'var(--color-fg-primary)',
+                  backgroundColor: selectedScript?.scriptId === s.scriptId ? 'var(--color-accent-muted)' : 'transparent',
+                  borderRadius: 'var(--radius-xs)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: 'var(--font-size-2xs)',
+                }}
+                title={s.url}
+              >
+                {displayUrl(s.url)}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Breakpoints list */}
+        <div style={{ borderTop: '1px solid var(--color-border-subtle)', flexShrink: 0 }}>
+          <div
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              fontSize: 'var(--font-size-2xs)',
+              fontWeight: 'var(--font-weight-semibold)',
+              color: 'var(--color-fg-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            Breakpoints
+          </div>
+          <div style={{ maxHeight: '120px', overflowY: 'auto' }}>
+            {breakpoints.length === 0 ? (
+              <div style={{ padding: 'var(--space-2) var(--space-3)', color: 'var(--color-fg-tertiary)', fontSize: 'var(--font-size-2xs)' }}>
+                None set
+              </div>
+            ) : (
+              breakpoints.map((bp) => (
+                <div
+                  key={bp.breakpointId}
+                  style={{
+                    padding: 'var(--space-1) var(--space-3)',
+                    fontSize: 'var(--font-size-2xs)',
+                    color: 'var(--color-fg-primary)',
+                    display: 'flex',
+                    gap: 'var(--space-2)',
+                  }}
+                >
+                  <span style={{ color: '#f87171' }}>◉</span>
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {displayUrl(bp.url)}:{bp.lineNumber + 1}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Watch expressions */}
+        <div style={{ borderTop: '1px solid var(--color-border-subtle)', flexShrink: 0 }}>
+          <div
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              fontSize: 'var(--font-size-2xs)',
+              fontWeight: 'var(--font-weight-semibold)',
+              color: 'var(--color-fg-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            Watch
+          </div>
+          <div style={{ maxHeight: '100px', overflowY: 'auto' }}>
+            {watchExpressions.map((w) => (
+              <div
+                key={w.id}
+                style={{
+                  padding: 'var(--space-1) var(--space-3)',
+                  fontSize: 'var(--font-size-2xs)',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 'var(--space-2)',
+                }}
+              >
+                <span style={{ color: '#c792ea', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{w.expression}</span>
+                <span style={{ color: 'var(--color-fg-secondary)', flexShrink: 0 }}>{w.result}</span>
+                <span
+                  style={{ color: 'var(--color-fg-tertiary)', cursor: 'pointer', flexShrink: 0 }}
+                  onClick={() => handleRemoveWatch(w.id)}
+                >
+                  ✕
+                </span>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'flex', padding: 'var(--space-1) var(--space-3)', gap: 'var(--space-2)' }}>
+            <input
+              value={newWatchExpr}
+              onChange={(e) => setNewWatchExpr(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleAddWatch(); }}
+              placeholder="Add expression..."
+              style={{
+                flex: 1,
+                background: 'var(--color-bg-elevated)',
+                border: '1px solid var(--color-border-subtle)',
+                borderRadius: 'var(--radius-sm)',
+                padding: 'var(--space-1) var(--space-2)',
+                fontSize: 'var(--font-size-2xs)',
+                color: 'var(--color-fg-primary)',
+                fontFamily: 'var(--font-mono)',
+              }}
+            />
+            <button
+              onClick={() => void handleAddWatch()}
+              style={{
+                padding: '0 var(--space-2)',
+                background: 'var(--color-accent-default)',
+                color: 'var(--color-fg-inverse)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: 'var(--font-size-2xs)',
+                cursor: 'pointer',
+              }}
+            >
+              +
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Center pane: source viewer */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* Debugger controls when paused */}
+        {paused && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-3)',
+              padding: 'var(--space-2) var(--space-4)',
+              background: 'rgba(245,158,11,0.08)',
+              borderBottom: '1px solid var(--color-status-warning)',
+              flexShrink: 0,
+            }}
+          >
+            <span style={{ color: 'var(--color-status-warning)', fontSize: 'var(--font-size-2xs)', fontWeight: 'var(--font-weight-semibold)' }}>
+              Paused: {paused.reason}
+            </span>
+            <button onClick={() => void handleResume()} style={debugBtnStyle}>Resume</button>
+            <button onClick={() => void handleStepOver()} style={debugBtnStyle}>Step Over</button>
+            <button onClick={() => void handleStepInto()} style={debugBtnStyle}>Step Into</button>
+          </div>
+        )}
+
+        {/* Source code viewer */}
+        <div ref={sourceViewRef} style={{ flex: 1, overflowY: 'auto', overflowX: 'auto', position: 'relative' }}>
+          {!selectedScript ? (
+            <div className="panel-placeholder">
+              <div className="panel-placeholder-title" style={{ fontSize: 'var(--font-size-sm)' }}>
+                Select a script to view its source
+              </div>
+            </div>
+          ) : loadingSource ? (
+            <div className="panel-placeholder">
+              <div className="panel-placeholder-title" style={{ fontSize: 'var(--font-size-sm)' }}>Loading...</div>
+            </div>
+          ) : (
+            <table style={{ borderCollapse: 'collapse', width: '100%', tableLayout: 'fixed' }}>
+              <tbody>
+                {sourceLines.map((line, idx) => {
+                  const lineNum = idx; // 0-based to match CDP
+                  const hasBp = isBreakpointLine(lineNum);
+                  return (
+                    <tr
+                      key={idx}
+                      style={{
+                        background: hasBp ? 'rgba(248,113,113,0.12)' : 'transparent',
+                      }}
+                    >
+                      <td
+                        onClick={() => void handleLineClick(lineNum)}
+                        style={{
+                          width: '48px',
+                          minWidth: '48px',
+                          textAlign: 'right',
+                          paddingRight: 'var(--space-3)',
+                          paddingLeft: 'var(--space-2)',
+                          color: hasBp ? '#f87171' : 'var(--color-fg-tertiary)',
+                          fontSize: 'var(--font-size-2xs)',
+                          cursor: 'pointer',
+                          userSelect: 'none',
+                          borderRight: '1px solid var(--color-border-subtle)',
+                          verticalAlign: 'top',
+                        }}
+                      >
+                        {hasBp ? '◉' : idx + 1}
+                      </td>
+                      <td
+                        style={{
+                          paddingLeft: 'var(--space-4)',
+                          paddingRight: 'var(--space-4)',
+                          color: 'var(--color-fg-primary)',
+                          whiteSpace: 'pre',
+                          verticalAlign: 'top',
+                          fontSize: 'var(--font-size-xs)',
+                        }}
+                      >
+                        {line}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* Right pane: call stack + scope when paused */}
+      {paused && (
+        <div
+          style={{
+            width: '220px',
+            flexShrink: 0,
+            borderLeft: '1px solid var(--color-border-default)',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            fontSize: 'var(--font-size-2xs)',
+          }}
+        >
+          <div
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderBottom: '1px solid var(--color-border-subtle)',
+              fontWeight: 'var(--font-weight-semibold)',
+              color: 'var(--color-fg-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            Call Stack
+          </div>
+          <div style={{ maxHeight: '160px', overflowY: 'auto' }}>
+            {paused.callFrames.map((frame, i) => (
+              <div
+                key={frame.callFrameId}
+                style={{
+                  padding: 'var(--space-1) var(--space-3)',
+                  color: i === 0 ? 'var(--color-accent-default)' : 'var(--color-fg-primary)',
+                  borderBottom: '1px solid var(--color-border-subtle)',
+                }}
+              >
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {frame.functionName || '(anonymous)'}
+                </div>
+                <div style={{ color: 'var(--color-fg-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {displayUrl(frame.url)}:{frame.lineNumber + 1}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderBottom: '1px solid var(--color-border-subtle)',
+              borderTop: '1px solid var(--color-border-subtle)',
+              fontWeight: 'var(--font-weight-semibold)',
+              color: 'var(--color-fg-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            Scope
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto' }}>
+            {scopeVars.length === 0 ? (
+              <div style={{ padding: 'var(--space-2) var(--space-3)', color: 'var(--color-fg-tertiary)' }}>
+                No variables
+              </div>
+            ) : (
+              scopeVars.map((v, i) => (
+                <div key={i} style={{ padding: 'var(--space-1) var(--space-3)', display: 'flex', gap: 'var(--space-2)', justifyContent: 'space-between' }}>
+                  <span style={{ color: '#c792ea', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{v.name}</span>
+                  <span style={{ color: '#c3e88d', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '100px' }}>{v.value}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Shared style for debugger control buttons
+const debugBtnStyle: React.CSSProperties = {
+  padding: 'var(--space-1) var(--space-3)',
+  background: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-subtle)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--color-fg-primary)',
+  fontSize: 'var(--font-size-2xs)',
+  cursor: 'pointer',
+};

--- a/my-app/vite.devtools.config.ts
+++ b/my-app/vite.devtools.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/devtools/devtools.html'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Implements all 10 DevTools panels from issue #77 with real CDP (Chrome DevTools Protocol) integration
- **Elements**: DOM tree via `DOM.getDocument`, CSS styles via `CSS.getMatchedStylesForNode`, computed styles, accessibility tree
- **Console**: REPL via `Runtime.evaluate`, live log capture via `Runtime.consoleAPICalled`, level/text filters, command history
- **Sources**: Script list via `Debugger.scriptParsed`, source viewer with line numbers, breakpoint support, call stack + scope when paused
- **Network**: Request table with waterfall via `Network.requestWillBeSent`/`responseReceived`, type filters, detail pane with headers/preview/response
- **Performance**: Live metrics via `Performance.getMetrics`, Web Vitals (FCP/LCP/CLS), tracing via `Tracing.start`/`end`
- **Memory**: Heap snapshots via `HeapProfiler.takeHeapSnapshot`, allocation tracking, GC stats
- **Application**: Storage inspection (cookies, localStorage, sessionStorage, IndexedDB, Cache Storage), service workers, manifest
- **Security**: TLS/certificate info via `Security` domain, mixed content warnings, isolation status
- **Lighthouse**: Lightweight audits for Performance, Accessibility, Best Practices, SEO via `Runtime.evaluate`
- **Recorder**: User flow recording/replay via CDP input events, step management, JSON export

## Architecture
- Main process: `DevToolsBridge` attaches Electron's `WebContents.debugger` to the active tab and proxies CDP commands/events
- Preload: `devtoolsAPI` exposes `attach()`, `send()`, `onCdpEvent()` via contextBridge
- Renderer: `DevToolsApp` manages CDP connection lifecycle and routes to panel components
- Window opened via Cmd+Alt+D menu shortcut

## Test plan
- [ ] Open DevTools via Cmd+Alt+D, verify connection to active tab
- [ ] Elements: expand DOM tree nodes, select node to see matched CSS styles
- [ ] Console: type expressions in REPL, verify output; check log capture from page
- [ ] Network: navigate to a page, verify requests appear with timing waterfall
- [ ] Sources: verify script list populates, click to view source
- [ ] Performance: click "Take Snapshot" to see current metrics
- [ ] Application: verify cookies/localStorage display for current page
- [ ] Security: verify TLS status displays for HTTPS pages
- [ ] Lighthouse: run audit and verify scores appear
- [ ] Recorder: start recording, perform actions, stop, verify steps captured

Closes #77