### PR TITLE
ci(release): GitHub Releases flow with tag trigger + DMG + checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,45 @@
-name: Release (manual)
+name: Release
 
-# Manual-only: produces a DMG from the current ref as a downloadable artifact.
-# Does NOT publish to any store, GitHub Releases, or update channel — this is
-# the "I want a build I can hand to a tester" workflow. Use `gh workflow run
-# release.yml --ref <branch>` or the GitHub UI.
+# Produces a downloadable DMG for a given ref and attaches it to a GitHub
+# Release page. Two entry points:
+#
+#   1. Push a git tag matching v*.*.* (e.g. `git tag v1.2.3 && git push origin v1.2.3`).
+#      This is the primary way to cut a release. The release name equals the tag.
+#
+#   2. Manual `workflow_dispatch` for dry-runs / tester builds. The optional
+#      `tag` input defaults to a timestamp-based pre-release tag
+#      (`v0.0.0-dev-<timestamp>`) so the manual path always yields a
+#      prerelease that is easy to identify and discard.
+#
+# Signing is optional. Without Apple secrets the build is unsigned (the same
+# output the previous manual workflow produced). With the secrets present and
+# `skip-signing=false`, the DMG is signed + notarized. See SIGNING.md.
+#
+# The job also uploads the DMG/zip as a workflow artifact (14-day retention)
+# so internal users can grab builds without waiting for the Release page to
+# finish populating — belt-and-suspenders backup.
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       skip-signing:
         description: 'Build unsigned (no Apple Developer credentials needed)'
         type: boolean
         default: true
+      tag:
+        description: 'Tag/release name for this manual run (defaults to v0.0.0-dev-<timestamp>)'
+        type: string
+        required: false
+        default: ''
 
+# Scope concurrency to the tag/input so two simultaneous runs for the same
+# release cannot race each other. `github.ref` resolves to `refs/tags/<tag>`
+# on tag pushes, and the `tag` input (or the fallback) on manual runs.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.inputs.tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -26,8 +51,39 @@ jobs:
     name: Package + make DMG (macOS)
     runs-on: macos-latest
     timeout-minutes: 40
+    # Least-privilege: only this job needs contents:write (to publish the
+    # Release + upload assets via softprops/action-gh-release).
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so release-notes generation can walk back to the
+          # previous tag.
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          elif [[ -n "${INPUT_TAG}" ]]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="v0.0.0-dev-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          # Prerelease if the tag contains a recognized pre-release suffix.
+          if [[ "${TAG}" == *-dev* || "${TAG}" == *-rc* || "${TAG}" == *-beta* || "${TAG}" == *-alpha* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Resolved tag: ${TAG}"
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -54,15 +110,46 @@ jobs:
         working-directory: my-app/python
         run: bash build.sh
 
+      # Decide signed vs unsigned. The rule:
+      #   - `workflow_dispatch` respects the `skip-signing` input (default true).
+      #   - Tag pushes auto-sign IF the required secrets are present; else
+      #     fall back to unsigned so the workflow still works with just
+      #     GITHUB_TOKEN.
+      # We detect secret presence by testing whether SIGNING_IDENTITY is a
+      # non-empty string — secrets cannot be referenced directly in `if:`
+      # expressions, but they can flow through env + a resolve step.
+      - name: Resolve signing mode
+        id: signing
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SKIP_SIGNING_INPUT: ${{ github.event.inputs.skip-signing }}
+          HAS_SIGNING_IDENTITY: ${{ secrets.SIGNING_IDENTITY != '' }}
+        run: |
+          set -euo pipefail
+          mode="unsigned"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$SKIP_SIGNING_INPUT" == "false" ]]; then
+              mode="signed"
+            fi
+          else
+            # Tag push: sign automatically when the signing secret is present.
+            if [[ "$HAS_SIGNING_IDENTITY" == "true" ]]; then
+              mode="signed"
+            fi
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+          echo "Signing mode: ${mode}"
+
       - name: electron-forge make (unsigned)
-        if: inputs.skip-signing
+        if: ${{ steps.signing.outputs.mode == 'unsigned' }}
         working-directory: my-app
         env:
           SKIP_SIGNING: '1'
         run: npm run make
 
       - name: electron-forge make (signed + notarized)
-        if: ${{ !inputs.skip-signing }}
+        if: ${{ steps.signing.outputs.mode == 'signed' }}
         working-directory: my-app
         env:
           # Only exposed to the forge process when signing is explicitly
@@ -73,12 +160,80 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run make
 
-      - name: Upload DMG artifact
+      - name: Collect release assets + compute checksums
+        id: assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          shopt -s nullglob globstar
+
+          dmg_count=0
+          for f in my-app/out/make/**/*.dmg; do
+            cp "$f" release-assets/
+            dmg_count=$((dmg_count + 1))
+          done
+
+          zip_count=0
+          for f in my-app/out/make/**/*.zip; do
+            cp "$f" release-assets/
+            zip_count=$((zip_count + 1))
+          done
+
+          if [[ "$dmg_count" -eq 0 ]]; then
+            echo "::error::No DMG produced by electron-forge make — refusing to publish empty release."
+            ls -R my-app/out/make || true
+            exit 1
+          fi
+
+          # SHA256SUMS.txt covers every asset we're about to publish.
+          # `nullglob` makes non-matching globs vanish instead of expanding
+          # literally — important because `*.zip` may not exist (Forge won't
+          # emit one for unsigned arm64 builds in some configurations).
+          (
+            cd release-assets
+            shopt -s nullglob
+            shasum -a 256 *.dmg *.zip \
+              | sed 's|\./||g' \
+              > SHA256SUMS.txt
+          )
+
+          echo "dmg_count=${dmg_count}" >> "$GITHUB_OUTPUT"
+          echo "zip_count=${zip_count}" >> "$GITHUB_OUTPUT"
+          echo "Collected ${dmg_count} DMG(s) and ${zip_count} zip(s):"
+          ls -la release-assets/
+          echo "---- SHA256SUMS.txt ----"
+          cat release-assets/SHA256SUMS.txt
+
+      # Backup path: the raw DMG/zip/checksums stay available as a workflow
+      # artifact for 14 days regardless of what happens to the Release page.
+      - name: Upload DMG artifact (backup)
         uses: actions/upload-artifact@v4
         with:
           name: agentic-browser-${{ github.sha }}
           path: |
-            my-app/out/make/**/*.dmg
-            my-app/out/make/**/*.zip
+            release-assets/*.dmg
+            release-assets/*.zip
+            release-assets/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 14
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}
+          # Auto-generate notes from commits since the previous tag.
+          generate_release_notes: true
+          # For workflow_dispatch runs the tag doesn't exist yet — let the
+          # action create it against the workflow's sha.
+          target_commitish: ${{ github.sha }}
+          # We already hard-fail on missing DMG in the asset-collection
+          # step, so false here tolerates the legitimate case where Forge
+          # didn't emit a .zip.
+          fail_on_unmatched_files: false
+          files: |
+            release-assets/*.dmg
+            release-assets/*.zip
+            release-assets/SHA256SUMS.txt

--- a/my-app/docs/CI.md
+++ b/my-app/docs/CI.md
@@ -34,19 +34,70 @@ build targets `out/my-app-darwin-*/my-app.app`:
 Both Playwright jobs depend on `build`; the build artifact is reused so
 we only pay the ~8 min Forge build cost once per SHA.
 
-### `release.yml` — manual only
+### `release.yml` — tag-driven GitHub Release (+ manual dry-runs)
 
-`workflow_dispatch` produces a DMG as a downloadable artifact. By default
-it builds unsigned (`SKIP_SIGNING=1`). To build signed, flip the input to
-`skip-signing: false` and make sure these repo secrets are set:
+Two entry points:
+
+1. **Push a `v*.*.*` tag.** This is the primary way to cut a release:
+
+   ```bash
+   # make sure my-app/package.json version is what you want in the tag name
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+   The workflow builds on macOS, produces an unsigned DMG (or a signed +
+   notarized DMG if secrets are present), writes `SHA256SUMS.txt`, and
+   publishes a GitHub Release at `https://github.com/<owner>/<repo>/releases/tag/v1.2.3`
+   with the DMG, zip, and checksums attached. Release notes are
+   auto-generated from commits since the previous tag.
+
+2. **`workflow_dispatch`** — for iteration and tester builds. Inputs:
+
+   - `skip-signing` (bool, default `true`) — build unsigned.
+   - `tag` (string, optional) — defaults to `v0.0.0-dev-<timestamp>`.
+     The workflow always creates a Release at that tag; if it contains
+     `-dev`, `-rc`, `-beta`, or `-alpha`, it is marked **prerelease**.
+
+   Example:
+
+   ```bash
+   gh workflow run release.yml --ref main \
+     -f tag=v0.0.0-smoketest-$(date +%s)
+   ```
+
+**Cutting a signed release.** For tag pushes, signing activates
+automatically when the secrets are set. For `workflow_dispatch`, flip
+`skip-signing: false`. The required secrets:
 
 - `SIGNING_IDENTITY`
 - `APPLE_ID`
 - `APPLE_APP_SPECIFIC_PASSWORD`
 - `APPLE_TEAM_ID`
 
-It does **not** publish to any update channel or create a GitHub Release —
-that workflow is for producing a build you can hand to a tester.
+Without those secrets, every run is unsigned. `GITHUB_TOKEN` alone is
+enough to publish the Release (the workflow grants itself
+`contents: write`).
+
+**Cutting a pre-release.** Use a tag with a recognized suffix:
+`v1.2.3-rc.1`, `v1.2.3-beta.2`, `v1.2.3-alpha`, `v1.2.3-dev-20260101`.
+The workflow flips `prerelease: true` based on substring match.
+
+**Where to find the DMG after release.** Two places:
+
+- **GitHub Release page** — `https://github.com/<owner>/<repo>/releases/tag/<tag>`.
+  This is the canonical user-facing download.
+- **Workflow artifact** (14-day retention) — Actions → Release run →
+  `agentic-browser-<sha>`. Backup path for internal use or if Release
+  publishing fails partway.
+
+The workflow does **not** publish to any update channel (no Squirrel /
+autoUpdater / brew). Users download the DMG from the Release page.
+
+**Version field.** `my-app/package.json`'s `version` is consumed by Forge
+when it names the DMG (`my-app-<version>-arm64.dmg`). Keep the `version`
+in sync with the tag you push — e.g. bump to `1.2.3` in a commit before
+tagging `v1.2.3`. The workflow does **not** auto-bump this for you.
 
 ## Running locally
 


### PR DESCRIPTION
## Summary

Rework `.github/workflows/release.yml` into a real GitHub Releases flow.
Push a `v*.*.*` tag -> a Release page appears with the DMG, zip, and
`SHA256SUMS.txt` attached and auto-generated notes. `workflow_dispatch`
stays around for dry-runs / tester builds.

### What changed in `release.yml`

- **Triggers:** `push: tags: ['v*.*.*']` (primary) + `workflow_dispatch`
  (manual). The manual path takes an optional `tag` input; if empty it
  defaults to `v0.0.0-dev-<utc-timestamp>`, which means every manual run
  still produces a valid, identifiable, throwaway prerelease.
- **Signing mode resolution:** new `Resolve signing mode` step. For
  `workflow_dispatch` it respects the `skip-signing` input (default
  `true`). For tag pushes it auto-signs when `SIGNING_IDENTITY` is set,
  otherwise falls back to unsigned so a tag push works with just
  `GITHUB_TOKEN`.
- **Build steps are unchanged** - same node/python setup, same
  `npm ci`, same python deps, same `python/build.sh`, same
  `npm run make`.
- **New asset collection step** copies DMG + zip(s) into
  `release-assets/` and writes `SHA256SUMS.txt` via `shasum -a 256`.
  Hard-fails if zero DMGs were produced (no empty releases).
- **Workflow artifact upload preserved** - `agentic-browser-<sha>`,
  14-day retention, same as before, belt-and-suspenders backup.
- **Publish step:** `softprops/action-gh-release@v2` creates the Release
  using the resolved tag name, flips `prerelease: true` if the tag
  contains `-dev`/`-rc`/`-beta`/`-alpha`, and uploads the three asset
  globs. `generate_release_notes: true` pulls commits since the previous
  tag.
- **Permissions:** `contents: write` scoped to the `make` job only (no
  workflow-wide grant).
- **Concurrency:** group keyed to `github.event.inputs.tag || github.ref`
  so two simultaneous runs of the same release can't race.
- **No `continue-on-error` anywhere.** Release workflow fails loud.

### Docs

`my-app/docs/CI.md` section for `release.yml` rewritten to cover:
- How to cut a release (`git tag v1.2.3 && git push origin v1.2.3`)
- How to cut a signed release (required secrets, tag-push auto-signs)
- How to cut a prerelease (tag suffix convention)
- Where to find the DMG after release (Release page + workflow artifact
  fallback)
- That `my-app/package.json` `version` must be kept in sync with the
  tag by hand (not auto-bumped)

## Testing guide

Secrets required for this PR: **none** (unsigned path works with
`GITHUB_TOKEN` only). Signed path is opt-in via the existing
`SIGNING_IDENTITY` / `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` /
`APPLE_TEAM_ID` repo secrets.

1. **YAML parses on GitHub.** Pushing the branch is itself a sanity
   check - if the YAML is malformed, GitHub flags it on the PR.
2. **Dry-run a manual build (recommended before tagging):**

   ```bash
   gh workflow run release.yml --ref ci/release-flow \
     -f tag=v0.0.0-smoketest-$(date +%s)
   ```

   Expected: the run completes, a **prerelease** appears at
   `https://github.com/<owner>/desktop-app/releases/tag/v0.0.0-smoketest-...`
   with a DMG + `SHA256SUMS.txt` attached. The same assets are also
   visible as the `agentic-browser-<sha>` workflow artifact.
3. **Real release (after merge, when ready):**

   ```bash
   # bump my-app/package.json version to 1.2.3 in a commit first, then
   git tag v1.2.3
   git push origin v1.2.3
   ```

   Expected: Release `v1.2.3` published (non-prerelease), signed if
   secrets present, unsigned otherwise.
4. **Rollback:** delete the Release + tag via `gh release delete` /
   `git push --delete origin <tag>` if a smoke-test run needs cleanup.

## Not in scope

- No update channels (no Squirrel / autoUpdater / brew). Just a
  downloadable DMG.
- No auto version-bump. `my-app/package.json`'s `version` stays a
  manual edit.
- Did not touch `forge.config.ts`. Signing config already lives there.
- Did not touch the stray `my-app/.github/workflows/release.yml` - it
  lives at a nested path GitHub never reads, so it's inert. Flagging
  only - can be deleted in a follow-up.

## Test plan

- [ ] Workflow YAML parses on GitHub (green syntax badge on the PR)
- [ ] `gh workflow run release.yml --ref ci/release-flow -f tag=v0.0.0-smoketest-<ts>` completes green
- [ ] Resulting Release page shows DMG + `SHA256SUMS.txt`, marked **prerelease**
- [ ] `agentic-browser-<sha>` artifact appears under Actions -> run -> Artifacts
- [ ] `shasum -a 256 -c SHA256SUMS.txt` passes against the downloaded DMG

Generated with Claude Code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `release.yml` to a tag-driven GitHub Releases flow that builds DMG/zip, generates SHA256 checksums, and publishes assets when pushing `v*.*.*` tags. Manual runs remain for dry-runs, with optional signing and prerelease tags.

- **New Features**
  - Trigger on `push` tags `v*.*.*`; `workflow_dispatch` supports an optional `tag` input for timestamped prereleases.
  - Auto-resolve signing: tag pushes sign if Apple secrets exist; manual runs respect `skip-signing` (default `true`).
  - Collect DMG/zip into `release-assets/` and write `SHA256SUMS.txt`; fail if no DMG to avoid empty releases.
  - Publish via `softprops/action-gh-release@v2` with auto notes and prerelease detection for `-dev/-rc/-beta/-alpha`.
  - Keep a 14‑day backup artifact, scope `contents: write` to the job, and prevent races with tag/input-based concurrency; docs updated in `my-app/docs/CI.md` with release steps and version sync notes.

- **Migration**
  - To release: bump `my-app/package.json` version, `git tag vX.Y.Z`, then `git push origin vX.Y.Z`.
  - For signed builds: add `SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`; otherwise builds are unsigned.
  - For dry-runs: `gh workflow run release.yml --ref <branch> -f tag=v0.0.0-dev-$(date +%s)`; assets land on the Release page and as the `agentic-browser-<sha>` artifact.

<sup>Written for commit ebf128b20bee57b092ca044df74fc2dddad6e29f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

