### PR TITLE
fix: resolve shell UI issues (tabs, agent stream, dropdowns, favicons)

### DIFF
--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -208,6 +208,12 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
+        {
+          // Issue #105: new tab page preload
+          entry: 'src/preload/newtab.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
       ],
       renderer: [
         {
@@ -259,6 +265,11 @@ const config: ForgeConfig = {
           // Issue #97: print preview renderer
           name: 'print_preview',
           config: 'vite.printPreview.config.ts',
+        },
+        {
+          // Issue #105: new tab page renderer
+          name: 'newtab',
+          config: 'vite.newtab.config.ts',
         },
       ],
     }),

--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -54,6 +54,8 @@ const CH_OPEN_FILE = 'downloads:open-file';
 const CH_SHOW_IN_FOLDER = 'downloads:show-in-folder';
 const CH_SET_OPEN_WHEN_DONE = 'downloads:set-open-when-done';
 const CH_CLEAR_COMPLETED = 'downloads:clear-completed';
+const CH_REMOVE = 'downloads:remove';
+const CH_CLEAR_ALL = 'downloads:clear-all';
 const CH_GET_SHOW_ON_COMPLETE = 'downloads:get-show-on-complete';
 const CH_SET_SHOW_ON_COMPLETE = 'downloads:set-show-on-complete';
 
@@ -241,6 +243,14 @@ export class DownloadManager {
       this.clearCompleted();
     });
 
+    ipcMain.handle(CH_REMOVE, (_e, id: string) => {
+      this.removeFromList(id);
+    });
+
+    ipcMain.handle(CH_CLEAR_ALL, () => {
+      this.clearAll();
+    });
+
     ipcMain.handle(CH_GET_SHOW_ON_COMPLETE, () => {
       return this.getShowOnComplete();
     });
@@ -249,7 +259,7 @@ export class DownloadManager {
       this.setShowOnComplete(value);
     });
 
-    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 10 });
+    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 12 });
   }
 
   // ---------------------------------------------------------------------------
@@ -351,6 +361,35 @@ export class DownloadManager {
     this.broadcastState();
   }
 
+  private removeFromList(id: string): void {
+    const dl = this.downloads.get(id);
+    if (!dl) {
+      mainLogger.warn('DownloadManager.removeFromList.notFound', { id });
+      return;
+    }
+    const eItem = this.electronItems.get(id);
+    if (eItem) {
+      eItem.cancel();
+      this.electronItems.delete(id);
+    }
+    this.downloads.delete(id);
+    this.clearThrottle(id);
+    mainLogger.info('DownloadManager.removeFromList', { id, filename: dl.filename });
+    this.broadcastState();
+  }
+
+  private clearAll(): void {
+    for (const [id, eItem] of this.electronItems) {
+      eItem.cancel();
+      this.clearThrottle(id);
+    }
+    this.electronItems.clear();
+    const count = this.downloads.size;
+    this.downloads.clear();
+    mainLogger.info('DownloadManager.clearAll', { removed: count });
+    this.broadcastState();
+  }
+
   // ---------------------------------------------------------------------------
   // Settings: show downloads when done
   // ---------------------------------------------------------------------------
@@ -434,6 +473,8 @@ export class DownloadManager {
     ipcMain.removeHandler(CH_SHOW_IN_FOLDER);
     ipcMain.removeHandler(CH_SET_OPEN_WHEN_DONE);
     ipcMain.removeHandler(CH_CLEAR_COMPLETED);
+    ipcMain.removeHandler(CH_REMOVE);
+    ipcMain.removeHandler(CH_CLEAR_ALL);
     ipcMain.removeHandler(CH_GET_SHOW_ON_COMPLETE);
     ipcMain.removeHandler(CH_SET_SHOW_ON_COMPLETE);
     for (const timer of this.throttleTimers.values()) {

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -26,17 +26,20 @@ import { attachContextMenu } from '../contextMenu/ContextMenuController';
 import { getFormDetectorScript, FORM_DETECTOR_PREFIX } from '../passwords/formDetector';
 import { readPrefs } from '../settings/ipc';
 
-// Chrome's chrome://newtab is a local page — zero network, instant paint.
-// We mirror that with a dark-themed data: URL so a new tab opens instantly
-// instead of waiting on google.com. The body is intentionally empty; the
-// URL bar is auto-focused (see createTab) so the user can type right away.
-const NEW_TAB_URL =
-  'data:text/html;charset=utf-8,' +
-  encodeURIComponent(
-    '<!DOCTYPE html><html><head><meta charset="utf-8"><title>New Tab</title>' +
-      '<style>html,body{margin:0;height:100vh;background:#0a0a0d}</style>' +
-      '</head><body></body></html>',
-  );
+// Forge VitePlugin globals for the new-tab page (injected at build time)
+declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
+declare const NEWTAB_VITE_NAME: string | undefined;
+
+function resolveNewTabUrl(): string {
+  if (typeof NEWTAB_VITE_DEV_SERVER_URL !== 'undefined' && NEWTAB_VITE_DEV_SERVER_URL) {
+    return NEWTAB_VITE_DEV_SERVER_URL + '/src/renderer/newtab/newtab.html';
+  }
+  const name = typeof NEWTAB_VITE_NAME !== 'undefined' ? NEWTAB_VITE_NAME : 'newtab';
+  return 'file://' + path.join(__dirname, '..', '..', 'renderer', name, 'newtab.html');
+}
+
+const NEW_TAB_URL = resolveNewTabUrl();
+const NEWTAB_PRELOAD = path.join(__dirname, 'newtab.js');
 // Must stay in sync with --chrome-height in shell.css (tab row 40 + toolbar 36).
 // The renderer can add extra height (e.g. a 32 px bookmarks bar) by calling
 // TabManager.setChromeOffset(offset); positionView() uses BASE + offset.
@@ -94,6 +97,7 @@ const CHROME_URL_RE = /^chrome:\/\/([a-z-]+)\/?$/i;
 
 // URLs that should not be recorded in browsing history
 const SKIP_HISTORY_RE = /^(data:|about:|chrome:|devtools:|view-source:)/i;
+const NEWTAB_URL_RE = /newtab\.html$/;
 
 export class TabManager {
   private win: BrowserWindow;
@@ -322,6 +326,9 @@ export class TabManager {
       nodeIntegration: false,
       sandbox: true,
     };
+    if (isUserInitiated) {
+      webPrefs.preload = NEWTAB_PRELOAD;
+    }
     if (this.partition) {
       webPrefs.partition = this.partition;
     }

--- a/my-app/src/preload/downloads.ts
+++ b/my-app/src/preload/downloads.ts
@@ -1,0 +1,55 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+export type DownloadStatus =
+  | 'in-progress'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'interrupted';
+
+export interface DownloadItemDTO {
+  id: string;
+  filename: string;
+  url: string;
+  savePath: string;
+  totalBytes: number;
+  receivedBytes: number;
+  status: DownloadStatus;
+  startTime: number;
+  endTime: number | null;
+  openWhenDone: boolean;
+  speed: number;
+  eta: number;
+}
+
+contextBridge.exposeInMainWorld('downloadsAPI', {
+  getAll: (): Promise<DownloadItemDTO[]> =>
+    ipcRenderer.invoke('downloads:get-all'),
+
+  pause: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:pause', id),
+
+  resume: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:resume', id),
+
+  cancel: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:cancel', id),
+
+  openFile: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:open-file', id),
+
+  showInFolder: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:show-in-folder', id),
+
+  remove: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:remove', id),
+
+  clearAll: (): Promise<void> =>
+    ipcRenderer.invoke('downloads:clear-all'),
+
+  onStateChanged: (cb: (downloads: DownloadItemDTO[]) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: DownloadItemDTO[]) => cb(data);
+    ipcRenderer.on('downloads-state', handler);
+    return () => { ipcRenderer.removeListener('downloads-state', handler); };
+  },
+});

--- a/my-app/src/renderer/design/theme.shell.css
+++ b/my-app/src/renderer/design/theme.shell.css
@@ -126,7 +126,7 @@
   -webkit-app-region: no-drag;
 }
 
-/* Tab strip */
+/* Tab strip — no border-bottom so the active tab merges into the toolbar */
 [data-theme="shell"] .tab-strip {
   display: flex;
   align-items: flex-end;
@@ -134,7 +134,6 @@
   padding-inline: var(--space-2);
   gap: 1px;
   background-color: var(--color-bg-base);
-  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 [data-theme="shell"] .tab {
@@ -171,7 +170,7 @@
 [data-theme="shell"] .url-bar {
   display: flex;
   align-items: center;
-  height: 32px;
+  height: 36px;
   padding-inline: 10px;
   border-radius: var(--radius-md);
   background-color: var(--color-bg-elevated);

--- a/my-app/src/renderer/downloads/DownloadsPage.tsx
+++ b/my-app/src/renderer/downloads/DownloadsPage.tsx
@@ -1,0 +1,434 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+type DownloadStatus = 'in-progress' | 'paused' | 'completed' | 'cancelled' | 'interrupted';
+
+interface DownloadItemDTO {
+  id: string;
+  filename: string;
+  url: string;
+  savePath: string;
+  totalBytes: number;
+  receivedBytes: number;
+  status: DownloadStatus;
+  startTime: number;
+  endTime: number | null;
+  openWhenDone: boolean;
+  speed: number;
+  eta: number;
+}
+
+declare const downloadsAPI: {
+  getAll: () => Promise<DownloadItemDTO[]>;
+  pause: (id: string) => Promise<void>;
+  resume: (id: string) => Promise<void>;
+  cancel: (id: string) => Promise<void>;
+  openFile: (id: string) => Promise<void>;
+  showInFolder: (id: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  clearAll: () => Promise<void>;
+  onStateChanged: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const val = bytes / Math.pow(1024, i);
+  return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatSpeed(bytesPerSec: number): string {
+  if (bytesPerSec <= 0) return '';
+  return `${formatBytes(bytesPerSec)}/s`;
+}
+
+function formatEta(seconds: number): string {
+  if (seconds <= 0) return '';
+  if (seconds < 60) return `${seconds}s left`;
+  if (seconds < 3600) return `${Math.ceil(seconds / 60)}m left`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.ceil((seconds % 3600) / 60);
+  return `${h}h ${m}m left`;
+}
+
+function getDateLabel(ts: number): string {
+  const now = new Date();
+  const date = new Date(ts);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const entryDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+  if (entryDate.getTime() === today.getTime()) return 'Today';
+  if (entryDate.getTime() === yesterday.getTime()) return 'Yesterday';
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function groupByDate(items: DownloadItemDTO[]): Map<string, DownloadItemDTO[]> {
+  const groups = new Map<string, DownloadItemDTO[]>();
+  for (const item of items) {
+    const label = getDateLabel(item.startTime);
+    const group = groups.get(label);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(label, [item]);
+    }
+  }
+  return groups;
+}
+
+function matchesSearch(item: DownloadItemDTO, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    item.filename.toLowerCase().includes(q) ||
+    item.url.toLowerCase().includes(q)
+  );
+}
+
+function domainLabel(pageUrl: string): string {
+  try {
+    return new URL(pageUrl).hostname.replace(/^www\./, '');
+  } catch {
+    return pageUrl;
+  }
+}
+
+function fileExtension(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return '';
+  return filename.slice(dot + 1).toUpperCase();
+}
+
+function statusLabel(status: DownloadStatus): string {
+  switch (status) {
+    case 'cancelled': return 'Cancelled';
+    case 'interrupted': return 'Interrupted';
+    case 'paused': return 'Paused';
+    default: return '';
+  }
+}
+
+function DownloadEntry({
+  item,
+  onPause,
+  onResume,
+  onCancel,
+  onOpenFile,
+  onShowInFolder,
+  onCopyLink,
+  onRemove,
+}: {
+  item: DownloadItemDTO;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onCancel: (id: string) => void;
+  onOpenFile: (id: string) => void;
+  onShowInFolder: (id: string) => void;
+  onCopyLink: (url: string) => void;
+  onRemove: (id: string) => void;
+}): React.ReactElement {
+  const isActive = item.status === 'in-progress' || item.status === 'paused';
+  const isCompleted = item.status === 'completed';
+  const progress = item.totalBytes > 0
+    ? Math.round((item.receivedBytes / item.totalBytes) * 100)
+    : 0;
+
+  const ext = fileExtension(item.filename);
+
+  return (
+    <div className={`dl__entry dl__entry--${item.status}`}>
+      <div className="dl__entry-icon">
+        <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+          <rect x="6" y="4" width="20" height="24" rx="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
+          <path d="M12 4V10H6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        {ext && <span className="dl__entry-ext">{ext}</span>}
+      </div>
+
+      <div className="dl__entry-info">
+        <div className="dl__entry-name-row">
+          {isCompleted ? (
+            <button
+              type="button"
+              className="dl__entry-name dl__entry-name--link"
+              onClick={() => onOpenFile(item.id)}
+              title={item.savePath}
+            >
+              {item.filename}
+            </button>
+          ) : (
+            <span className="dl__entry-name" title={item.savePath || item.filename}>
+              {item.filename}
+            </span>
+          )}
+        </div>
+
+        <div className="dl__entry-meta">
+          {isActive && (
+            <>
+              <span className="dl__entry-progress-text">
+                {formatBytes(item.receivedBytes)}
+                {item.totalBytes > 0 && ` / ${formatBytes(item.totalBytes)}`}
+              </span>
+              {item.status === 'in-progress' && item.speed > 0 && (
+                <span className="dl__entry-speed">{formatSpeed(item.speed)}</span>
+              )}
+              {item.status === 'in-progress' && item.eta > 0 && (
+                <span className="dl__entry-eta">{formatEta(item.eta)}</span>
+              )}
+              {item.status === 'paused' && (
+                <span className="dl__entry-status-label">Paused</span>
+              )}
+            </>
+          )}
+          {!isActive && (
+            <>
+              {item.totalBytes > 0 && (
+                <span className="dl__entry-size">{formatBytes(item.totalBytes)}</span>
+              )}
+              <span className="dl__entry-source">{domainLabel(item.url)}</span>
+              {(item.status === 'cancelled' || item.status === 'interrupted') && (
+                <span className="dl__entry-status-label dl__entry-status-label--warn">
+                  {statusLabel(item.status)}
+                </span>
+              )}
+            </>
+          )}
+        </div>
+
+        {isActive && item.totalBytes > 0 && (
+          <div className="dl__progress-bar">
+            <div
+              className={`dl__progress-fill ${item.status === 'paused' ? 'dl__progress-fill--paused' : ''}`}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="dl__entry-actions">
+        {item.status === 'in-progress' && (
+          <>
+            <button type="button" className="dl__action-btn" onClick={() => onPause(item.id)} title="Pause">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <rect x="4" y="3" width="3" height="10" rx="0.5" fill="currentColor" />
+                <rect x="9" y="3" width="3" height="10" rx="0.5" fill="currentColor" />
+              </svg>
+            </button>
+            <button type="button" className="dl__action-btn dl__action-btn--danger" onClick={() => onCancel(item.id)} title="Cancel">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </>
+        )}
+        {item.status === 'paused' && (
+          <>
+            <button type="button" className="dl__action-btn" onClick={() => onResume(item.id)} title="Resume">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <polygon points="5,3 13,8 5,13" fill="currentColor" />
+              </svg>
+            </button>
+            <button type="button" className="dl__action-btn dl__action-btn--danger" onClick={() => onCancel(item.id)} title="Cancel">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </>
+        )}
+        {isCompleted && (
+          <button type="button" className="dl__action-btn" onClick={() => onShowInFolder(item.id)} title="Show in Finder">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M2 4.5C2 3.67 2.67 3 3.5 3H6l1.5 1.5H12.5C13.33 4.5 14 5.17 14 6V11.5C14 12.33 13.33 13 12.5 13H3.5C2.67 13 2 12.33 2 11.5V4.5Z" stroke="currentColor" strokeWidth="1.3" fill="none" />
+            </svg>
+          </button>
+        )}
+        <button type="button" className="dl__action-btn" onClick={() => onCopyLink(item.url)} title="Copy download link">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <rect x="5" y="5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.3" fill="none" />
+            <path d="M3 11V3.5C3 3.22 3.22 3 3.5 3H11" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
+        <button type="button" className="dl__action-btn dl__action-btn--danger" onClick={() => onRemove(item.id)} title="Remove from list">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function DownloadsPage(): React.ReactElement {
+  const [downloads, setDownloads] = useState<DownloadItemDTO[]>([]);
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const fetchDownloads = useCallback(async () => {
+    try {
+      const items = await downloadsAPI.getAll();
+      items.sort((a, b) => b.startTime - a.startTime);
+      setDownloads(items);
+    } catch (err) {
+      console.error('DownloadsPage.fetchDownloads.failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDownloads();
+  }, [fetchDownloads]);
+
+  useEffect(() => {
+    const unsub = downloadsAPI.onStateChanged((items) => {
+      items.sort((a, b) => b.startTime - a.startTime);
+      setDownloads(items);
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setQuery(val);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(val);
+    }, 200);
+  }, []);
+
+  const handlePause = useCallback(async (id: string) => {
+    console.log('DownloadsPage.pause', { id });
+    await downloadsAPI.pause(id);
+  }, []);
+
+  const handleResume = useCallback(async (id: string) => {
+    console.log('DownloadsPage.resume', { id });
+    await downloadsAPI.resume(id);
+  }, []);
+
+  const handleCancel = useCallback(async (id: string) => {
+    console.log('DownloadsPage.cancel', { id });
+    await downloadsAPI.cancel(id);
+  }, []);
+
+  const handleOpenFile = useCallback(async (id: string) => {
+    console.log('DownloadsPage.openFile', { id });
+    await downloadsAPI.openFile(id);
+  }, []);
+
+  const handleShowInFolder = useCallback(async (id: string) => {
+    console.log('DownloadsPage.showInFolder', { id });
+    await downloadsAPI.showInFolder(id);
+  }, []);
+
+  const handleCopyLink = useCallback(async (url: string) => {
+    console.log('DownloadsPage.copyLink', { url: url.slice(0, 100) });
+    await navigator.clipboard.writeText(url);
+    setCopiedId(url);
+    setTimeout(() => setCopiedId(null), 1500);
+  }, []);
+
+  const handleRemove = useCallback(async (id: string) => {
+    console.log('DownloadsPage.remove', { id });
+    await downloadsAPI.remove(id);
+    setDownloads((prev) => prev.filter((d) => d.id !== id));
+  }, []);
+
+  const handleClearAll = useCallback(async () => {
+    console.log('DownloadsPage.clearAll');
+    await downloadsAPI.clearAll();
+    setDownloads([]);
+  }, []);
+
+  const filtered = debouncedQuery
+    ? downloads.filter((d) => matchesSearch(d, debouncedQuery))
+    : downloads;
+  const groups = groupByDate(filtered);
+
+  return (
+    <div className="dl">
+      <header className="dl__header">
+        <h1 className="dl__title">Downloads</h1>
+        {downloads.length > 0 && (
+          <button
+            type="button"
+            className="dl__clear-btn"
+            onClick={handleClearAll}
+          >
+            Clear all
+          </button>
+        )}
+      </header>
+
+      <div className="dl__search-container">
+        <svg className="dl__search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" />
+          <line x1="11" y1="11" x2="14.5" y2="14.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+        <input
+          ref={searchRef}
+          className="dl__search"
+          type="text"
+          value={query}
+          onChange={handleQueryChange}
+          placeholder="Search downloads"
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          aria-label="Search downloads"
+        />
+      </div>
+
+      <div className="dl__content">
+        {loading ? (
+          <div className="dl__empty">Loading...</div>
+        ) : filtered.length === 0 ? (
+          <div className="dl__empty">
+            {debouncedQuery ? 'No results found' : 'No downloads'}
+          </div>
+        ) : (
+          Array.from(groups.entries()).map(([dateLabel, groupItems]) => (
+            <div key={dateLabel} className="dl__group">
+              <h2 className="dl__date-label">{dateLabel}</h2>
+              <div className="dl__entries">
+                {groupItems.map((item) => (
+                  <DownloadEntry
+                    key={item.id}
+                    item={item}
+                    onPause={handlePause}
+                    onResume={handleResume}
+                    onCancel={handleCancel}
+                    onOpenFile={handleOpenFile}
+                    onShowInFolder={handleShowInFolder}
+                    onCopyLink={handleCopyLink}
+                    onRemove={handleRemove}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {copiedId && <div className="dl__toast">Link copied</div>}
+    </div>
+  );
+}

--- a/my-app/src/renderer/downloads/downloads.css
+++ b/my-app/src/renderer/downloads/downloads.css
@@ -1,0 +1,294 @@
+.dl {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  font-family: var(--font-ui);
+  color: var(--color-fg-primary);
+  min-height: 100vh;
+  background-color: var(--color-bg-base);
+}
+
+.dl__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.dl__title {
+  font-size: 22px;
+  font-weight: 500;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.dl__clear-btn {
+  margin-left: auto;
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.dl__clear-btn:hover {
+  background-color: var(--color-surface-interactive-hover);
+  border-color: var(--color-border-strong);
+}
+
+.dl__search-container {
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.dl__search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-fg-tertiary);
+  pointer-events: none;
+}
+
+.dl__search {
+  width: 100%;
+  padding: 10px 12px 10px 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 120ms ease;
+}
+
+.dl__search:focus {
+  border-color: var(--color-accent-default);
+}
+
+.dl__search::placeholder {
+  color: var(--color-fg-tertiary);
+}
+
+.dl__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.dl__empty {
+  text-align: center;
+  padding: 48px 0;
+  color: var(--color-fg-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+.dl__group {
+  margin-bottom: 8px;
+}
+
+.dl__date-label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-fg-secondary);
+  padding: 12px 0 8px;
+  margin: 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.dl__entries {
+  display: flex;
+  flex-direction: column;
+}
+
+.dl__entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 8px;
+  border-radius: var(--radius-sm);
+  transition: background-color 80ms ease;
+}
+
+.dl__entry:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.dl__entry-icon {
+  position: relative;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  color: var(--color-fg-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dl__entry--completed .dl__entry-icon {
+  color: var(--color-accent-default);
+}
+
+.dl__entry-ext {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  color: var(--color-fg-tertiary);
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.dl__entry-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dl__entry-name-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.dl__entry-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font-ui);
+  text-align: left;
+}
+
+.dl__entry-name--link {
+  cursor: pointer;
+  color: var(--color-accent-default);
+}
+
+.dl__entry-name--link:hover {
+  text-decoration: underline;
+}
+
+.dl__entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  flex-wrap: wrap;
+}
+
+.dl__entry-meta > span + span::before {
+  content: '\00b7';
+  margin-right: 8px;
+}
+
+.dl__entry-status-label {
+  font-weight: 500;
+}
+
+.dl__entry-status-label--warn {
+  color: var(--color-status-warning);
+}
+
+.dl__progress-bar {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--color-border-subtle);
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.dl__progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--color-accent-default);
+  transition: width 250ms ease;
+}
+
+.dl__progress-fill--paused {
+  background: var(--color-fg-tertiary);
+}
+
+.dl__entry-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 80ms ease;
+}
+
+.dl__entry:hover .dl__entry-actions {
+  opacity: 1;
+}
+
+.dl__entry--in-progress .dl__entry-actions,
+.dl__entry--paused .dl__entry-actions {
+  opacity: 1;
+}
+
+.dl__action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: none;
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color 80ms ease, color 80ms ease;
+}
+
+.dl__action-btn:hover {
+  background-color: var(--color-surface-interactive-active);
+  color: var(--color-fg-primary);
+}
+
+.dl__action-btn--danger:hover {
+  color: var(--color-status-danger);
+}
+
+.dl__toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  animation: dl-toast-in 150ms ease;
+}
+
+@keyframes dl-toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}

--- a/my-app/src/renderer/downloads/downloads.html
+++ b/my-app/src/renderer/downloads/downloads.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en" data-theme="shell">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Downloads</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/my-app/src/renderer/downloads/index.tsx
+++ b/my-app/src/renderer/downloads/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { DownloadsPage } from './DownloadsPage';
+import '../design/theme.global.css';
+import './downloads.css';
+
+window.addEventListener('error', (e) => {
+  console.error('downloads.error', { message: e.message, file: e.filename, line: e.lineno });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('downloads.unhandledrejection', { reason: String(e.reason) });
+});
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('[downloads] #root element not found');
+
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <DownloadsPage />
+  </React.StrictMode>,
+);

--- a/my-app/src/renderer/pill/AgentStream.tsx
+++ b/my-app/src/renderer/pill/AgentStream.tsx
@@ -35,6 +35,37 @@ function safePreview(x: unknown, max = 80): string {
   } catch { return String(x).slice(0, max); }
 }
 
+function renderInlineMarkdown(text: string): React.ReactElement {
+  const parts: React.ReactNode[] = [];
+  const regex = /(\*\*(.+?)\*\*|`(.+?)`|\*(.+?)\*)/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > last) parts.push(text.slice(last, match.index));
+    if (match[2]) parts.push(<strong key={key++}>{match[2]}</strong>);
+    else if (match[3]) parts.push(<code key={key++} className="pill-stream-inline-code">{match[3]}</code>);
+    else if (match[4]) parts.push(<em key={key++}>{match[4]}</em>);
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return <>{parts}</>;
+}
+
+function ThinkingBlock({ text }: { text: string }): React.ReactElement {
+  const lines = text.split('\n');
+  return (
+    <div className="pill-stream-entry pill-stream-entry--thinking">
+      {lines.map((line, i) => {
+        if (line.startsWith('- ') || line.startsWith('* ')) {
+          return <div key={i} className="pill-stream-md-li">{renderInlineMarkdown(line.slice(2))}</div>;
+        }
+        return <span key={i}>{renderInlineMarkdown(line)}{i < lines.length - 1 ? '\n' : ''}</span>;
+      })}
+    </div>
+  );
+}
+
 /** Reducer: push one hl event into the running entry list. */
 export function applyHlEvent(entries: StreamEntry[], e: HlEventLike): StreamEntry[] {
   if (e.type === 'thinking' && e.text) {
@@ -46,7 +77,6 @@ export function applyHlEvent(entries: StreamEntry[], e: HlEventLike): StreamEntr
     return [...entries, entry].slice(-MAX_ENTRIES);
   }
   if (e.type === 'tool_result' && e.name) {
-    // Patch the last matching tool entry without a result.
     const out = entries.slice();
     for (let i = out.length - 1; i >= 0; i--) {
       const en = out[i];
@@ -88,16 +118,14 @@ export function AgentStream({ entries, iteration, maxIterations, onStop }: Agent
         )}
         {entries.map((en, i) => {
           if (en.kind === 'thinking') {
-            return <div key={i} className="pill-stream-entry pill-stream-entry--thinking">{en.text}</div>;
+            return <ThinkingBlock key={i} text={en.text} />;
           }
           const status = en.ok === undefined ? '⋯' : en.ok ? '✓' : '✗';
           return (
             <div key={i} className={`pill-stream-entry pill-stream-entry--tool ${en.ok === false ? 'is-error' : ''}`}>
-              <span className="pill-stream-tool-name">▶ {en.name}</span>
-              <span className="pill-stream-tool-args">({en.argsPreview})</span>
-              <div className="pill-stream-tool-result">
+              <div className="pill-stream-tool-row">
                 <span className="pill-stream-tool-status">{status}</span>
-                {en.resultPreview && <span className="pill-stream-tool-preview">{en.resultPreview}</span>}
+                <span className="pill-stream-tool-name">{en.name}</span>
                 {typeof en.ms === 'number' && <span className="pill-stream-tool-ms">{en.ms}ms</span>}
               </div>
             </div>

--- a/my-app/src/renderer/pill/pill.css
+++ b/my-app/src/renderer/pill/pill.css
@@ -63,7 +63,7 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background: #0a0a0d;
+  background: transparent;
   overflow: hidden;
   font-family: var(--font-ui, 'Geist', system-ui, sans-serif);
   -webkit-font-smoothing: antialiased;
@@ -73,7 +73,6 @@ body {
 
 #pill-root {
   width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -747,10 +746,17 @@ body {
 .pill-stream-entry--thinking {
   color: var(--color-fg-secondary, #8a8f98);
   font-style: italic;
+  white-space: pre-wrap;
 }
 
 .pill-stream-entry--tool {
   color: var(--color-fg-primary, #f0f0f2);
+}
+
+.pill-stream-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .pill-stream-tool-name {
@@ -759,39 +765,14 @@ body {
   font-size: 12px;
 }
 
-.pill-stream-tool-args {
-  color: var(--color-fg-tertiary, #6e737d);
-  font-family: var(--font-mono, 'Berkeley Mono', ui-monospace, monospace);
-  font-size: 11px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.pill-stream-tool-result {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding-left: 14px;
-  color: var(--color-fg-secondary, #8a8f98);
-  font-size: 11px;
-}
-
 .pill-stream-tool-status {
   font-family: var(--font-mono, 'Berkeley Mono', ui-monospace, monospace);
   color: var(--color-accent-default, #c8f135);
+  flex-shrink: 0;
 }
 
 .pill-stream-entry.is-error .pill-stream-tool-status {
   color: var(--color-status-error, #f87171);
-}
-
-.pill-stream-tool-preview {
-  font-family: var(--font-mono, 'Berkeley Mono', ui-monospace, monospace);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 280px;
 }
 
 .pill-stream-tool-ms {
@@ -799,4 +780,23 @@ body {
   font-family: var(--font-mono, 'Berkeley Mono', ui-monospace, monospace);
   font-size: 10px;
   color: var(--color-fg-tertiary, #6e737d);
+}
+
+.pill-stream-md-li {
+  padding-left: 10px;
+  position: relative;
+}
+
+.pill-stream-md-li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+}
+
+.pill-stream-inline-code {
+  font-family: var(--font-mono, 'Berkeley Mono', ui-monospace, monospace);
+  font-size: 11px;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
 }

--- a/my-app/src/renderer/shell/ProfileMenu.tsx
+++ b/my-app/src/renderer/shell/ProfileMenu.tsx
@@ -29,11 +29,15 @@ interface Profile {
   color: string;
 }
 
+interface ProfileMenuProps {
+  onDropdownChange?: (open: boolean) => void;
+}
+
 function getInitial(name: string): string {
   return (name[0] ?? '?').toUpperCase();
 }
 
-export function ProfileMenu(): React.ReactElement {
+export function ProfileMenu({ onDropdownChange }: ProfileMenuProps): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [currentProfileId, setCurrentProfileId] = useState<string>('default');
@@ -59,10 +63,15 @@ export function ProfileMenu(): React.ReactElement {
     });
   }, []);
 
+  const setOpenState = useCallback((next: boolean) => {
+    setOpen(next);
+    onDropdownChange?.(next);
+  }, [onDropdownChange]);
+
   const toggle = useCallback(() => {
     console.log('[ProfileMenu] Toggle dropdown, currently:', open ? 'open' : 'closed');
-    setOpen((prev) => !prev);
-  }, [open]);
+    setOpenState(!open);
+  }, [open, setOpenState]);
 
   useEffect(() => {
     if (!open) return;
@@ -71,13 +80,13 @@ export function ProfileMenu(): React.ReactElement {
       const btn = btnRef.current;
       if (menu && !menu.contains(e.target as Node) && btn && !btn.contains(e.target as Node)) {
         console.log('[ProfileMenu] Outside click, closing');
-        setOpen(false);
+        setOpenState(false);
       }
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         console.log('[ProfileMenu] Escape pressed, closing');
-        setOpen(false);
+        setOpenState(false);
       }
     };
     const t = setTimeout(() => document.addEventListener('mousedown', onDocClick), 0);
@@ -87,22 +96,22 @@ export function ProfileMenu(): React.ReactElement {
       document.removeEventListener('mousedown', onDocClick);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open]);
+  }, [open, setOpenState]);
 
   const handleSwitchProfile = useCallback((id: string) => {
     console.log('[ProfileMenu] Switch to profile:', id);
-    setOpen(false);
+    setOpenState(false);
     electronAPI.profiles.switchTo(id).catch((err) => {
       console.error('[ProfileMenu] Switch failed:', err);
     });
-  }, []);
+  }, [setOpenState]);
 
   const handleAddProfile = useCallback(() => {
     const colorIndex = profiles.length % (colors.length || 10);
     const name = `Person ${profiles.length + 1}`;
     const color = colors[colorIndex] ?? '#6366f1';
     console.log('[ProfileMenu] Adding new profile:', name, color);
-    setOpen(false);
+    setOpenState(false);
     electronAPI.profiles.add({ name, color }).then((newProfile) => {
       console.log('[ProfileMenu] Profile created:', newProfile.id);
       setProfiles((prev) => [...prev, newProfile]);
@@ -112,12 +121,12 @@ export function ProfileMenu(): React.ReactElement {
     }).catch((err) => {
       console.error('[ProfileMenu] Add profile failed:', err);
     });
-  }, [profiles.length, colors]);
+  }, [profiles.length, colors, setOpenState]);
 
   const handleOpenGuest = useCallback(() => {
     console.log('[ProfileMenu] Opening guest window');
-    setOpen(false);
-  }, []);
+    setOpenState(false);
+  }, [setOpenState]);
 
   if (!currentProfile) {
     return <div className="profile-menu" />;

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -16,6 +16,18 @@ declare const electronAPI: {
 // Constants
 // ---------------------------------------------------------------------------
 const DRAG_THRESHOLD_PX = 4;
+const GOOGLE_FAVICON_API = 'https://www.google.com/s2/favicons?sz=32&domain_url=';
+
+function faviconSrc(tab: TabState): string | null {
+  if (tab.favicon) return tab.favicon;
+  try {
+    const parsed = new URL(tab.url);
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return GOOGLE_FAVICON_API + encodeURIComponent(parsed.origin);
+    }
+  } catch { /* ignore invalid URLs */ }
+  return null;
+}
 
 interface TabStripProps {
   tabs: TabState[];
@@ -55,6 +67,7 @@ function TabItem({
   onContextMenu,
 }: TabItemProps): React.ReactElement {
   const isPinned = tab.pinned;
+  const favicon = faviconSrc(tab);
   return (
     <div
       className={[
@@ -89,8 +102,8 @@ function TabItem({
             <path d="M11 5.5c.8.8 1.2 1.8 1.2 2.5s-.4 1.7-1.2 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
             <path d="M12.5 3.5C14 5 14.8 6.8 14.8 8s-.8 3-2.3 4.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
           </svg>
-        ) : tab.favicon ? (
-          <img src={tab.favicon} alt="" width={14} height={14} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+        ) : favicon ? (
+          <img src={favicon} alt="" width={16} height={16} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
         ) : (
           <span className="tab-item__favicon-placeholder" />
         )}

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -18,8 +18,6 @@ import { ProfileMenu } from './ProfileMenu';
 import { DownloadButton } from './DownloadButton';
 import { DownloadBubble } from './DownloadBubble';
 import { AppMenuButton } from './AppMenuButton';
-import { SidePanel, SidePanelToggleButton } from './SidePanel';
-import type { SidePanelId, SidePanelPosition } from './SidePanel';
 import type {
   TabManagerState,
   TabState,
@@ -33,9 +31,9 @@ import type {
 import type { DownloadItemDTO } from '../../main/downloads/DownloadManager';
 
 // Layout constants — keep in sync with shell.css.
-const BASE_CHROME_HEIGHT = 82;
+const BASE_CHROME_HEIGHT = 76;
 const BOOKMARKS_BAR_HEIGHT = 32;
-const DEFAULT_SIDE_PANEL_WIDTH = 340;
+const DROPDOWN_OVERFLOW_HEIGHT = 300;
 // Any tab URL starting with this scheme is a new-tab placeholder; the
 // bookmarks bar treats those as "NTP" for the 'ntp-only' visibility mode.
 const NTP_URL_RE = /^(data:|about:blank$)/i;
@@ -153,6 +151,7 @@ export function WindowChrome(): React.ReactElement {
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [urlBarFocused, setUrlBarFocused] = useState(false);
   const [zoomPercent, setZoomPercent] = useState(100);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   // Bookmarks state
   const [bookmarksTree, setBookmarksTree] = useState<PersistedBookmarks | null>(null);
@@ -164,12 +163,6 @@ export function WindowChrome(): React.ReactElement {
   const [bubbleOpen, setBubbleOpen] = useState(false);
   const [showOnComplete, setShowOnComplete] = useState(true);
   const autoDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Side panel state
-  const [sidePanelOpen, setSidePanelOpen] = useState(false);
-  const [sidePanelActiveId, setSidePanelActiveId] = useState<SidePanelId>('bookmarks');
-  const [sidePanelPosition, setSidePanelPosition] = useState<SidePanelPosition>('right');
-  const [sidePanelWidth, setSidePanelWidth] = useState(DEFAULT_SIDE_PANEL_WIDTH);
 
   // Derived active tab
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
@@ -231,20 +224,12 @@ export function WindowChrome(): React.ReactElement {
     });
   }, []);
 
-  // Push total chrome height to main whenever bar visibility changes so the
-  // WebContentsView repositions correctly.
+  // Push total chrome height to main whenever bar visibility or dropdown changes
+  // so the WebContentsView repositions correctly.
   useEffect(() => {
-    const total = BASE_CHROME_HEIGHT + (barVisible ? BOOKMARKS_BAR_HEIGHT : 0);
+    const total = BASE_CHROME_HEIGHT + (barVisible ? BOOKMARKS_BAR_HEIGHT : 0) + (dropdownOpen ? DROPDOWN_OVERFLOW_HEIGHT : 0);
     electronAPI.shell.setChromeHeight(total);
-  }, [barVisible]);
-
-  // Push side panel width to main whenever panel open state or width changes
-  useEffect(() => {
-    const effectiveWidth = sidePanelOpen ? sidePanelWidth : 0;
-    console.log('[WindowChrome] Side panel width changed:', effectiveWidth, 'position:', sidePanelPosition);
-    electronAPI.shell.setSidePanelWidth(effectiveWidth);
-    electronAPI.shell.setSidePanelPosition(sidePanelPosition);
-  }, [sidePanelOpen, sidePanelWidth, sidePanelPosition]);
+  }, [barVisible, dropdownOpen]);
 
   // ---------------------------------------------------------------------------
   // IPC event subscriptions
@@ -430,9 +415,9 @@ export function WindowChrome(): React.ReactElement {
   }, []);
 
   const handleStarClick = useCallback(() => {
-    if (!activeUrl) return;
+    if (!activeUrl || !bookmarksTree) return;
     setBookmarkDialogOpen(true);
-  }, [activeUrl]);
+  }, [activeUrl, bookmarksTree]);
 
   // ---------------------------------------------------------------------------
   // Download actions
@@ -448,31 +433,6 @@ export function WindowChrome(): React.ReactElement {
   const handleSetShowOnComplete = useCallback((value: boolean) => {
     setShowOnComplete(value);
     electronAPI.downloads.setShowOnComplete(value);
-  }, []);
-
-  // ---------------------------------------------------------------------------
-  // Side panel actions
-  // ---------------------------------------------------------------------------
-  const handleSidePanelToggle = useCallback(() => {
-    setSidePanelOpen((prev) => {
-      const next = !prev;
-      console.log('[WindowChrome] Side panel toggled:', next ? 'open' : 'closed');
-      return next;
-    });
-  }, []);
-
-  const handleSidePanelClose = useCallback(() => {
-    console.log('[WindowChrome] Side panel closed');
-    setSidePanelOpen(false);
-  }, []);
-
-  const handleSidePanelSelect = useCallback((id: SidePanelId) => {
-    console.log('[WindowChrome] Side panel selected:', id);
-    setSidePanelActiveId(id);
-  }, []);
-
-  const handleSidePanelWidthChange = useCallback((width: number) => {
-    setSidePanelWidth(width);
   }, []);
 
   // ---------------------------------------------------------------------------
@@ -550,12 +510,7 @@ export function WindowChrome(): React.ReactElement {
           )}
         </div>
 
-        <SidePanelToggleButton
-          isOpen={sidePanelOpen}
-          onClick={handleSidePanelToggle}
-        />
-
-        <ProfileMenu />
+        <ProfileMenu onDropdownChange={setDropdownOpen} />
         <AppMenuButton />
       </div>
 
@@ -572,7 +527,7 @@ export function WindowChrome(): React.ReactElement {
         />
       )}
 
-      {bookmarkDialogOpen && activeUrl && (
+      {bookmarkDialogOpen && activeUrl && bookmarksTree && (
         <BookmarkDialog
           url={activeUrl}
           title={activeTab?.title ?? ''}
@@ -585,17 +540,6 @@ export function WindowChrome(): React.ReactElement {
       <PermissionBar activeTabId={activeTabId} />
       <PasswordPromptBar activeTabId={activeTabId} />
       <FindBar activeTabId={activeTabId} />
-
-      <SidePanel
-        open={sidePanelOpen}
-        activePanel={sidePanelActiveId}
-        position={sidePanelPosition}
-        width={sidePanelWidth}
-        activeTabId={activeTabId}
-        onClose={handleSidePanelClose}
-        onSelectPanel={handleSidePanelSelect}
-        onWidthChange={handleSidePanelWidthChange}
-      />
     </div>
   );
 }

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -123,8 +123,8 @@
   content: '';
   position: absolute;
   left: -1px;
-  top: 6px;
-  bottom: 6px;
+  top: 25%;
+  bottom: 25%;
   width: 1px;
   background: var(--color-border-default);
   opacity: 0.4;
@@ -138,7 +138,7 @@
 }
 
 .tab-item:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.04);
   color: var(--color-fg-primary);
 }
 
@@ -149,7 +149,7 @@
    active state. */
 .tab-item--active,
 .tab-item--active:hover {
-  background: var(--color-tab-active);
+  background: var(--color-bg-elevated);
   color: var(--color-fg-primary);
   margin-bottom: -1px;
   padding-bottom: 1px;

--- a/my-app/vite.downloads.config.ts
+++ b/my-app/vite.downloads.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/downloads/downloads.html'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- **AgentStream**: hide raw tool args JSON, render only tool name + status + timing; add basic markdown rendering for thinking text; fix pill window black area (transparent bg, remove height:100%)
- **Tabs**: remove active tab black border-bottom; match active tab bg to toolbar; subtle hover; center vertical separators; add Google Favicon API fallback
- **URL bar**: fix height override (32px→36px) to match Chrome proportions
- **Star/bookmark**: guard against null bookmarksTree to prevent black screen crash
- **ProfileMenu**: fix dropdown visibility by expanding chrome height when open
- **Sidebar**: removed broken side panel from toolbar
- **Black strip**: fix BASE_CHROME_HEIGHT mismatch (82→76px)

## Test plan
- [ ] Verify agent stream shows tool name + status without raw JSON args
- [ ] Verify thinking text renders bold/italic/code markdown
- [ ] Verify no black area below pill stream entries
- [ ] Verify active tab has no black underline and blends into toolbar
- [ ] Verify tab hover is subtle, separators are centered
- [ ] Verify favicons appear on tabs (Google API fallback)
- [ ] Verify URL bar is 36px tall, spans full toolbar width
- [ ] Verify star button opens bookmark dialog without black screen
- [ ] Verify profile dropdown renders visibly when clicked
- [ ] Verify no black strip below toolbar
- [ ] Verify sidebar toggle button is removed from toolbar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a full `chrome://downloads` page with searchable, real-time download history and item controls. Also fixes several shell UI issues (tabs, agent stream, dropdown overflow, URL bar sizing, favicons) to remove visual glitches and a crash.

- **New Features**
  - `chrome://downloads` page: search, date groups, per-item actions (pause/resume/cancel/open/show/copy/remove), Clear all, live IPC updates; shortcut: Cmd+Shift+J / Ctrl+J.
  - Preload API for downloads and new IPC handlers `downloads:remove` and `downloads:clear-all`.
  - Build setup for downloads UI (`vite.downloads.config.ts`, renderer entry).

- **Bug Fixes**
  - `AgentStream`: hide raw tool args; show tool name + status + ms; basic markdown for thinking; transparent background and fixed sizing.
  - Tabs/toolbar: remove active tab underline; match active bg to toolbar; subtle hover; centered separators; URL bar height set to 36px; `BASE_CHROME_HEIGHT` set to 76 to remove the black strip.
  - Favicons: fallback to Google Favicon API when site favicon is missing.
  - Profile/bookmarks: expand chrome height when `ProfileMenu` is open to prevent clipping; guard against null `bookmarksTree` to avoid the star dialog crash; removed broken sidebar toggle.

<sup>Written for commit b994c2579113fe05ccad8a4f9a8a57219acfdfc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

