### PR TITLE
fix(e2e): resolve electron.launch 30s timeout in Playwright regression

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,9 @@ jobs:
         # preload-path.spec.ts launches ./node_modules/.bin/electron against
         # .vite/build/main.js directly (dev-mode style). It does NOT use the
         # packaged out/my-app.app bundle — it needs the .vite/ output tree.
-        run: npm run package -- --skip-signing
+        env:
+          SKIP_SIGNING: '1'
+        run: npm run package
 
       - name: Playwright regression tests
         working-directory: my-app

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,15 +56,9 @@ jobs:
           if-no-files-found: error
 
   regression:
-    name: Playwright regression [soft-fail]
+    name: Playwright regression
     runs-on: macos-latest
-    needs: build
     timeout-minutes: 20
-    # The `preload-path` regression spec hits the same Electron launch
-    # hang that e2e-smoke does (electron.launch never resolves within
-    # 30s on CI macOS runners — also reproduces locally). Soft-fail
-    # until the launch-hang root cause is fixed. See docs/CI.md.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -78,24 +72,15 @@ jobs:
         working-directory: my-app
         run: npm ci --no-audit --no-fund
 
-      - name: Download built app
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-app-${{ github.sha }}
-          path: my-app/out/
-
-      - name: Restore permissions on Electron binary
+      - name: Build main + preload + renderer bundles
         working-directory: my-app
-        run: |
-          APP_DIR=$(ls -d out/my-app-darwin-* | head -n 1)
-          chmod +x "${APP_DIR}/my-app.app/Contents/MacOS/my-app"
+        # preload-path.spec.ts launches ./node_modules/.bin/electron against
+        # .vite/build/main.js directly (dev-mode style). It does NOT use the
+        # packaged out/my-app.app bundle — it needs the .vite/ output tree.
+        run: npm run package -- --skip-signing
 
       - name: Playwright regression tests
         working-directory: my-app
-        # Regression specs live outside the testDir in the shared
-        # playwright.config.ts (which targets tests/e2e). Use the default
-        # playwright config resolver + an inline testDir override so the
-        # positional arg actually matches.
         run: npx playwright test --config=tests/regression/playwright.regression.config.ts
 
       - name: Upload Playwright report

--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -209,12 +209,15 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
-        {
-          // Issue #105: new tab page preload
-          entry: 'src/preload/newtab.ts',
-          config: 'vite.preload.config.ts',
-          target: 'preload',
-        },
+        // Issue #105: new tab page preload — disabled in CI until
+        // src/preload/newtab.ts lands alongside the newtab renderer.
+        // Without this guard electron-forge fails the production build.
+        // Restore once the file exists.
+        // {
+        //   entry: 'src/preload/newtab.ts',
+        //   config: 'vite.preload.config.ts',
+        //   target: 'preload',
+        // },
       ],
       renderer: [
         {
@@ -270,11 +273,13 @@ const config: ForgeConfig = {
           name: 'print_preview',
           config: 'vite.printPreview.config.ts',
         },
-        {
-          // Issue #105: new tab page renderer
-          name: 'newtab',
-          config: 'vite.newtab.config.ts',
-        },
+        // Issue #105: new tab page renderer — disabled in CI until
+        // vite.newtab.config.ts lands. Without this guard electron-forge
+        // fails the production build. Restore once the file exists.
+        // {
+        //   name: 'newtab',
+        //   config: 'vite.newtab.config.ts',
+        // },
       ],
     }),
 

--- a/my-app/src/main/window.ts
+++ b/my-app/src/main/window.ts
@@ -114,12 +114,15 @@ export function createShellWindow(opts?: ShellWindowOptions): BrowserWindow {
     });
     win.webContents.openDevTools({ mode: 'detach' });
   } else {
-    // Forge VitePlugin outputs shell.html (matching the input filename).
-    // __dirname = .vite/build; renderer is at .vite/renderer/shell/shell.html
-    // so the path is one level up: ../renderer/shell/shell.html
+    // Forge VitePlugin preserves the HTML's location relative to Vite's `root`
+    // (which defaults to the project root when not overridden). The HTML is
+    // declared as src/renderer/shell/shell.html, so the built asset lands at
+    //   .vite/renderer/shell/src/renderer/shell/shell.html
+    // __dirname = .vite/build, so the path is:
+    //   ../renderer/shell/src/renderer/shell/shell.html
     const htmlPath = path.join(
       __dirname,
-      `../renderer/shell/shell.html`,
+      `../renderer/shell/src/renderer/shell/shell.html`,
     );
     mainLogger.debug('window.loadFile', { filePath: htmlPath });
     win.loadFile(htmlPath);

--- a/my-app/tests/e2e/golden-path.spec.ts
+++ b/my-app/tests/e2e/golden-path.spec.ts
@@ -103,8 +103,14 @@ async function launchFresh(): Promise<LaunchResult> {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'golden-path-'));
   log(`Launching fresh (no account.json), userDataDir=${userDataDir}`);
 
+  // NOTE: Do NOT pass executablePath here. When executablePath is set,
+  // Playwright skips injecting its `-r <loader>` arg into Electron, which
+  // is what hijacks app.whenReady() and signals __playwright_run back to
+  // the test harness. Without the loader, electron.launch() hangs for the
+  // full 30s even though the Electron process starts correctly.
+  // Omitting executablePath makes Playwright use require('electron') to
+  // resolve the same binary that ./node_modules/.bin/electron points at.
   const electronApp = await electron.launch({
-    executablePath: ELECTRON_BIN,
     args: [
       MAIN_JS,
       `--user-data-dir=${userDataDir}`,
@@ -130,8 +136,8 @@ async function launchFresh(): Promise<LaunchResult> {
 async function launchReturning(userDataDir: string): Promise<LaunchResult> {
   log(`Launching returning user, userDataDir=${userDataDir}`);
 
+  // See launchFresh above for why executablePath is intentionally omitted.
   const electronApp = await electron.launch({
-    executablePath: ELECTRON_BIN,
     args: [
       MAIN_JS,
       `--user-data-dir=${userDataDir}`,

--- a/my-app/tests/e2e/pill-flow.spec.ts
+++ b/my-app/tests/e2e/pill-flow.spec.ts
@@ -114,8 +114,14 @@ async function launchWithMockDaemon(): Promise<TestHandle> {
 
   log(`Launching with mock daemon, userDataDir=${userDataDir}`);
 
+  // NOTE: Do NOT pass executablePath here. When executablePath is set,
+  // Playwright skips injecting its `-r <loader>` arg into Electron, which
+  // is what hijacks app.whenReady() and signals __playwright_run back to
+  // the test harness. Without the loader, electron.launch() hangs for the
+  // full 30s even though the Electron process starts correctly.
+  // Omitting executablePath makes Playwright use require('electron') to
+  // resolve the same binary that ./node_modules/.bin/electron points at.
   const electronApp = await electron.launch({
-    executablePath: ELECTRON_BIN,
     args: [
       MAIN_JS,
       `--user-data-dir=${userDataDir}`,

--- a/my-app/tests/regression/preload-path.spec.ts
+++ b/my-app/tests/regression/preload-path.spec.ts
@@ -81,8 +81,14 @@ test.describe('preload path integrity', () => {
     fs.writeFileSync(path.join(userDataDir, 'account.json'), COMPLETED_ACCOUNT, 'utf-8');
     log(`Launching Electron with userData: ${userDataDir}`);
 
+    // NOTE: Do NOT pass executablePath here. When executablePath is set,
+    // Playwright skips injecting its `-r <loader>` arg into Electron, which
+    // is what hijacks app.whenReady() and signals __playwright_run back to
+    // the test harness. Without the loader, electron.launch() hangs for the
+    // full 30s even though the Electron process starts correctly.
+    // Omitting executablePath makes Playwright use require('electron') to
+    // resolve the same binary that ./node_modules/.bin/electron points at.
     electronApp = await electron.launch({
-      executablePath: ELECTRON_BIN,
       args: [
         MAIN_JS,
         `--user-data-dir=${userDataDir}`,


### PR DESCRIPTION
## Summary

Fixes the 30s `electron.launch: Timeout 30000ms exceeded` failure that has been blocking the Playwright regression job on CI macOS runners (reproduces locally too).

**Root cause:** `_electron.launch()` in Playwright only injects its `-r <loader>` bootstrap when `executablePath` is **not** set. That loader hijacks `app.whenReady()` and calls back into `__playwright_run` to signal launch success. With `executablePath` provided — as every E2E spec in this repo does — the loader never runs, and the launch promise hangs until timeout.

Primary fix: drop `executablePath` from the three failing specs so Playwright auto-resolves the same binary via `require('electron/index.js')` and injects the loader.

Secondary fix: once Electron actually ran, the shell window tried to load `.vite/renderer/shell/shell.html`, but Forge's VitePlugin (with the current `vite.renderer.config.ts` that has no `root` override) emits HTML at `.vite/renderer/shell/src/renderer/shell/shell.html`. Updated the `loadFile` path in `src/main/window.ts` to match.

Also had to:
- Comment out the dangling `newtab` preload/renderer entries in `forge.config.ts` — `vite.newtab.config.ts` and `src/preload/newtab.ts` don't exist on `main`, so `npm run package` fails before Playwright ever launches. Same pattern already used for the downloads renderer on this file.
- Switch the regression CI job from downloading the `out/my-app.app` artifact to running `npm run package` itself — the regression spec needs the `.vite/` output tree, not the packaged `.app` bundle.

## Test plan

- [x] `npm run package -- --skip-signing` succeeds on macOS arm64
- [x] `npx playwright test --config=tests/regression/playwright.regression.config.ts` passes 5/5 tests in ~900ms (was timing out at 30s × 5 before)
- [ ] CI regression job runs green on this PR
- [ ] CI regression job stays green on subsequent PRs

## Follow-ups (not in this PR)

- Other specs that use the same `executablePath: ELECTRON_BIN` pattern will still hang once unskipped. Same one-line fix applies: `tests/e2e/{session-restore,agent-task-wiki,multi-instance,daemon-crash-recovery,ipc}.spec.ts`, `tests/perf/startup.spec.ts`, `tests/visual/capture.spec.ts`, `tests/setup/electron-launcher.ts`.
- `vite.newtab.config.ts` + `src/preload/newtab.ts` + wiring for the new-tab renderer is still missing and should land before re-enabling the entries in `forge.config.ts`.
- The `e2e-smoke` CI job (`golden-path` + `pill-flow` + `ipc`) has the same artifact-vs-`.vite/` mismatch as the regression job did. Left on `continue-on-error: true` until those specs are independently verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 30s `electron.launch` timeout blocking the `playwright` regression job by letting `playwright` inject its loader, and corrects the packaged shell HTML path so the window loads correctly. CI now builds the `.vite/` output and runs tests against it; the regression job no longer soft-fails.

- **Bug Fixes**
  - Remove `executablePath` from affected specs so `playwright` auto-resolves `electron` and injects its loader; launch no longer hangs.
  - Update `src/main/window.ts` to load `.vite/renderer/shell/src/renderer/shell/shell.html`.
  - Comment out missing `newtab` preload/renderer entries in `forge.config.ts` to unblock `electron-forge` packaging.
  - Change regression job to build with `SKIP_SIGNING=1 npm run package` (needs `.vite/` output) and drop `continue-on-error`.

<sup>Written for commit 74b017f94fcde8f21d547b6fda660c95fb07b3fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

