### PR TITLE
test: backfill unit + integration tests for history, extensions, zoom

### DIFF
--- a/my-app/tests/integration/extensions-ipc.test.ts
+++ b/my-app/tests/integration/extensions-ipc.test.ts
@@ -1,0 +1,384 @@
+/**
+ * extensions-ipc.test.ts — integration tests for extensions:* IPC handlers.
+ *
+ * Verifies that:
+ *   - registerExtensionsHandlers binds every channel via ipcMain.handle / .on
+ *   - extensions:list / get-details delegate to the manager
+ *   - extensions:enable / disable / remove update manager state
+ *   - extensions:set-host-access validates input (assertOneOf)
+ *   - extensions:get-dev-mode / set-dev-mode round-trip
+ *   - extensions:load-unpacked uses dialog.showOpenDialog and respects cancel
+ *   - extensions:pick-directory returns null on cancel, else the path
+ *   - extensions:close-window is registered on .on (one-way)
+ *   - unregisterExtensionsHandlers tears everything down
+ *
+ * NOTE: scoped to the non-mv3 surface only. PR #119 owns the mv3 manager.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// vi.hoisted shared state
+// ---------------------------------------------------------------------------
+
+const {
+  invokeHandlers,
+  onListeners,
+  removedHandlers,
+  removedListeners,
+  dialogState,
+  loggerStub,
+} = vi.hoisted(() => ({
+  invokeHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  onListeners: new Map<string, (...args: unknown[]) => unknown>(),
+  removedHandlers: [] as string[],
+  removedListeners: [] as string[],
+  dialogState: {
+    showOpenDialog: undefined as unknown as ReturnType<typeof vi.fn>,
+  },
+  loggerStub: {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('electron', () => {
+  dialogState.showOpenDialog = vi.fn(async () =>
+    Promise.resolve({ canceled: true, filePaths: [] }),
+  );
+  return {
+    app: { getPath: vi.fn().mockReturnValue('/tmp/ext-ipc-test-userData') },
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        invokeHandlers.set(channel, handler);
+      }),
+      on: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        onListeners.set(channel, handler);
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        invokeHandlers.delete(channel);
+        removedHandlers.push(channel);
+      }),
+      removeAllListeners: vi.fn((channel: string) => {
+        onListeners.delete(channel);
+        removedListeners.push(channel);
+      }),
+    },
+    dialog: {
+      showOpenDialog: dialogState.showOpenDialog,
+    },
+  };
+});
+
+// Avoid pulling the real ExtensionsWindow (which requires Electron BrowserWindow)
+vi.mock('../../src/main/extensions/ExtensionsWindow', () => ({
+  getExtensionsWindow: vi.fn(() => null),
+  openExtensionsWindow: vi.fn(),
+}));
+
+vi.mock('../../src/main/logger', () => ({
+  mainLogger: loggerStub,
+}));
+
+import {
+  registerExtensionsHandlers,
+  unregisterExtensionsHandlers,
+} from '../../src/main/extensions/ipc';
+import type { ExtensionRecord } from '../../src/main/extensions/ExtensionManager';
+
+// ---------------------------------------------------------------------------
+// Fake ExtensionManager — minimal surface the handlers exercise
+// ---------------------------------------------------------------------------
+
+function makeFakeManager(initial: ExtensionRecord[] = []) {
+  let records = [...initial];
+  let devMode = false;
+  return {
+    listExtensions: vi.fn(() => records.slice()),
+    enableExtension: vi.fn(async (id: string) => {
+      const r = records.find((e) => e.id === id);
+      if (!r) throw new Error('not found');
+      r.enabled = true;
+    }),
+    disableExtension: vi.fn((id: string) => {
+      const r = records.find((e) => e.id === id);
+      if (!r) throw new Error('not found');
+      r.enabled = false;
+    }),
+    removeExtension: vi.fn((id: string) => {
+      records = records.filter((e) => e.id !== id);
+    }),
+    getExtensionDetails: vi.fn((id: string) => records.find((e) => e.id === id) ?? null),
+    loadUnpacked: vi.fn(async (p: string): Promise<ExtensionRecord> => {
+      const newRec: ExtensionRecord = {
+        id: `loaded-${records.length + 1}`,
+        name: `Loaded ${records.length + 1}`,
+        version: '1.0.0',
+        description: '',
+        path: p,
+        enabled: true,
+        permissions: [],
+        hostPermissions: [],
+        hostAccess: 'on-click',
+        icons: {},
+      };
+      records.push(newRec);
+      return newRec;
+    }),
+    updateExtension: vi.fn(async (_id: string) => undefined),
+    setHostAccess: vi.fn((id: string, access: ExtensionRecord['hostAccess']) => {
+      const r = records.find((e) => e.id === id);
+      if (!r) throw new Error('not found');
+      r.hostAccess = access;
+    }),
+    getDeveloperMode: vi.fn(() => devMode),
+    setDeveloperMode: vi.fn((enabled: boolean) => {
+      devMode = !!enabled;
+    }),
+  };
+}
+
+const FAKE_EVENT = {} as unknown as Electron.IpcMainInvokeEvent;
+
+function invoke<T>(channel: string, ...args: unknown[]): T {
+  const handler = invokeHandlers.get(channel);
+  if (!handler) throw new Error(`No invoke handler for ${channel}`);
+  return handler(FAKE_EVENT, ...args) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extensions-ipc — registration', () => {
+  beforeEach(() => {
+    invokeHandlers.clear();
+    onListeners.clear();
+    removedHandlers.length = 0;
+    removedListeners.length = 0;
+  });
+
+  afterEach(() => {
+    unregisterExtensionsHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('registers every documented extensions:* invoke channel', () => {
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    for (const ch of [
+      'extensions:list',
+      'extensions:enable',
+      'extensions:disable',
+      'extensions:remove',
+      'extensions:get-details',
+      'extensions:load-unpacked',
+      'extensions:update',
+      'extensions:set-host-access',
+      'extensions:get-dev-mode',
+      'extensions:set-dev-mode',
+      'extensions:pick-directory',
+    ]) {
+      expect(invokeHandlers.has(ch)).toBe(true);
+    }
+  });
+
+  it('registers extensions:close-window as a one-way listener', () => {
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    expect(onListeners.has('extensions:close-window')).toBe(true);
+  });
+
+  it('unregisterExtensionsHandlers tears down every handler/listener', () => {
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    unregisterExtensionsHandlers();
+    expect(removedHandlers).toEqual(
+      expect.arrayContaining([
+        'extensions:list',
+        'extensions:enable',
+        'extensions:disable',
+        'extensions:remove',
+        'extensions:get-details',
+        'extensions:load-unpacked',
+        'extensions:update',
+        'extensions:set-host-access',
+        'extensions:get-dev-mode',
+        'extensions:set-dev-mode',
+        'extensions:pick-directory',
+      ]),
+    );
+    expect(removedListeners).toContain('extensions:close-window');
+  });
+});
+
+describe('extensions-ipc — list / details / toggles', () => {
+  beforeEach(() => {
+    invokeHandlers.clear();
+    onListeners.clear();
+  });
+
+  afterEach(() => {
+    unregisterExtensionsHandlers();
+    vi.clearAllMocks();
+  });
+
+  function seed(): ExtensionRecord[] {
+    return [
+      {
+        id: 'ext-a',
+        name: 'A',
+        version: '1.0.0',
+        description: '',
+        path: '/x/a',
+        enabled: true,
+        permissions: ['storage'],
+        hostPermissions: [],
+        hostAccess: 'on-click',
+        icons: {},
+      },
+    ];
+  }
+
+  it('extensions:list returns the manager records', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    const list = invoke<ExtensionRecord[]>('extensions:list');
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('ext-a');
+  });
+
+  it('extensions:enable invokes manager.enableExtension and validates id', async () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    await invoke<Promise<void>>('extensions:enable', 'ext-a');
+    expect(mgr.enableExtension).toHaveBeenCalledWith('ext-a');
+
+    // handleEnable is async — assertString throws synchronously, but the
+    // outer fn is async so the rejection comes through the returned promise.
+    await expect(invoke<Promise<void>>('extensions:enable', 12345)).rejects.toThrow();
+  });
+
+  it('extensions:disable invokes manager.disableExtension', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    invoke('extensions:disable', 'ext-a');
+    expect(mgr.disableExtension).toHaveBeenCalledWith('ext-a');
+  });
+
+  it('extensions:remove invokes manager.removeExtension', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    invoke('extensions:remove', 'ext-a');
+    expect(mgr.removeExtension).toHaveBeenCalledWith('ext-a');
+  });
+
+  it('extensions:get-details returns the record (or null)', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    expect(invoke<ExtensionRecord | null>('extensions:get-details', 'ext-a')?.name).toBe('A');
+    expect(invoke<ExtensionRecord | null>('extensions:get-details', 'nope')).toBeNull();
+  });
+
+  it('extensions:set-host-access rejects values outside the allow-list', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    expect(() => invoke('extensions:set-host-access', 'ext-a', 'bogus')).toThrow();
+  });
+
+  it('extensions:set-host-access calls manager.setHostAccess for valid values', () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    invoke('extensions:set-host-access', 'ext-a', 'all-sites');
+    expect(mgr.setHostAccess).toHaveBeenCalledWith('ext-a', 'all-sites');
+  });
+
+  it('extensions:update calls manager.updateExtension', async () => {
+    const mgr = makeFakeManager(seed());
+    registerExtensionsHandlers(mgr as never);
+    await invoke<Promise<void>>('extensions:update', 'ext-a');
+    expect(mgr.updateExtension).toHaveBeenCalledWith('ext-a');
+  });
+});
+
+describe('extensions-ipc — developer mode and dialog flows', () => {
+  beforeEach(() => {
+    invokeHandlers.clear();
+    onListeners.clear();
+    dialogState.showOpenDialog.mockReset();
+  });
+
+  afterEach(() => {
+    unregisterExtensionsHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('extensions:get-dev-mode / set-dev-mode round-trip via the manager', () => {
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    expect(invoke<boolean>('extensions:get-dev-mode')).toBe(false);
+    invoke('extensions:set-dev-mode', true);
+    expect(invoke<boolean>('extensions:get-dev-mode')).toBe(true);
+  });
+
+  it('extensions:load-unpacked returns null when the dialog is canceled', async () => {
+    dialogState.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    const result = await invoke<Promise<ExtensionRecord | null>>('extensions:load-unpacked');
+    expect(result).toBeNull();
+    expect(mgr.loadUnpacked).not.toHaveBeenCalled();
+  });
+
+  it('extensions:load-unpacked passes the chosen directory to manager.loadUnpacked', async () => {
+    dialogState.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/me/my-ext'],
+    });
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    const result = await invoke<Promise<ExtensionRecord | null>>('extensions:load-unpacked');
+    expect(mgr.loadUnpacked).toHaveBeenCalledWith('/Users/me/my-ext');
+    expect(result?.path).toBe('/Users/me/my-ext');
+  });
+
+  it('extensions:pick-directory returns null on cancel, else the chosen path', async () => {
+    dialogState.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    expect(await invoke<Promise<string | null>>('extensions:pick-directory')).toBeNull();
+
+    dialogState.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/some/dir'],
+    });
+    expect(await invoke<Promise<string | null>>('extensions:pick-directory')).toBe('/some/dir');
+  });
+});
+
+describe('extensions-ipc — uninitialised manager guard', () => {
+  beforeEach(() => {
+    invokeHandlers.clear();
+    onListeners.clear();
+  });
+
+  afterEach(() => {
+    unregisterExtensionsHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('handlers throw a clear error when invoked after unregister', () => {
+    const mgr = makeFakeManager();
+    registerExtensionsHandlers(mgr as never);
+    // Capture handler reference, then unregister to nil out _manager
+    const handler = invokeHandlers.get('extensions:list');
+    unregisterExtensionsHandlers();
+    expect(() => handler!(FAKE_EVENT)).toThrow(/not initialised/);
+  });
+});

--- a/my-app/tests/integration/history-ipc.test.ts
+++ b/my-app/tests/integration/history-ipc.test.ts
@@ -1,0 +1,288 @@
+/**
+ * history-ipc.test.ts — integration tests for the history:* IPC handlers.
+ *
+ * Verifies that:
+ *   - registerHistoryHandlers binds every documented channel via ipcMain.handle
+ *   - history:query → returns entries + totalCount
+ *   - history:remove deletes a single entry
+ *   - history:remove-bulk deletes multiple entries and rejects oversized inputs
+ *   - history:clear-all empties the store
+ *   - history:journeys clusters and queries the persisted entries
+ *   - history:remove-cluster removes every entry id in a cluster
+ *   - unregisterHistoryHandlers tears down every handler
+ *
+ * Strategy: stub ipcMain via vi.hoisted() so we can capture (channel, handler)
+ * registrations and invoke them directly with a fake event.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// vi.hoisted helpers — captured ipcMain registrations + in-memory fs
+// ---------------------------------------------------------------------------
+
+const {
+  ipcHandlers,
+  ipcRemoved,
+  fsStore,
+  loggerStub,
+} = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  ipcRemoved: [] as string[],
+  fsStore: new Map<string, string>(),
+  loggerStub: {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs', () => {
+  const readFileSync = vi.fn((p: string) => {
+    const content = fsStore.get(p);
+    if (content === undefined) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+    return content;
+  });
+  const writeFileSync = vi.fn((p: string, data: string) => {
+    fsStore.set(p, data);
+  });
+  const existsSync = vi.fn((p: string) => fsStore.has(p));
+  const mkdirSync = vi.fn();
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp/history-ipc-test-userData'),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcHandlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      ipcHandlers.delete(channel);
+      ipcRemoved.push(channel);
+    }),
+  },
+}));
+
+vi.mock('../../src/main/logger', () => ({
+  mainLogger: loggerStub,
+}));
+
+import { HistoryStore } from '../../src/main/history/HistoryStore';
+import {
+  registerHistoryHandlers,
+  unregisterHistoryHandlers,
+} from '../../src/main/history/ipc';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_EVENT = {} as unknown as Electron.IpcMainInvokeEvent;
+
+function invoke<T = unknown>(channel: string, ...args: unknown[]): T {
+  const handler = ipcHandlers.get(channel);
+  if (!handler) {
+    throw new Error(`No handler registered for ${channel}`);
+  }
+  return handler(FAKE_EVENT, ...args) as T;
+}
+
+interface QueryResult {
+  entries: { id: string; url: string; title: string }[];
+  totalCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('history-ipc — registration', () => {
+  beforeEach(() => {
+    ipcHandlers.clear();
+    ipcRemoved.length = 0;
+    fsStore.clear();
+  });
+
+  afterEach(() => {
+    unregisterHistoryHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('registers every documented history:* channel', () => {
+    const store = new HistoryStore();
+    registerHistoryHandlers({ store });
+    expect(ipcHandlers.has('history:query')).toBe(true);
+    expect(ipcHandlers.has('history:remove')).toBe(true);
+    expect(ipcHandlers.has('history:remove-bulk')).toBe(true);
+    expect(ipcHandlers.has('history:clear-all')).toBe(true);
+    expect(ipcHandlers.has('history:journeys')).toBe(true);
+    expect(ipcHandlers.has('history:remove-cluster')).toBe(true);
+  });
+
+  it('unregisterHistoryHandlers calls removeHandler for every channel', () => {
+    const store = new HistoryStore();
+    registerHistoryHandlers({ store });
+    unregisterHistoryHandlers();
+    expect(ipcRemoved).toEqual(
+      expect.arrayContaining([
+        'history:query',
+        'history:remove',
+        'history:remove-bulk',
+        'history:clear-all',
+        'history:journeys',
+        'history:remove-cluster',
+      ]),
+    );
+  });
+});
+
+describe('history-ipc — round-trip flow (visit → query → search → delete)', () => {
+  let store: HistoryStore;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    ipcRemoved.length = 0;
+    fsStore.clear();
+    store = new HistoryStore();
+    registerHistoryHandlers({ store });
+  });
+
+  afterEach(() => {
+    unregisterHistoryHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('history:query returns the entries inserted via the store', () => {
+    store.addVisit('https://example.com', 'Example');
+    store.addVisit('https://github.com', 'GitHub');
+    const result = invoke<QueryResult>('history:query');
+    expect(result.totalCount).toBe(2);
+    expect(result.entries.map((e) => e.url)).toContain('https://example.com');
+  });
+
+  it('history:query honours the search query payload', () => {
+    store.addVisit('https://github.com/foo', 'GitHub Foo');
+    store.addVisit('https://news.ycombinator.com', 'HN');
+    const result = invoke<QueryResult>('history:query', { query: 'github' });
+    expect(result.totalCount).toBe(1);
+    expect(result.entries[0].url).toContain('github');
+  });
+
+  it('history:query clamps oversized limit values', () => {
+    for (let i = 0; i < 30; i++) store.addVisit(`https://e${i}.com`, `E${i}`);
+    // limit=99999 should be clamped to 500 internally; we just check we get ≤500
+    const result = invoke<QueryResult>('history:query', { limit: 99999, offset: 0 });
+    expect(result.entries.length).toBeLessThanOrEqual(500);
+  });
+
+  it('history:remove deletes a single entry by id', () => {
+    const entry = store.addVisit('https://gone.com', 'Gone');
+    const ok = invoke<boolean>('history:remove', entry.id);
+    expect(ok).toBe(true);
+    expect(store.getAll().some((e) => e.id === entry.id)).toBe(false);
+  });
+
+  it('history:remove rejects non-string ids', () => {
+    expect(() => invoke('history:remove', 12345)).toThrow();
+  });
+
+  it('history:remove-bulk deletes multiple ids at once', () => {
+    const a = store.addVisit('https://a.com', 'A');
+    const b = store.addVisit('https://b.com', 'B');
+    const c = store.addVisit('https://c.com', 'C');
+    const removed = invoke<number>('history:remove-bulk', [a.id, b.id]);
+    expect(removed).toBe(2);
+    expect(store.getAll()).toHaveLength(1);
+    expect(store.getAll()[0].id).toBe(c.id);
+  });
+
+  it('history:remove-bulk rejects non-array payloads', () => {
+    expect(() => invoke('history:remove-bulk', 'not-an-array')).toThrow();
+  });
+
+  it('history:remove-bulk rejects payloads larger than 1000', () => {
+    const ids = new Array(1001).fill('x-id');
+    expect(() => invoke('history:remove-bulk', ids)).toThrow(/max 1000/);
+  });
+
+  it('history:clear-all empties the store and returns true', () => {
+    store.addVisit('https://a.com', 'A');
+    store.addVisit('https://b.com', 'B');
+    const ok = invoke<boolean>('history:clear-all');
+    expect(ok).toBe(true);
+    expect(store.getAll()).toEqual([]);
+  });
+});
+
+describe('history-ipc — journeys', () => {
+  let store: HistoryStore;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    fsStore.clear();
+    store = new HistoryStore();
+    registerHistoryHandlers({ store });
+  });
+
+  afterEach(() => {
+    unregisterHistoryHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('history:journeys clusters two same-domain visits and returns them', () => {
+    store.addVisit('https://github.com/a', 'A');
+    store.addVisit('https://github.com/b', 'B');
+    const result = invoke<{ clusters: { id: string }[]; totalCount: number }>('history:journeys');
+    expect(result.totalCount).toBe(1);
+    expect(result.clusters[0].id).toMatch(/^j-/);
+  });
+
+  it('history:journeys filters when a query is supplied', () => {
+    store.addVisit('https://github.com/a', 'A');
+    store.addVisit('https://github.com/b', 'B');
+    store.addVisit('https://news.ycombinator.com/x', 'X');
+    store.addVisit('https://news.ycombinator.com/y', 'Y');
+    const result = invoke<{ clusters: { domain: string }[]; totalCount: number }>(
+      'history:journeys',
+      { query: 'github' },
+    );
+    expect(result.totalCount).toBe(1);
+    expect(result.clusters[0].domain).toBe('github.com');
+  });
+
+  it('history:remove-cluster removes every entry in the cluster', () => {
+    store.addVisit('https://github.com/a', 'A');
+    store.addVisit('https://github.com/b', 'B');
+    const journeys = invoke<{ clusters: { id: string }[] }>('history:journeys');
+    const clusterId = journeys.clusters[0].id;
+    const removed = invoke<number>('history:remove-cluster', clusterId);
+    expect(removed).toBe(2);
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('history:remove-cluster returns 0 for an unknown cluster id', () => {
+    const removed = invoke<number>('history:remove-cluster', 'j-not-real');
+    expect(removed).toBe(0);
+  });
+
+  it('history:remove-cluster rejects non-string cluster ids', () => {
+    expect(() => invoke('history:remove-cluster', 42)).toThrow();
+  });
+});

--- a/my-app/tests/unit/extensions/ExtensionManager.spec.ts
+++ b/my-app/tests/unit/extensions/ExtensionManager.spec.ts
@@ -1,0 +1,442 @@
+/**
+ * ExtensionManager unit tests — backfilled coverage for chrome://extensions
+ * (non-mv3 surface; PR #119 owns the mv3-specific manager).
+ *
+ * Tests cover:
+ *   - constructor reads extensions-state.json from userData (or starts empty)
+ *   - loadAllEnabled skips disabled / missing-path entries and loads valid ones
+ *   - listExtensions merges persisted records with live session data
+ *   - loadUnpacked validates the path + manifest, calls session.loadExtension,
+ *     persists the record, and returns ExtensionRecord
+ *   - enableExtension / disableExtension mutate state and call session APIs
+ *   - removeExtension drops the record from state
+ *   - setHostAccess persists the new value
+ *   - getDeveloperMode / setDeveloperMode round-trip
+ *   - getExtensionDetails returns a record or null
+ *   - error paths: missing extension path, missing manifest.json, unknown id
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// In-memory fs and session mocks
+// ---------------------------------------------------------------------------
+
+const fsStore = new Map<string, string>();
+const dirSet = new Set<string>(); // paths that exist as directories
+
+vi.mock('node:fs', () => {
+  const readFileSync = vi.fn((p: string) => {
+    const content = fsStore.get(p);
+    if (content === undefined) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+    return content;
+  });
+  const writeFileSync = vi.fn((p: string, data: string) => {
+    fsStore.set(p, data);
+  });
+  const existsSync = vi.fn((p: string) => fsStore.has(p) || dirSet.has(p));
+  const mkdirSync = vi.fn((p: string) => {
+    dirSet.add(p);
+  });
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+
+interface FakeLiveExtension {
+  id: string;
+  name: string;
+  version: string;
+  manifest: Record<string, unknown>;
+  path: string;
+}
+
+const sessionState: {
+  loaded: Map<string, FakeLiveExtension>;
+  loadShouldFail: boolean;
+  loadCalls: Array<{ path: string; opts?: unknown }>;
+  removeCalls: string[];
+} = {
+  loaded: new Map(),
+  loadShouldFail: false,
+  loadCalls: [],
+  removeCalls: [],
+};
+
+let nextLoadId = 1;
+
+vi.mock('electron', () => {
+  const sessionStub = {
+    loadExtension: vi.fn(async (extPath: string, opts?: unknown) => {
+      sessionState.loadCalls.push({ path: extPath, opts });
+      if (sessionState.loadShouldFail) {
+        throw new Error('loadExtension failed (mock)');
+      }
+      const id = `ext-${nextLoadId++}`;
+      const manifest =
+        (fsStore.get(path.join(extPath, 'manifest.json'))
+          ? (JSON.parse(fsStore.get(path.join(extPath, 'manifest.json'))!) as Record<string, unknown>)
+          : { name: 'mock', version: '0.0.0' });
+      const live: FakeLiveExtension = {
+        id,
+        name: (manifest.name as string) ?? 'mock',
+        version: (manifest.version as string) ?? '0.0.0',
+        manifest,
+        path: extPath,
+      };
+      sessionState.loaded.set(id, live);
+      return live;
+    }),
+    removeExtension: vi.fn((id: string) => {
+      sessionState.removeCalls.push(id);
+      sessionState.loaded.delete(id);
+    }),
+    getAllExtensions: vi.fn(() => Array.from(sessionState.loaded.values())),
+    getExtension: vi.fn((id: string) => sessionState.loaded.get(id) ?? null),
+  };
+  return {
+    app: {
+      getPath: vi.fn().mockReturnValue('/tmp/test-extensions-userData'),
+    },
+    session: {
+      defaultSession: sessionStub,
+      fromPartition: vi.fn(() => sessionStub),
+    },
+  };
+});
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ExtensionManager } from '../../../src/main/extensions/ExtensionManager';
+
+const STATE_PATH = path.join('/tmp/test-extensions-userData', 'extensions-state.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedExtensionDir(dir: string, manifest: Record<string, unknown>): void {
+  dirSet.add(dir);
+  fsStore.set(path.join(dir, 'manifest.json'), JSON.stringify(manifest));
+}
+
+function resetSessionMockState(): void {
+  sessionState.loaded.clear();
+  sessionState.loadShouldFail = false;
+  sessionState.loadCalls.length = 0;
+  sessionState.removeCalls.length = 0;
+  nextLoadId = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ExtensionManager — construction and state load', () => {
+  beforeEach(() => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with no extensions and developerMode=false when state file missing', () => {
+    const mgr = new ExtensionManager();
+    expect(mgr.listExtensions()).toEqual([]);
+    expect(mgr.getDeveloperMode()).toBe(false);
+  });
+
+  it('loads persisted extensions from extensions-state.json', () => {
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [
+          { id: 'persisted-1', path: '/ext/persisted-1', enabled: true, hostAccess: 'on-click' },
+        ],
+        developerMode: true,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    const list = mgr.listExtensions();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('persisted-1');
+    expect(mgr.getDeveloperMode()).toBe(true);
+  });
+
+  it('treats malformed state file as empty', () => {
+    fsStore.set(STATE_PATH, '{not-json');
+    const mgr = new ExtensionManager();
+    expect(mgr.listExtensions()).toEqual([]);
+    expect(mgr.getDeveloperMode()).toBe(false);
+  });
+});
+
+describe('ExtensionManager — loadAllEnabled', () => {
+  beforeEach(() => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips disabled records', async () => {
+    seedExtensionDir('/ext/dis', { name: 'Disabled', version: '1' });
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [{ id: 'dis-1', path: '/ext/dis', enabled: false, hostAccess: 'on-click' }],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    await mgr.loadAllEnabled();
+    expect(sessionState.loadCalls).toHaveLength(0);
+  });
+
+  it('skips records whose path no longer exists on disk', async () => {
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [{ id: 'gone-1', path: '/ext/gone', enabled: true, hostAccess: 'on-click' }],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    await mgr.loadAllEnabled();
+    expect(sessionState.loadCalls).toHaveLength(0);
+  });
+
+  it('loads enabled extensions whose path exists, updating the record id', async () => {
+    seedExtensionDir('/ext/ok', { name: 'OK', version: '1.2.3' });
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [{ id: 'old-id', path: '/ext/ok', enabled: true, hostAccess: 'on-click' }],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    await mgr.loadAllEnabled();
+    expect(sessionState.loadCalls).toHaveLength(1);
+    expect(sessionState.loadCalls[0].path).toBe('/ext/ok');
+    // New id from session is now reflected
+    const list = mgr.listExtensions();
+    expect(list[0].id).toMatch(/^ext-\d+$/);
+  });
+
+  it('continues past extensions whose loadExtension throws', async () => {
+    seedExtensionDir('/ext/bad', { name: 'Bad', version: '1' });
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [{ id: 'bad-1', path: '/ext/bad', enabled: true, hostAccess: 'on-click' }],
+        developerMode: false,
+      }),
+    );
+    sessionState.loadShouldFail = true;
+    const mgr = new ExtensionManager();
+    await expect(mgr.loadAllEnabled()).resolves.not.toThrow();
+    expect(sessionState.loadCalls).toHaveLength(1);
+  });
+});
+
+describe('ExtensionManager — loadUnpacked', () => {
+  let mgr: ExtensionManager;
+
+  beforeEach(() => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+    mgr = new ExtensionManager();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when the extension path does not exist', async () => {
+    await expect(mgr.loadUnpacked('/no/such/dir')).rejects.toThrow(/path does not exist/);
+  });
+
+  it('throws when manifest.json is missing', async () => {
+    dirSet.add('/ext/empty');
+    await expect(mgr.loadUnpacked('/ext/empty')).rejects.toThrow(/manifest.json/);
+  });
+
+  it('loads a valid extension and persists a new record', async () => {
+    seedExtensionDir('/ext/valid', {
+      name: 'Valid Extension',
+      version: '2.0.0',
+      description: 'My ext',
+      permissions: ['storage'],
+      host_permissions: ['https://*/*'],
+      icons: { '16': 'icon16.png' },
+    });
+    const record = await mgr.loadUnpacked('/ext/valid');
+    expect(record.name).toBe('Valid Extension');
+    expect(record.version).toBe('2.0.0');
+    expect(record.permissions).toEqual(['storage']);
+    expect(record.hostPermissions).toEqual(['https://*/*']);
+    expect(record.enabled).toBe(true);
+    expect(record.hostAccess).toBe('on-click');
+    // State file written
+    expect(fsStore.has(STATE_PATH)).toBe(true);
+    const parsed = JSON.parse(fsStore.get(STATE_PATH)!);
+    expect(parsed.extensions).toHaveLength(1);
+  });
+
+  it('overwrites an existing record when reloading the same path', async () => {
+    seedExtensionDir('/ext/dup', { name: 'Dup', version: '1' });
+    const first = await mgr.loadUnpacked('/ext/dup');
+    const second = await mgr.loadUnpacked('/ext/dup');
+    expect(mgr.listExtensions()).toHaveLength(1);
+    expect(second.id).not.toBe(first.id);
+  });
+});
+
+describe('ExtensionManager — enable / disable / remove', () => {
+  let mgr: ExtensionManager;
+
+  beforeEach(async () => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+    mgr = new ExtensionManager();
+    seedExtensionDir('/ext/a', { name: 'A', version: '1' });
+    await mgr.loadUnpacked('/ext/a');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enableExtension throws for unknown id', async () => {
+    await expect(mgr.enableExtension('does-not-exist')).rejects.toThrow(/not found/);
+  });
+
+  it('enableExtension throws when the persisted path is missing', async () => {
+    const id = mgr.listExtensions()[0].id;
+    dirSet.delete('/ext/a');
+    fsStore.delete(path.join('/ext/a', 'manifest.json'));
+    await expect(mgr.enableExtension(id)).rejects.toThrow(/path missing/);
+  });
+
+  it('enableExtension calls session.loadExtension and marks enabled=true', async () => {
+    const id = mgr.listExtensions()[0].id;
+    sessionState.loadCalls.length = 0;
+    await mgr.enableExtension(id);
+    expect(sessionState.loadCalls).toHaveLength(1);
+    expect(mgr.listExtensions()[0].enabled).toBe(true);
+  });
+
+  it('disableExtension throws for unknown id', () => {
+    expect(() => mgr.disableExtension('nope')).toThrow(/not found/);
+  });
+
+  it('disableExtension calls session.removeExtension and marks enabled=false', () => {
+    const id = mgr.listExtensions()[0].id;
+    mgr.disableExtension(id);
+    expect(sessionState.removeCalls).toContain(id);
+    expect(mgr.listExtensions()[0].enabled).toBe(false);
+  });
+
+  it('removeExtension drops the record from state', () => {
+    const id = mgr.listExtensions()[0].id;
+    mgr.removeExtension(id);
+    expect(mgr.listExtensions()).toEqual([]);
+    expect(sessionState.removeCalls).toContain(id);
+  });
+});
+
+describe('ExtensionManager — updateExtension / setHostAccess', () => {
+  let mgr: ExtensionManager;
+
+  beforeEach(async () => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+    mgr = new ExtensionManager();
+    seedExtensionDir('/ext/a', { name: 'A', version: '1' });
+    await mgr.loadUnpacked('/ext/a');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updateExtension reloads the extension via session.loadExtension', async () => {
+    const id = mgr.listExtensions()[0].id;
+    sessionState.loadCalls.length = 0;
+    await mgr.updateExtension(id);
+    expect(sessionState.loadCalls).toHaveLength(1);
+  });
+
+  it('updateExtension throws when the id is unknown', async () => {
+    await expect(mgr.updateExtension('nope')).rejects.toThrow(/not found/);
+  });
+
+  it('setHostAccess persists the new value on the record', () => {
+    const id = mgr.listExtensions()[0].id;
+    mgr.setHostAccess(id, 'all-sites');
+    expect(mgr.listExtensions()[0].hostAccess).toBe('all-sites');
+  });
+
+  it('setHostAccess throws for unknown id', () => {
+    expect(() => mgr.setHostAccess('nope', 'all-sites')).toThrow(/not found/);
+  });
+});
+
+describe('ExtensionManager — developer mode and getExtensionDetails', () => {
+  let mgr: ExtensionManager;
+
+  beforeEach(() => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+    mgr = new ExtensionManager();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('developer mode round-trips through set/get and is persisted', () => {
+    expect(mgr.getDeveloperMode()).toBe(false);
+    mgr.setDeveloperMode(true);
+    expect(mgr.getDeveloperMode()).toBe(true);
+    const parsed = JSON.parse(fsStore.get(STATE_PATH)!);
+    expect(parsed.developerMode).toBe(true);
+  });
+
+  it('getExtensionDetails returns null for an unknown id', () => {
+    expect(mgr.getExtensionDetails('nope')).toBeNull();
+  });
+
+  it('getExtensionDetails returns the loaded ExtensionRecord', async () => {
+    seedExtensionDir('/ext/dets', { name: 'Dets', version: '1.0' });
+    const rec = await mgr.loadUnpacked('/ext/dets');
+    const fetched = mgr.getExtensionDetails(rec.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.name).toBe('Dets');
+  });
+});

--- a/my-app/tests/unit/extensions/ExtensionsApp.spec.tsx
+++ b/my-app/tests/unit/extensions/ExtensionsApp.spec.tsx
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ExtensionsApp renderer smoke tests — backfilled coverage for
+ * chrome://extensions (non-mv3 surface; PR #119 owns the mv3 page).
+ *
+ * Tests cover:
+ *   - mounts and renders the title + dev-mode toggle
+ *   - shows EmptyState when no extensions are loaded
+ *   - renders an extension card per record
+ *   - clicking the per-card toggle calls extensionsAPI.disable / enable
+ *   - clicking the Remove button opens the confirmation modal
+ *   - toggling developer mode reveals the dev toolbar
+ *   - close button calls extensionsAPI.closeWindow
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
+
+import { ExtensionsApp } from '../../../src/renderer/extensions/ExtensionsApp';
+
+interface FakeExtension {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  path: string;
+  enabled: boolean;
+  permissions: string[];
+  hostPermissions: string[];
+  hostAccess: 'all-sites' | 'specific-sites' | 'on-click';
+  icons: Record<string, string>;
+}
+
+function makeAPI(initial: FakeExtension[] = [], devModeStart = false) {
+  let extensions = initial.map((e) => ({ ...e }));
+  let devMode = devModeStart;
+  return {
+    listExtensions: vi.fn(async () => extensions.map((e) => ({ ...e }))),
+    enableExtension: vi.fn(async (id: string) => {
+      const e = extensions.find((x) => x.id === id);
+      if (e) e.enabled = true;
+    }),
+    disableExtension: vi.fn(async (id: string) => {
+      const e = extensions.find((x) => x.id === id);
+      if (e) e.enabled = false;
+    }),
+    removeExtension: vi.fn(async (id: string) => {
+      extensions = extensions.filter((e) => e.id !== id);
+    }),
+    getExtensionDetails: vi.fn(async (id: string) =>
+      extensions.find((e) => e.id === id) ?? null,
+    ),
+    loadUnpacked: vi.fn(async () => null),
+    updateExtension: vi.fn(async () => undefined),
+    setHostAccess: vi.fn(async () => undefined),
+    getDeveloperMode: vi.fn(async () => devMode),
+    setDeveloperMode: vi.fn(async (enabled: boolean) => {
+      devMode = enabled;
+    }),
+    pickDirectory: vi.fn(async () => null),
+    closeWindow: vi.fn(),
+  };
+}
+
+function makeExt(over: Partial<FakeExtension> = {}): FakeExtension {
+  return {
+    id: 'ext-1',
+    name: 'Sample Extension',
+    version: '1.0.0',
+    description: 'A sample',
+    path: '/path/to/ext',
+    enabled: true,
+    permissions: [],
+    hostPermissions: [],
+    hostAccess: 'on-click',
+    icons: {},
+    ...over,
+  };
+}
+
+describe('ExtensionsApp', () => {
+  beforeEach(() => {
+    (window as unknown as { extensionsAPI?: unknown }).extensionsAPI = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('mounts and renders the Extensions title once loaded', async () => {
+    (window as unknown as { extensionsAPI: ReturnType<typeof makeAPI> }).extensionsAPI = makeAPI();
+    render(<ExtensionsApp />);
+    expect(await screen.findByRole('heading', { level: 1, name: /^extensions$/i })).toBeTruthy();
+  });
+
+  it('shows the empty state when there are no extensions', async () => {
+    (window as unknown as { extensionsAPI: ReturnType<typeof makeAPI> }).extensionsAPI = makeAPI();
+    render(<ExtensionsApp />);
+    expect(await screen.findByText(/no extensions installed/i)).toBeTruthy();
+  });
+
+  it('renders one card per extension record', async () => {
+    const api = makeAPI([
+      makeExt({ id: 'a', name: 'Alpha' }),
+      makeExt({ id: 'b', name: 'Beta' }),
+    ]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+    expect(await screen.findByText('Alpha')).toBeTruthy();
+    expect(await screen.findByText('Beta')).toBeTruthy();
+  });
+
+  it('clicking the card toggle calls disableExtension when currently enabled', async () => {
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', enabled: true })]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+    const toggle = await screen.findByRole('switch', { name: /disable alpha/i });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await waitFor(() => expect(api.disableExtension).toHaveBeenCalledWith('a'));
+  });
+
+  it('clicking the card toggle calls enableExtension when currently disabled', async () => {
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', enabled: false })]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+    const toggle = await screen.findByRole('switch', { name: /enable alpha/i });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await waitFor(() => expect(api.enableExtension).toHaveBeenCalledWith('a'));
+  });
+
+  it('clicking Remove opens the confirmation modal', async () => {
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha' })]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+    const removeBtn = await screen.findByRole('button', { name: /remove/i });
+    fireEvent.click(removeBtn);
+    // The modal body mentions "Remove <strong>Alpha</strong>?"
+    expect(await screen.findByText(/remove extension/i)).toBeTruthy();
+  });
+
+  it('toggling developer mode calls setDeveloperMode and reveals the dev toolbar', async () => {
+    const api = makeAPI([], false);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+
+    const devToggle = await screen.findByRole('switch', { name: /toggle developer mode/i });
+    await act(async () => {
+      fireEvent.click(devToggle);
+    });
+    await waitFor(() => expect(api.setDeveloperMode).toHaveBeenCalledWith(true));
+    expect(await screen.findByRole('button', { name: /load unpacked/i })).toBeTruthy();
+  });
+
+  it('clicking the close button calls extensionsAPI.closeWindow', async () => {
+    const api = makeAPI();
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+    const closeBtn = await screen.findByRole('button', { name: /close extensions/i });
+    fireEvent.click(closeBtn);
+    expect(api.closeWindow).toHaveBeenCalled();
+  });
+
+  it('opens the host-access dropdown and persists a new selection', async () => {
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', hostAccess: 'on-click' })]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+
+    // The button label is the current value: "On click"
+    const btn = await screen.findByRole('button', { name: /on click/i });
+    fireEvent.click(btn);
+    const allSitesOpt = await screen.findByRole('option', { name: /on all sites/i });
+    await act(async () => {
+      fireEvent.click(allSitesOpt);
+    });
+    await waitFor(() => expect(api.setHostAccess).toHaveBeenCalledWith('a', 'all-sites'));
+  });
+});

--- a/my-app/tests/unit/history/HistoryPage.spec.tsx
+++ b/my-app/tests/unit/history/HistoryPage.spec.tsx
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * HistoryPage renderer smoke tests — backfilled coverage for chrome://history.
+ *
+ * Tests cover:
+ *   - mounts without crashing
+ *   - renders the "List" / "Journeys" tab nav
+ *   - renders entries grouped by date (Today/Yesterday/etc.)
+ *   - empty-state shows the right copy when there are no entries
+ *   - typing in the search box debounces and triggers a re-query
+ *   - clicking the per-row remove (X) button calls historyAPI.remove
+ *   - clicking the entry link calls historyAPI.navigateTo
+ *
+ * Strategy: install a global historyAPI stub before mounting; assert the
+ * IPC calls landed on the stub.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
+
+// Stub the JourneysPage subtree to keep this smoke test focused
+vi.mock('../../../src/renderer/history/JourneysPage', () => ({
+  JourneysPage: () => <div data-testid="journeys-page">journeys</div>,
+}));
+
+import { HistoryPage } from '../../../src/renderer/history/HistoryPage';
+
+interface FakeEntry {
+  id: string;
+  url: string;
+  title: string;
+  visitTime: number;
+  favicon: string | null;
+}
+
+function makeAPI(initial: FakeEntry[] = []) {
+  let entries = [...initial];
+  return {
+    query: vi.fn(async () => ({ entries: entries.slice(), totalCount: entries.length })),
+    remove: vi.fn(async (id: string) => {
+      entries = entries.filter((e) => e.id !== id);
+      return true;
+    }),
+    removeBulk: vi.fn(async (ids: string[]) => {
+      const before = entries.length;
+      const set = new Set(ids);
+      entries = entries.filter((e) => !set.has(e.id));
+      return before - entries.length;
+    }),
+    clearAll: vi.fn(async () => true),
+    navigateTo: vi.fn(async () => undefined),
+    _entries: () => entries.slice(),
+  };
+}
+
+function todayAt(hour: number, minute = 0): number {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  return d.getTime();
+}
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    // Reset globals between tests
+    (globalThis as unknown as { historyAPI?: unknown }).historyAPI = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('mounts and renders the title and tab nav', async () => {
+    (globalThis as unknown as { historyAPI: ReturnType<typeof makeAPI> }).historyAPI = makeAPI();
+    render(<HistoryPage />);
+    expect(screen.getByText('History')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /list/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /journeys/i })).toBeTruthy();
+  });
+
+  it('renders entries returned by historyAPI.query', async () => {
+    const api = makeAPI([
+      { id: 'a', url: 'https://example.com', title: 'Example Site', visitTime: todayAt(9), favicon: null },
+      { id: 'b', url: 'https://github.com', title: 'GitHub', visitTime: todayAt(10), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    await waitFor(() => expect(api.query).toHaveBeenCalled());
+    expect(await screen.findByText('Example Site')).toBeTruthy();
+    expect(await screen.findByText('GitHub')).toBeTruthy();
+  });
+
+  it('groups entries under a date label (e.g. "Today")', async () => {
+    const api = makeAPI([
+      { id: 'a', url: 'https://x.com', title: 'X', visitTime: todayAt(9), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    expect(await screen.findByText('Today')).toBeTruthy();
+  });
+
+  it('renders the empty state when no entries are returned', async () => {
+    (globalThis as unknown as { historyAPI: ReturnType<typeof makeAPI> }).historyAPI = makeAPI();
+    render(<HistoryPage />);
+    expect(await screen.findByText(/no browsing history/i)).toBeTruthy();
+  });
+
+  it('clicking the row remove button calls historyAPI.remove with the entry id', async () => {
+    const api = makeAPI([
+      { id: 'doomed', url: 'https://x.com', title: 'Doomed', visitTime: todayAt(9), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    const removeBtn = await screen.findByRole('button', { name: /remove from history/i });
+    await act(async () => {
+      fireEvent.click(removeBtn);
+    });
+    expect(api.remove).toHaveBeenCalledWith('doomed');
+  });
+
+  it('clicking an entry link calls historyAPI.navigateTo with the URL', async () => {
+    const api = makeAPI([
+      { id: 'a', url: 'https://example.com/foo', title: 'Foo', visitTime: todayAt(9), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    const link = await screen.findByText('Foo');
+    fireEvent.click(link);
+    expect(api.navigateTo).toHaveBeenCalledWith('https://example.com/foo');
+  });
+
+  it('typing in the search box (after debounce) re-issues query with the term', async () => {
+    vi.useFakeTimers();
+    const api = makeAPI([
+      { id: 'a', url: 'https://x.com', title: 'X', visitTime: todayAt(9), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    // Wait for first effect / initial fetch
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const callCountBefore = api.query.mock.calls.length;
+
+    const input = screen.getByLabelText(/search history/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'hello' } });
+
+    // Advance past the 250ms debounce
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    // Allow the post-state-update fetch to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(api.query.mock.calls.length).toBeGreaterThan(callCountBefore);
+    const lastCall = api.query.mock.calls[api.query.mock.calls.length - 1] as unknown as
+      | [{ query?: string } | undefined]
+      | undefined;
+    expect(lastCall?.[0]?.query).toBe('hello');
+
+    vi.useRealTimers();
+  });
+
+  it('switching to the Journeys tab swaps the page content', async () => {
+    (globalThis as unknown as { historyAPI: ReturnType<typeof makeAPI> }).historyAPI = makeAPI();
+    render(<HistoryPage />);
+    fireEvent.click(screen.getByRole('tab', { name: /journeys/i }));
+    expect(screen.getByTestId('journeys-page')).toBeTruthy();
+  });
+
+  it('selecting an entry exposes the bulk-delete bar', async () => {
+    const api = makeAPI([
+      { id: 'a', url: 'https://x.com', title: 'X', visitTime: todayAt(9), favicon: null },
+      { id: 'b', url: 'https://y.com', title: 'Y', visitTime: todayAt(10), favicon: null },
+    ]);
+    (globalThis as unknown as { historyAPI: typeof api }).historyAPI = api;
+
+    render(<HistoryPage />);
+    const checkboxes = await screen.findAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByText(/1 selected/i)).toBeTruthy();
+  });
+});

--- a/my-app/tests/unit/history/HistoryStore.spec.ts
+++ b/my-app/tests/unit/history/HistoryStore.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * HistoryStore unit tests — backfilled coverage for chrome://history.
+ *
+ * Tests cover:
+ *   - load() handles missing file (ENOENT) without throwing
+ *   - load() handles malformed JSON / wrong version
+ *   - addVisit() inserts entries reverse-chronologically
+ *   - addVisit() trims to MAX_ENTRIES (10,000)
+ *   - query() filters by case-insensitive substring on title + url
+ *   - query() supports limit / offset pagination + totalCount
+ *   - removeEntry() / removeEntries() / clearAll() mutate state correctly
+ *   - flushSync() writes a JSON-shape PersistedHistory to disk
+ *   - debounced scheduleSave triggers a single flush after 300ms
+ *
+ * Uses an in-memory fs mock to avoid touching the real userData dir.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// In-memory fs mock — captures writes, replays reads
+// ---------------------------------------------------------------------------
+
+const fsStore = new Map<string, string>();
+
+vi.mock('node:fs', () => {
+  const readFileSync = vi.fn((p: string) => {
+    const content = fsStore.get(p);
+    if (content === undefined) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+    return content;
+  });
+  const writeFileSync = vi.fn((p: string, data: string) => {
+    fsStore.set(p, data);
+  });
+  const existsSync = vi.fn((p: string) => fsStore.has(p));
+  const mkdirSync = vi.fn();
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp/test-history-userData'),
+  },
+}));
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { HistoryStore } from '../../../src/main/history/HistoryStore';
+import type { PersistedHistory } from '../../../src/main/history/HistoryStore';
+
+const HISTORY_PATH = path.join('/tmp/test-history-userData', 'history.json');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HistoryStore — construction and load()', () => {
+  beforeEach(() => {
+    fsStore.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with an empty entry list when history.json does not exist', () => {
+    const store = new HistoryStore();
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('loads entries from a valid history.json on disk', () => {
+    const persisted: PersistedHistory = {
+      version: 1,
+      entries: [
+        { id: 'h-1', url: 'https://example.com', title: 'Example', visitTime: 1, favicon: null },
+        { id: 'h-2', url: 'https://test.com', title: 'Test', visitTime: 2, favicon: null },
+      ],
+    };
+    fsStore.set(HISTORY_PATH, JSON.stringify(persisted));
+
+    const store = new HistoryStore();
+    expect(store.getAll()).toHaveLength(2);
+    expect(store.getAll()[0].id).toBe('h-1');
+  });
+
+  it('resets to empty when persisted version does not match', () => {
+    fsStore.set(HISTORY_PATH, JSON.stringify({ version: 99, entries: [{ id: 'x' }] }));
+    const store = new HistoryStore();
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('resets to empty when persisted JSON is malformed', () => {
+    fsStore.set(HISTORY_PATH, '{not-valid-json');
+    const store = new HistoryStore();
+    expect(store.getAll()).toEqual([]);
+  });
+});
+
+describe('HistoryStore — addVisit()', () => {
+  let store: HistoryStore;
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new HistoryStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inserts the new entry at the front (reverse-chronological)', () => {
+    store.addVisit('https://a.com', 'A');
+    store.addVisit('https://b.com', 'B');
+    const all = store.getAll();
+    expect(all[0].url).toBe('https://b.com');
+    expect(all[1].url).toBe('https://a.com');
+  });
+
+  it('falls back to the URL when the title is empty', () => {
+    const entry = store.addVisit('https://untitled.com', '');
+    expect(entry.title).toBe('https://untitled.com');
+  });
+
+  it('returns an entry with a generated id and current visitTime', () => {
+    const before = Date.now();
+    const entry = store.addVisit('https://a.com', 'A');
+    const after = Date.now();
+    expect(entry.id).toMatch(/^h-/);
+    expect(entry.visitTime).toBeGreaterThanOrEqual(before);
+    expect(entry.visitTime).toBeLessThanOrEqual(after);
+  });
+
+  it('persists the favicon when supplied', () => {
+    const entry = store.addVisit('https://a.com', 'A', 'data:image/png;base64,abc');
+    expect(entry.favicon).toBe('data:image/png;base64,abc');
+  });
+});
+
+describe('HistoryStore — query()', () => {
+  let store: HistoryStore;
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new HistoryStore();
+    store.addVisit('https://github.com/foo', 'GitHub Foo');
+    store.addVisit('https://news.ycombinator.com', 'Hacker News');
+    store.addVisit('https://example.com/docs', 'Example Docs');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns all entries when query is empty', () => {
+    const result = store.query();
+    expect(result.totalCount).toBe(3);
+    expect(result.entries).toHaveLength(3);
+  });
+
+  it('filters by case-insensitive title substring', () => {
+    const result = store.query({ query: 'hacker' });
+    expect(result.totalCount).toBe(1);
+    expect(result.entries[0].title).toBe('Hacker News');
+  });
+
+  it('filters by case-insensitive URL substring', () => {
+    const result = store.query({ query: 'GITHUB' });
+    expect(result.totalCount).toBe(1);
+    expect(result.entries[0].url).toContain('github.com');
+  });
+
+  it('respects the limit argument', () => {
+    const result = store.query({ limit: 2 });
+    expect(result.entries).toHaveLength(2);
+    expect(result.totalCount).toBe(3);
+  });
+
+  it('respects the offset argument', () => {
+    const result = store.query({ offset: 1, limit: 10 });
+    expect(result.entries).toHaveLength(2);
+    // Most-recent (index 0) was Example Docs
+    expect(result.entries[0].title).toBe('Hacker News');
+  });
+
+  it('returns no entries when nothing matches', () => {
+    const result = store.query({ query: 'no-match-xyz' });
+    expect(result.totalCount).toBe(0);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it('treats whitespace-only queries as no-filter', () => {
+    const result = store.query({ query: '   ' });
+    expect(result.totalCount).toBe(3);
+  });
+});
+
+describe('HistoryStore — removeEntry / removeEntries / clearAll', () => {
+  let store: HistoryStore;
+  let ids: string[];
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new HistoryStore();
+    const a = store.addVisit('https://a.com', 'A');
+    const b = store.addVisit('https://b.com', 'B');
+    const c = store.addVisit('https://c.com', 'C');
+    ids = [a.id, b.id, c.id];
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('removeEntry returns true when the id is present', () => {
+    expect(store.removeEntry(ids[0])).toBe(true);
+    expect(store.getAll()).toHaveLength(2);
+  });
+
+  it('removeEntry returns false when the id is unknown', () => {
+    expect(store.removeEntry('not-an-id')).toBe(false);
+    expect(store.getAll()).toHaveLength(3);
+  });
+
+  it('removeEntries removes every matching id and returns the count', () => {
+    const removed = store.removeEntries([ids[0], ids[2]]);
+    expect(removed).toBe(2);
+    expect(store.getAll()).toHaveLength(1);
+    expect(store.getAll()[0].id).toBe(ids[1]);
+  });
+
+  it('removeEntries returns 0 when no ids match (and does not call save)', () => {
+    const removed = store.removeEntries(['ghost-1', 'ghost-2']);
+    expect(removed).toBe(0);
+    expect(store.getAll()).toHaveLength(3);
+  });
+
+  it('clearAll empties the store', () => {
+    store.clearAll();
+    expect(store.getAll()).toHaveLength(0);
+  });
+});
+
+describe('HistoryStore — persistence (flushSync)', () => {
+  beforeEach(() => {
+    fsStore.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes a PersistedHistory v1 shape on flushSync()', () => {
+    const store = new HistoryStore();
+    store.addVisit('https://a.com', 'A');
+    store.flushSync();
+
+    const raw = fsStore.get(HISTORY_PATH);
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!) as PersistedHistory;
+    expect(parsed.version).toBe(1);
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0].url).toBe('https://a.com');
+  });
+
+  it('flushSync is a no-op when there are no pending changes', () => {
+    const store = new HistoryStore();
+    store.flushSync();
+    expect(fsStore.has(HISTORY_PATH)).toBe(false);
+  });
+
+  it('round-trips entries through flushSync + new store load', () => {
+    const writer = new HistoryStore();
+    writer.addVisit('https://a.com', 'A');
+    writer.addVisit('https://b.com', 'B');
+    writer.flushSync();
+
+    const reader = new HistoryStore();
+    const all = reader.getAll();
+    expect(all).toHaveLength(2);
+    // Reverse-chronological: B was added second so it sits at index 0
+    expect(all[0].url).toBe('https://b.com');
+  });
+});

--- a/my-app/tests/unit/history/JourneyCluster.spec.ts
+++ b/my-app/tests/unit/history/JourneyCluster.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * JourneyCluster unit tests — backfilled coverage for chrome://history journeys.
+ *
+ * Tests cover:
+ *   - clusterEntries returns [] for empty input and for single-entry input
+ *     (MIN_CLUSTER_SIZE is 2)
+ *   - groups entries by root domain (strips www., uses last-2 labels)
+ *   - splits clusters when gap exceeds CLUSTER_GAP_MS (30 minutes)
+ *   - keeps clusters together at the boundary (gap == CLUSTER_GAP_MS)
+ *   - sorts clusters newest-first by endTime
+ *   - cluster label uses the unique title when ≤ 60 chars, else "Site — N pages"
+ *   - queryJourneys filters on label, domain, and entry title/url
+ *   - queryJourneys honours limit and offset
+ *   - removeClusterEntries returns the entry ids; empty array for unknown id
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  clusterEntries,
+  queryJourneys,
+  removeClusterEntries,
+} from '../../../src/main/history/JourneyCluster';
+import type { HistoryEntry } from '../../../src/main/history/HistoryStore';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HOUR = 60 * 60 * 1000;
+const MIN = 60 * 1000;
+const BASE = 1_700_000_000_000; // arbitrary fixed timestamp
+
+function makeEntry(
+  id: string,
+  url: string,
+  title: string,
+  visitTime: number,
+): HistoryEntry {
+  return { id, url, title, visitTime, favicon: null };
+}
+
+// ---------------------------------------------------------------------------
+// clusterEntries
+// ---------------------------------------------------------------------------
+
+describe('clusterEntries — edge cases', () => {
+  it('returns an empty array for an empty input', () => {
+    expect(clusterEntries([])).toEqual([]);
+  });
+
+  it('returns an empty array when only one visit per domain (below MIN_CLUSTER_SIZE)', () => {
+    const entries = [makeEntry('1', 'https://a.com', 'A', BASE)];
+    expect(clusterEntries(entries)).toEqual([]);
+  });
+
+  it('returns an empty array when single visits across many domains never reach 2-per-cluster', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com', 'A', BASE),
+      makeEntry('2', 'https://b.com', 'B', BASE + MIN),
+      makeEntry('3', 'https://c.com', 'C', BASE + 2 * MIN),
+    ];
+    expect(clusterEntries(entries)).toEqual([]);
+  });
+});
+
+describe('clusterEntries — grouping by domain', () => {
+  it('groups two visits to the same domain within 30 minutes into one cluster', () => {
+    const entries = [
+      makeEntry('1', 'https://example.com/page1', 'Page 1', BASE),
+      makeEntry('2', 'https://example.com/page2', 'Page 2', BASE + 5 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].domain).toBe('example.com');
+    expect(clusters[0].entries).toHaveLength(2);
+  });
+
+  it('treats www. and bare hostnames as the same domain', () => {
+    const entries = [
+      makeEntry('1', 'https://www.example.com/a', 'A', BASE),
+      makeEntry('2', 'https://example.com/b', 'B', BASE + MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].domain).toBe('example.com');
+  });
+
+  it('uses the last two hostname labels for subdomains', () => {
+    const entries = [
+      makeEntry('1', 'https://docs.github.com/foo', 'Foo', BASE),
+      makeEntry('2', 'https://api.github.com/bar', 'Bar', BASE + 2 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].domain).toBe('github.com');
+  });
+
+  it('keeps separate domains in separate clusters', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A1', BASE),
+      makeEntry('2', 'https://a.com/2', 'A2', BASE + MIN),
+      makeEntry('3', 'https://b.com/1', 'B1', BASE + 2 * MIN),
+      makeEntry('4', 'https://b.com/2', 'B2', BASE + 3 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(2);
+    expect(new Set(clusters.map((c) => c.domain))).toEqual(new Set(['a.com', 'b.com']));
+  });
+});
+
+describe('clusterEntries — temporal splitting', () => {
+  it('splits into two clusters when a same-domain gap exceeds 30 minutes', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + 10 * MIN),
+      // 31-minute gap → starts new cluster
+      makeEntry('3', 'https://a.com/3', 'A', BASE + 41 * MIN),
+      makeEntry('4', 'https://a.com/4', 'A', BASE + 50 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(2);
+    expect(clusters.every((c) => c.entries.length === 2)).toBe(true);
+  });
+
+  it('keeps a cluster together at the exact 30-minute boundary', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + 30 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].entries).toHaveLength(2);
+  });
+
+  it('drops orphaned visits that do not reach MIN_CLUSTER_SIZE within their group', () => {
+    // First 2 form a cluster; the 3rd is orphaned across the gap
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + 10 * MIN),
+      makeEntry('3', 'https://a.com/3', 'A', BASE + 60 * MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].entries).toHaveLength(2);
+  });
+});
+
+describe('clusterEntries — sorting and labelling', () => {
+  it('sorts clusters newest-first by endTime', () => {
+    const entries = [
+      // Older cluster on a.com
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + MIN),
+      // Newer cluster on b.com
+      makeEntry('3', 'https://b.com/1', 'B', BASE + 5 * HOUR),
+      makeEntry('4', 'https://b.com/2', 'B', BASE + 5 * HOUR + MIN),
+    ];
+    const clusters = clusterEntries(entries);
+    expect(clusters[0].domain).toBe('b.com');
+    expect(clusters[1].domain).toBe('a.com');
+  });
+
+  it('uses the unique short title for the cluster label when applicable', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/x', 'Same Title', BASE),
+      makeEntry('2', 'https://a.com/y', 'Same Title', BASE + MIN),
+    ];
+    const [cluster] = clusterEntries(entries);
+    expect(cluster.label).toBe('Same Title');
+  });
+
+  it('falls back to "Site — N pages" label when titles differ', () => {
+    const entries = [
+      makeEntry('1', 'https://example.com/x', 'First', BASE),
+      makeEntry('2', 'https://example.com/y', 'Second', BASE + MIN),
+      makeEntry('3', 'https://example.com/z', 'Third', BASE + 2 * MIN),
+    ];
+    const [cluster] = clusterEntries(entries);
+    expect(cluster.label).toBe('Example — 3 pages');
+  });
+
+  it('returns clusters with entries reversed (most-recent first within cluster)', () => {
+    const entries = [
+      makeEntry('older', 'https://a.com/1', 'A', BASE),
+      makeEntry('newer', 'https://a.com/2', 'A', BASE + MIN),
+    ];
+    const [cluster] = clusterEntries(entries);
+    expect(cluster.entries[0].id).toBe('newer');
+    expect(cluster.entries[1].id).toBe('older');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryJourneys
+// ---------------------------------------------------------------------------
+
+describe('queryJourneys', () => {
+  function fixtures(): HistoryEntry[] {
+    return [
+      // github cluster
+      makeEntry('g1', 'https://github.com/foo', 'Foo PR', BASE),
+      makeEntry('g2', 'https://github.com/bar', 'Bar issue', BASE + 5 * MIN),
+      // hacker news cluster (different domain)
+      makeEntry('h1', 'https://news.ycombinator.com/a', 'Top story', BASE + 6 * HOUR),
+      makeEntry('h2', 'https://news.ycombinator.com/b', 'Comments', BASE + 6 * HOUR + MIN),
+    ];
+  }
+
+  it('returns all clusters when no query is given', () => {
+    const result = queryJourneys(fixtures());
+    expect(result.totalCount).toBe(2);
+    expect(result.clusters).toHaveLength(2);
+  });
+
+  it('filters by domain substring', () => {
+    const result = queryJourneys(fixtures(), { query: 'github' });
+    expect(result.totalCount).toBe(1);
+    expect(result.clusters[0].domain).toBe('github.com');
+  });
+
+  it('filters by entry title substring', () => {
+    const result = queryJourneys(fixtures(), { query: 'comments' });
+    expect(result.totalCount).toBe(1);
+    expect(result.clusters[0].domain).toBe('ycombinator.com');
+  });
+
+  it('filters by entry URL substring', () => {
+    const result = queryJourneys(fixtures(), { query: '/foo' });
+    expect(result.totalCount).toBe(1);
+    expect(result.clusters[0].domain).toBe('github.com');
+  });
+
+  it('returns empty result when nothing matches', () => {
+    const result = queryJourneys(fixtures(), { query: 'no-such-thing' });
+    expect(result.totalCount).toBe(0);
+    expect(result.clusters).toHaveLength(0);
+  });
+
+  it('respects limit and offset', () => {
+    const result = queryJourneys(fixtures(), { limit: 1, offset: 1 });
+    expect(result.totalCount).toBe(2);
+    expect(result.clusters).toHaveLength(1);
+  });
+
+  it('treats whitespace-only queries as no-filter', () => {
+    const result = queryJourneys(fixtures(), { query: '   ' });
+    expect(result.totalCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeClusterEntries
+// ---------------------------------------------------------------------------
+
+describe('removeClusterEntries', () => {
+  it('returns the entry ids belonging to the targeted cluster', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + MIN),
+    ];
+    const [cluster] = clusterEntries(entries);
+    const ids = removeClusterEntries(entries, cluster.id);
+    expect(ids).toEqual(expect.arrayContaining(['1', '2']));
+    expect(ids).toHaveLength(2);
+  });
+
+  it('returns an empty array when the cluster id is unknown', () => {
+    const entries = [
+      makeEntry('1', 'https://a.com/1', 'A', BASE),
+      makeEntry('2', 'https://a.com/2', 'A', BASE + MIN),
+    ];
+    const ids = removeClusterEntries(entries, 'j-not-a-real-cluster');
+    expect(ids).toEqual([]);
+  });
+});

--- a/my-app/tests/unit/shell/ZoomBadge.spec.tsx
+++ b/my-app/tests/unit/shell/ZoomBadge.spec.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ZoomBadge renderer smoke tests — backfilled coverage for the shell zoom UI.
+ *
+ * Tests cover:
+ *   - mounts and renders the current zoom percentage label
+ *   - opens the popover on click and closes on Escape
+ *   - +/− buttons call onZoomIn / onZoomOut
+ *   - Reset button calls onReset and closes the popover
+ *   - zoom-in disabled at the upper clamp (≥ 500%)
+ *   - zoom-out disabled at the lower clamp (≤ 25%)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+
+import { ZoomBadge } from '../../../src/renderer/shell/ZoomBadge';
+
+function renderBadge(percent: number) {
+  const onZoomIn = vi.fn();
+  const onZoomOut = vi.fn();
+  const onReset = vi.fn();
+  const utils = render(
+    <ZoomBadge
+      percent={percent}
+      onZoomIn={onZoomIn}
+      onZoomOut={onZoomOut}
+      onReset={onReset}
+    />,
+  );
+  return { ...utils, onZoomIn, onZoomOut, onReset };
+}
+
+describe('ZoomBadge', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the current zoom percentage on the badge', () => {
+    renderBadge(125);
+    expect(screen.getByRole('button', { name: /zoom 125%/i })).toBeTruthy();
+  });
+
+  it('opens the popover when the badge is clicked', () => {
+    renderBadge(150);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 150%/i }));
+    expect(screen.getByRole('dialog', { name: /zoom controls/i })).toBeTruthy();
+  });
+
+  it('toggles the popover closed on a second click', () => {
+    renderBadge(150);
+    const badge = screen.getByRole('button', { name: /zoom 150%/i });
+    fireEvent.click(badge);
+    fireEvent.click(badge);
+    expect(screen.queryByRole('dialog', { name: /zoom controls/i })).toBeNull();
+  });
+
+  it('closes the popover when Escape is pressed', () => {
+    renderBadge(150);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 150%/i }));
+    expect(screen.getByRole('dialog', { name: /zoom controls/i })).toBeTruthy();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(screen.queryByRole('dialog', { name: /zoom controls/i })).toBeNull();
+  });
+
+  it('+ button calls onZoomIn', () => {
+    const { onZoomIn } = renderBadge(150);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 150%/i }));
+    fireEvent.click(screen.getByRole('button', { name: /zoom in/i }));
+    expect(onZoomIn).toHaveBeenCalled();
+  });
+
+  it('− button calls onZoomOut', () => {
+    const { onZoomOut } = renderBadge(150);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 150%/i }));
+    fireEvent.click(screen.getByRole('button', { name: /zoom out/i }));
+    expect(onZoomOut).toHaveBeenCalled();
+  });
+
+  it('Reset button calls onReset and closes the popover', () => {
+    const { onReset } = renderBadge(150);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 150%/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^reset$/i }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog', { name: /zoom controls/i })).toBeNull();
+  });
+
+  it('disables zoom-out when at the lower clamp (≤25%)', () => {
+    renderBadge(25);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 25%/i }));
+    const out = screen.getByRole('button', { name: /zoom out/i }) as HTMLButtonElement;
+    expect(out.disabled).toBe(true);
+  });
+
+  it('disables zoom-in when at the upper clamp (≥500%)', () => {
+    renderBadge(500);
+    fireEvent.click(screen.getByRole('button', { name: /zoom 500%/i }));
+    const inBtn = screen.getByRole('button', { name: /zoom in/i }) as HTMLButtonElement;
+    expect(inBtn.disabled).toBe(true);
+  });
+});

--- a/my-app/tests/unit/zoom/ZoomStore.spec.ts
+++ b/my-app/tests/unit/zoom/ZoomStore.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * ZoomStore unit tests — backfilled coverage for the per-origin zoom feature.
+ *
+ * Tests cover:
+ *   - extractOrigin: standard URLs, data:/about: rejection, malformed input
+ *   - zoomLevelToPercent: matches the 1.2^level formula used by the badge
+ *   - get/set/remove round-trip on a fresh store
+ *   - setZoomForOrigin(origin, 0) deletes the override (don't store noise)
+ *   - listOverrides returns one entry per persisted origin
+ *   - removeOrigin returns false for unknown origin
+ *   - clearAll wipes all overrides
+ *   - flushSync writes the JSON file with the right shape
+ *   - load() handles missing file (returns empty), malformed JSON, wrong version
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// In-memory fs mock
+// ---------------------------------------------------------------------------
+
+const fsStore = new Map<string, string>();
+
+vi.mock('node:fs', () => {
+  const readFileSync = vi.fn((p: string) => {
+    const content = fsStore.get(p);
+    if (content === undefined) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }
+    return content;
+  });
+  const writeFileSync = vi.fn((p: string, data: string) => {
+    fsStore.set(p, data);
+  });
+  const existsSync = vi.fn((p: string) => fsStore.has(p));
+  const mkdirSync = vi.fn();
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp/test-zoom-userData'),
+  },
+}));
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  ZoomStore,
+  extractOrigin,
+  zoomLevelToPercent,
+} from '../../../src/main/tabs/ZoomStore';
+
+const ZOOM_PATH = path.join('/tmp/test-zoom-userData', 'zoom.json');
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('extractOrigin', () => {
+  it('extracts the origin from a standard https URL', () => {
+    expect(extractOrigin('https://example.com/path?q=1')).toBe('https://example.com');
+  });
+
+  it('preserves the port in the origin', () => {
+    expect(extractOrigin('http://localhost:3000/foo')).toBe('http://localhost:3000');
+  });
+
+  it('returns null for data: URLs', () => {
+    expect(extractOrigin('data:text/html,<h1>hi</h1>')).toBeNull();
+  });
+
+  it('returns null for about: URLs', () => {
+    expect(extractOrigin('about:blank')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(extractOrigin('')).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(extractOrigin('not a url')).toBeNull();
+  });
+});
+
+describe('zoomLevelToPercent', () => {
+  it('returns 100 when level is 0 (Chrome default)', () => {
+    expect(zoomLevelToPercent(0)).toBe(100);
+  });
+
+  it('returns 120 when level is 1 (1.2^1 == 120)', () => {
+    expect(zoomLevelToPercent(1)).toBe(120);
+  });
+
+  it('rounds to the nearest integer', () => {
+    // 1.2^0.5 ≈ 1.0954 → 110
+    expect(zoomLevelToPercent(0.5)).toBe(110);
+  });
+
+  it('decreases for negative levels', () => {
+    expect(zoomLevelToPercent(-1)).toBe(83); // 1.2^-1 ≈ 0.833
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ZoomStore lifecycle
+// ---------------------------------------------------------------------------
+
+describe('ZoomStore — load and construction', () => {
+  beforeEach(() => {
+    fsStore.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts empty when zoom.json does not exist', () => {
+    const store = new ZoomStore();
+    expect(store.listOverrides()).toEqual([]);
+  });
+
+  it('loads existing origin overrides from disk', () => {
+    const persisted = {
+      version: 1,
+      origins: {
+        'https://example.com': 0.5,
+        'https://github.com': 1,
+      },
+    };
+    fsStore.set(ZOOM_PATH, JSON.stringify(persisted));
+    const store = new ZoomStore();
+    expect(store.listOverrides()).toHaveLength(2);
+    expect(store.getZoomForOrigin('https://example.com')).toBe(0.5);
+  });
+
+  it('resets to empty when persisted version is wrong', () => {
+    fsStore.set(ZOOM_PATH, JSON.stringify({ version: 2, origins: { 'https://x.com': 1 } }));
+    const store = new ZoomStore();
+    expect(store.listOverrides()).toEqual([]);
+  });
+
+  it('resets to empty when persisted JSON is malformed', () => {
+    fsStore.set(ZOOM_PATH, '{not-valid-json');
+    const store = new ZoomStore();
+    expect(store.listOverrides()).toEqual([]);
+  });
+});
+
+describe('ZoomStore — get / set', () => {
+  let store: ZoomStore;
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new ZoomStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getZoomForOrigin returns 0 for an unknown origin', () => {
+    expect(store.getZoomForOrigin('https://nope.com')).toBe(0);
+  });
+
+  it('setZoomForOrigin persists a non-zero level', () => {
+    store.setZoomForOrigin('https://example.com', 1.5);
+    expect(store.getZoomForOrigin('https://example.com')).toBe(1.5);
+  });
+
+  it('setZoomForOrigin with level=0 deletes the entry (no noise stored)', () => {
+    store.setZoomForOrigin('https://example.com', 1.5);
+    store.setZoomForOrigin('https://example.com', 0);
+    expect(store.listOverrides()).toEqual([]);
+  });
+
+  it('getZoomForUrl extracts the origin and looks it up', () => {
+    store.setZoomForOrigin('https://example.com', 0.75);
+    expect(store.getZoomForUrl('https://example.com/path?q=1')).toBe(0.75);
+  });
+
+  it('getZoomForUrl returns 0 for data: URLs', () => {
+    store.setZoomForOrigin('https://example.com', 0.75);
+    expect(store.getZoomForUrl('data:text/html,hi')).toBe(0);
+  });
+
+  it('setZoomForUrl ignores URLs with no resolvable origin', () => {
+    store.setZoomForUrl('about:blank', 1);
+    expect(store.listOverrides()).toEqual([]);
+  });
+
+  it('listOverrides returns one entry per persisted origin', () => {
+    store.setZoomForOrigin('https://a.com', 1);
+    store.setZoomForOrigin('https://b.com', 2);
+    const overrides = store.listOverrides();
+    expect(overrides).toHaveLength(2);
+    expect(overrides.map((o) => o.origin).sort()).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ]);
+  });
+});
+
+describe('ZoomStore — remove and clear', () => {
+  let store: ZoomStore;
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new ZoomStore();
+    store.setZoomForOrigin('https://a.com', 1);
+    store.setZoomForOrigin('https://b.com', 2);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('removeOrigin returns true and removes the entry', () => {
+    expect(store.removeOrigin('https://a.com')).toBe(true);
+    expect(store.listOverrides()).toHaveLength(1);
+  });
+
+  it('removeOrigin returns false for unknown origin', () => {
+    expect(store.removeOrigin('https://nope.com')).toBe(false);
+    expect(store.listOverrides()).toHaveLength(2);
+  });
+
+  it('clearAll wipes every override', () => {
+    store.clearAll();
+    expect(store.listOverrides()).toEqual([]);
+  });
+});
+
+describe('ZoomStore — persistence (flushSync)', () => {
+  beforeEach(() => {
+    fsStore.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes a versioned origins map on flushSync()', () => {
+    const store = new ZoomStore();
+    store.setZoomForOrigin('https://example.com', 1.5);
+    store.flushSync();
+
+    const raw = fsStore.get(ZOOM_PATH);
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(1);
+    expect(parsed.origins['https://example.com']).toBe(1.5);
+  });
+
+  it('flushSync is a no-op when nothing is dirty', () => {
+    const store = new ZoomStore();
+    store.flushSync();
+    expect(fsStore.has(ZOOM_PATH)).toBe(false);
+  });
+
+  it('round-trips through flushSync + a fresh ZoomStore load', () => {
+    const writer = new ZoomStore();
+    writer.setZoomForOrigin('https://a.com', 1);
+    writer.setZoomForOrigin('https://b.com', -0.5);
+    writer.flushSync();
+
+    const reader = new ZoomStore();
+    expect(reader.getZoomForOrigin('https://a.com')).toBe(1);
+    expect(reader.getZoomForOrigin('https://b.com')).toBe(-0.5);
+  });
+});

--- a/my-app/vitest.config.ts
+++ b/my-app/vitest.config.ts
@@ -10,9 +10,11 @@
  */
 
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     name: 'unit',
     include: [
@@ -21,8 +23,19 @@ export default defineConfig({
       'tests/integration/**/*.test.ts',
       // Regression tests that don't need a live Electron process
       'tests/regression/no-global-shortcuts.spec.ts',
+      // Backfilled tests for chrome://history, chrome://extensions, zoom
+      // (PR: test backfill for D1 TDD compliance)
+      'tests/unit/history/**/*.spec.ts',
+      'tests/unit/history/**/*.spec.tsx',
+      'tests/unit/extensions/**/*.spec.ts',
+      'tests/unit/extensions/**/*.spec.tsx',
+      'tests/unit/zoom/**/*.spec.ts',
+      'tests/unit/shell/**/*.spec.tsx',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],
+    // Renderer .spec.tsx files declare jsdom via the per-file
+    //   // @vitest-environment jsdom
+    // pragma. The default is node so the existing pure-unit suite is unaffected.
     environment: 'node',
     globals: false,
     // Mock electron module so tests run outside Electron


### PR DESCRIPTION
## Summary

Backfills unit and integration tests for three Chromium-parity features that shipped without any tests, restoring D1 (TDD) compliance:

- **chrome://history** (commit a8e7b51) — `HistoryStore`, `JourneyCluster`, `history/ipc.ts`, `HistoryPage`
- **chrome://extensions** (commit 6304cf4), **non-mv3 surface only** — `ExtensionManager`, `extensions/ipc.ts`, `ExtensionsApp`
- **Per-origin zoom** (commit 39b4d85) — `ZoomStore`, `ZoomBadge`

`vitest.config.ts` is extended to pick up the new renderer `.spec.tsx` files; each renderer test declares its own `jsdom` environment via the `// @vitest-environment jsdom` file pragma so the existing pure-unit suite is unaffected.

## What's in the PR

**9 new test files, 156 new test cases**

Unit (main-process, no Electron required):
- `tests/unit/history/HistoryStore.spec.ts` — 24 tests (load, addVisit, query/search, remove, clearAll, flushSync round-trip)
- `tests/unit/history/JourneyCluster.spec.ts` — 23 tests (clustering edge cases, domain grouping, temporal splitting at 30-min boundary, sorting/labelling, query/remove)
- `tests/unit/extensions/ExtensionManager.spec.ts` — 24 tests (state load, loadAllEnabled, loadUnpacked, enable/disable/remove, updateExtension, setHostAccess, developer mode)
- `tests/unit/zoom/ZoomStore.spec.ts` — 27 tests (extractOrigin/zoomLevelToPercent helpers, get/set/remove, persistence, invalid-input handling)

Integration (vi.hoisted + vi.mock):
- `tests/integration/history-ipc.test.ts` — 17 tests (handler registration, query/remove/bulk/clear flow, journeys, validator rejections)
- `tests/integration/extensions-ipc.test.ts` — 17 tests (handler registration, list/details/toggle, host-access validator, dev mode, dialog flows)

Renderer smoke (jsdom + @testing-library/react):
- `tests/unit/history/HistoryPage.spec.tsx` — 9 tests (mount, group-by-date, empty state, search debounce, remove/navigate IPC, journeys tab swap, bulk-select bar)
- `tests/unit/extensions/ExtensionsApp.spec.tsx` — 9 tests (mount, empty state, card render, enable/disable, remove modal, developer mode toolbar reveal, host-access dropdown)
- `tests/unit/shell/ZoomBadge.spec.tsx` — 9 tests (badge label, popover open/close, +/- callbacks, reset, escape close, upper/lower clamp disabling)

## Coverage delta

Coverage on every targeted module clears the D1 80% line bar:

| File | Lines | Branches | Funcs |
| --- | --- | --- | --- |
| `src/main/history/HistoryStore.ts` | 96.6% | 94.1% | 100% |
| `src/main/history/JourneyCluster.ts` | 96.8% | 91.7% | 100% |
| `src/main/history/ipc.ts` | 100% | 93.1% | 100% |
| `src/main/extensions/ExtensionManager.ts` | 95.0% | 85.5% | 100% |
| `src/main/extensions/ipc.ts` | 96.6% | 69.0% | 92.8% |
| `src/main/tabs/ZoomStore.ts` | 98.1% | 94.7% | 100% |
| `src/renderer/history/HistoryPage.tsx` | 89.8% | 81.5% | 84.6% |
| `src/renderer/extensions/ExtensionsApp.tsx` | 82.8% | 82.1% | 63.1% |
| `src/renderer/shell/ZoomBadge.tsx` | 91.5% | 100% | 75% |

Untested in this PR (in scope but deferred):

- **`src/renderer/history/JourneysPage.tsx`** — 0%. The HistoryPage smoke covers the tab-swap to JourneysPage but does not exercise the JourneysPage internals (cluster expand/collapse, removeCluster). The clustering logic itself is covered by `JourneyCluster.spec.ts` (96.8%); the renderer slice is left as a follow-up to keep this PR focused on the deliverables list.
- **TabManager zoom methods** (`getZoomOverrides`/`removeZoomOverride`/`clearAllZoomOverrides`) — covered indirectly through `ZoomStore` (98.1%). Direct TabManager tests would require constructing a real `BrowserWindow`, well outside the "test only the zoom surface, not the whole TabManager" scope. Flagged here as **untested pending refactor**: TabManager's zoom slice would benefit from being extracted into a thin coordinator that takes the store + a webContents-like dependency, to allow direct unit testing without Electron.

Out of scope per the brief: mv3 extension code (PR #119), e2e/Playwright (separate PR pending the launch-hang fix), and refactors to feature source.

## Test plan

- [x] `npm run lint` — 0 errors (174 pre-existing warnings unchanged)
- [x] `npm run test` — 274/274 pass (118 baseline + 156 new)
- [x] `npm run test -- tests/unit/history tests/unit/extensions tests/unit/zoom tests/integration/history-ipc.test.ts tests/integration/extensions-ipc.test.ts` — 147/147 pass
- [x] `npm run test:coverage` — every targeted module ≥80% lines
- [x] No source code changes outside `vitest.config.ts` (added `react()` plugin + `.spec.tsx` includes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills unit and integration tests for chrome://history, chrome://extensions (non‑mv3), and per‑origin zoom to restore D1 TDD compliance. Adds 9 test files, raises coverage on targeted modules to ≥80%, and updates `vitest.config.ts` to pick up renderer `.spec.tsx` tests with per-file `jsdom`.

- **Dependencies**
  - `vitest.config.ts` now uses `@vitejs/plugin-react` for React renderer tests. Ensure `@vitejs/plugin-react` is installed.

<sup>Written for commit c5c95515b2c2f95a45e699755b306a865a3a391c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

