### PR TITLE
feat(privacy): add prediction service and preload pages settings

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -89,6 +89,13 @@ const CH_SET_BIOMETRIC_LOCK  = 'settings:set-biometric-lock';
 const CH_BIOMETRIC_AVAILABLE = 'settings:biometric-available';
 const CH_GET_HTTPS_FIRST     = 'settings:get-https-first';
 const CH_SET_HTTPS_FIRST     = 'settings:set-https-first';
+const CH_GET_PREDICTION      = 'settings:get-prediction-service';
+const CH_SET_PREDICTION      = 'settings:set-prediction-service';
+const CH_GET_PRELOAD         = 'settings:get-preload-pages';
+const CH_SET_PRELOAD         = 'settings:set-preload-pages';
+
+const ALLOWED_PRELOAD_MODES = ['none', 'standard', 'extended'] as const;
+type PreloadMode = typeof ALLOWED_PRELOAD_MODES[number];
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -589,6 +596,41 @@ function handleSetHttpsFirst(_event: Electron.IpcMainInvokeEvent, enabled: boole
   mainLogger.info(`${CH_SET_HTTPS_FIRST}.ok`, { enabled });
 }
 
+
+function handleGetPredictionService(): boolean {
+  mainLogger.info(CH_GET_PREDICTION);
+  const prefs = readPrefs();
+  const enabled = prefs.predictionService === true;
+  mainLogger.info(`${CH_GET_PREDICTION}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetPredictionService(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('predictionService must be a boolean');
+  }
+  mainLogger.info(CH_SET_PREDICTION, { enabled });
+  mergePrefs({ predictionService: enabled });
+  mainLogger.info(`${CH_SET_PREDICTION}.ok`, { enabled });
+}
+
+function handleGetPreloadPages(): string {
+  mainLogger.info(CH_GET_PRELOAD);
+  const prefs = readPrefs();
+  const mode = (ALLOWED_PRELOAD_MODES as readonly string[]).includes(prefs.preloadPages as string)
+    ? (prefs.preloadPages as string)
+    : 'standard';
+  mainLogger.info(`${CH_GET_PRELOAD}.ok`, { mode });
+  return mode;
+}
+
+function handleSetPreloadPages(_event: Electron.IpcMainInvokeEvent, mode: string): void {
+  const validatedMode: PreloadMode = assertOneOf(mode, 'preloadPages', ALLOWED_PRELOAD_MODES);
+  mainLogger.info(CH_SET_PRELOAD, { mode: validatedMode });
+  mergePrefs({ preloadPages: validatedMode });
+  mainLogger.info(`${CH_SET_PRELOAD}.ok`, { mode: validatedMode });
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -633,8 +675,12 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_BIOMETRIC_AVAILABLE, handleBiometricAvailable);
   ipcMain.handle(CH_GET_HTTPS_FIRST,    handleGetHttpsFirst);
   ipcMain.handle(CH_SET_HTTPS_FIRST,    handleSetHttpsFirst);
+  ipcMain.handle(CH_GET_PREDICTION,     handleGetPredictionService);
+  ipcMain.handle(CH_SET_PREDICTION,     handleSetPredictionService);
+  ipcMain.handle(CH_GET_PRELOAD,        handleGetPreloadPages);
+  ipcMain.handle(CH_SET_PRELOAD,        handleSetPreloadPages);
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 21 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -661,6 +707,10 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_BIOMETRIC_AVAILABLE);
   ipcMain.removeHandler(CH_GET_HTTPS_FIRST);
   ipcMain.removeHandler(CH_SET_HTTPS_FIRST);
+  ipcMain.removeHandler(CH_GET_PREDICTION);
+  ipcMain.removeHandler(CH_SET_PREDICTION);
+  ipcMain.removeHandler(CH_GET_PRELOAD);
+  ipcMain.removeHandler(CH_SET_PRELOAD);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -149,6 +149,18 @@ export interface SettingsAPI {
 
   /** Set whether HTTPS-First mode is enabled */
   setHttpsFirst: (enabled: boolean) => Promise<void>;
+
+  /** Get whether prediction service is enabled */
+  getPredictionService: () => Promise<boolean>;
+
+  /** Set whether prediction service is enabled */
+  setPredictionService: (enabled: boolean) => Promise<void>;
+
+  /** Get the current preload pages mode */
+  getPreloadPages: () => Promise<string>;
+
+  /** Set the preload pages mode */
+  setPreloadPages: (mode: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -339,6 +351,26 @@ const api: SettingsAPI = {
   setHttpsFirst: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setHttpsFirst', { enabled });
     await ipcRenderer.invoke('settings:set-https-first', enabled);
+  },
+
+  getPredictionService: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getPredictionService');
+    return ipcRenderer.invoke('settings:get-prediction-service') as Promise<boolean>;
+  },
+
+  setPredictionService: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setPredictionService', { enabled });
+    await ipcRenderer.invoke('settings:set-prediction-service', enabled);
+  },
+
+  getPreloadPages: async (): Promise<string> => {
+    console.debug('[settings-preload] getPreloadPages');
+    return ipcRenderer.invoke('settings:get-preload-pages') as Promise<string>;
+  },
+
+  setPreloadPages: async (mode: string): Promise<void> => {
+    console.debug('[settings-preload] setPreloadPages', { mode });
+    await ipcRenderer.invoke('settings:set-preload-pages', mode);
   },
 };
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -150,6 +150,10 @@ declare global {
       setBiometricLock: (enabled: boolean) => Promise<void>;
       getHttpsFirst: () => Promise<boolean>;
       setHttpsFirst: (enabled: boolean) => Promise<void>;
+      getPredictionService: () => Promise<boolean>;
+      setPredictionService: (enabled: boolean) => Promise<void>;
+      getPreloadPages: () => Promise<string>;
+      setPreloadPages: (mode: string) => Promise<void>;
     };
   }
 }
@@ -748,6 +752,10 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
   const toast = useToast();
   const [httpsFirst, setHttpsFirst] = useState(false);
   const [httpsFirstLoading, setHttpsFirstLoading] = useState(true);
+  const [predictionService, setPredictionService] = useState(false);
+  const [predictionLoading, setPredictionLoading] = useState(true);
+  const [preloadPages, setPreloadPages] = useState('standard');
+  const [preloadLoading, setPreloadLoading] = useState(true);
 
   useEffect(() => {
     void window.settingsAPI.getHttpsFirst().then((val) => {
@@ -755,6 +763,18 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
     }).catch(() => {
     }).finally(() => {
       setHttpsFirstLoading(false);
+    });
+    void window.settingsAPI.getPredictionService().then((val) => {
+      setPredictionService(val);
+    }).catch(() => {
+    }).finally(() => {
+      setPredictionLoading(false);
+    });
+    void window.settingsAPI.getPreloadPages().then((val) => {
+      setPreloadPages(val);
+    }).catch(() => {
+    }).finally(() => {
+      setPreloadLoading(false);
     });
   }, []);
 
@@ -768,6 +788,46 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
       });
     } catch (err) {
       setHttpsFirst(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handlePredictionToggle(checked: boolean): Promise<void> {
+    setPredictionService(checked);
+    try {
+      await window.settingsAPI.setPredictionService(checked);
+      toast.show({
+        variant: 'success',
+        title: checked ? 'Prediction service enabled' : 'Prediction service disabled',
+      });
+    } catch (err) {
+      setPredictionService(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handlePreloadChange(mode: string): Promise<void> {
+    setPreloadPages(mode);
+    try {
+      await window.settingsAPI.setPreloadPages(mode);
+      const labels: Record<string, string> = {
+        none: 'No preloading',
+        standard: 'Standard preloading',
+        extended: 'Extended preloading',
+      };
+      toast.show({
+        variant: 'success',
+        title: labels[mode] ?? mode,
+      });
+    } catch (err) {
       toast.show({
         variant: 'error',
         title: 'Failed to update setting',
@@ -803,6 +863,54 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
             />
             <span className="settings-toggle-track" />
           </label>
+        </div>
+      </Card>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">
+              Use a prediction service to help complete searches and URLs
+            </span>
+            <span className="settings-toggle-desc">
+              Sends what you type in the address bar to your default search
+              engine for better suggestions. Not used in Incognito mode.
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={predictionService}
+              disabled={predictionLoading}
+              onChange={(e) => void handlePredictionToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </Card>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-field">
+          <label className="settings-label" htmlFor="preload-pages-select">
+            Preload pages
+          </label>
+          <p className="settings-field-hint">
+            Preloading makes pages load faster by fetching resources ahead of
+            time. Standard preloading pre-fetches only the page you are likely
+            to visit next. Extended preloading fetches more pages in advance,
+            using more data and memory.
+          </p>
+          <select
+            id="preload-pages-select"
+            className="settings-select"
+            value={preloadPages}
+            disabled={preloadLoading}
+            onChange={(e) => void handlePreloadChange(e.target.value)}
+          >
+            <option value="none">No preloading</option>
+            <option value="standard">Standard preloading</option>
+            <option value="extended">Extended preloading</option>
+          </select>
         </div>
       </Card>
 


### PR DESCRIPTION
Closes #66

## Summary
- Adds a toggle for "Use a prediction service to help complete searches and URLs" in the Privacy and security settings tab
- Adds a dropdown for page preload mode with three options: No preloading, Standard, and Extended
- Full IPC pipeline: main process handlers → preload bridge → React UI

## Test plan
- [ ] Open Settings → Privacy and security tab
- [ ] Verify prediction service toggle appears and persists across restarts
- [ ] Verify preload pages dropdown shows three options and persists selection
- [ ] Verify toggling/selecting shows success toast notifications
- [ ] Verify error handling rolls back UI state on failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two privacy settings: a prediction service toggle and a page preloading mode selector (none/standard/extended). Settings persist across restarts with full IPC wiring and clear UI feedback; satisfies #66.

- **New Features**
  - Prediction service toggle in Privacy & security; persists with success/error toasts and rollback on failure.
  - Preload pages dropdown (none/standard/extended); validated in main and falls back to `standard` if unknown; shows success/error toasts.
  - End-to-end IPC: new main handlers, preload bridge, and React UI.

<sup>Written for commit 4afbdb02da250948350d210b8c9bad7a2cd9f7bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

