### PR TITLE
feat(ntp): Customize Chrome side panel

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -77,6 +77,9 @@ import { registerChromeHandlers, unregisterChromeHandlers } from './chrome/ipc';
 import { openPrintPreviewWindow } from './print/PrintPreviewWindow';
 // Issue #98 — Share menu
 import { registerShareHandlers, unregisterShareHandlers } from './share/ipc';
+// Issue #84 — NTP Customization
+import { NtpCustomizationStore } from './ntp/NtpCustomizationStore';
+import { registerNtpHandlers, unregisterNtpHandlers } from './ntp/ipc';
 
 // ---------------------------------------------------------------------------
 // Crash telemetry: catch unhandled errors before anything else
@@ -488,6 +491,25 @@ app.whenReady().then(async () => {
   // Track 5 — Settings IPC handlers
   registerSettingsHandlers({ accountStore, keychainStore });
 
+  // Issue #84 — NTP Customization store + IPC
+  const ntpStore = new NtpCustomizationStore();
+  registerNtpHandlers({
+    store: ntpStore,
+    notifyShell: (data) => {
+      const shellWin = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+      if (shellWin) {
+        shellWin.webContents.send('ntp-customization-updated', data);
+      }
+    },
+    notifyNewTab: (data) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) {
+          win.webContents.send('ntp-customization-updated', data);
+        }
+      }
+    },
+  });
+
   // Issue #71 — Extensions: init manager + register IPC
   extensionManager = new ExtensionManager();
   registerExtensionsHandlers(extensionManager);
@@ -588,6 +610,7 @@ app.whenReady().then(async () => {
     ipcMain.removeHandler('settings:get-zoom-overrides');
     ipcMain.removeHandler('settings:remove-zoom-override');
     ipcMain.removeHandler('settings:clear-all-zoom-overrides');
+    unregisterNtpHandlers();
     unregisterShareHandlers();
     unregisterBookmarkHandlers();
     unregisterHistoryHandlers();

--- a/my-app/src/main/ntp/NtpCustomizationStore.ts
+++ b/my-app/src/main/ntp/NtpCustomizationStore.ts
@@ -1,0 +1,134 @@
+/**
+ * NtpCustomizationStore — persistence layer for New Tab Page customization.
+ * Stores user preferences for background, theme color, shortcuts, and cards
+ * in `userData/ntp-customization.json`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import { mainLogger } from '../logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NtpShortcut {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export interface NtpCustomization {
+  backgroundType: 'default' | 'solid-color' | 'uploaded-image';
+  backgroundColor: string;
+  backgroundImageDataUrl: string;
+
+  accentColor: string;
+  colorScheme: 'light' | 'dark' | 'system';
+
+  shortcutMode: 'most-visited' | 'custom';
+  shortcutsVisible: boolean;
+  customShortcuts: NtpShortcut[];
+
+  cardsVisible: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const FILE_NAME = 'ntp-customization.json';
+
+const DEFAULTS: NtpCustomization = {
+  backgroundType: 'default',
+  backgroundColor: '#202124',
+  backgroundImageDataUrl: '',
+
+  accentColor: '#c8f135',
+  colorScheme: 'system',
+
+  shortcutMode: 'most-visited',
+  shortcutsVisible: true,
+  customShortcuts: [],
+
+  cardsVisible: true,
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export class NtpCustomizationStore {
+  private filePath: string;
+  private cache: NtpCustomization | null = null;
+
+  constructor() {
+    let userDataPath: string;
+    try {
+      userDataPath = app.getPath('userData');
+    } catch {
+      userDataPath = '/tmp/agentic-browser';
+    }
+    this.filePath = path.join(userDataPath, FILE_NAME);
+    mainLogger.info('NtpCustomizationStore.init', { filePath: this.filePath });
+  }
+
+  load(): NtpCustomization {
+    if (this.cache) return this.cache;
+
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<NtpCustomization>;
+      this.cache = { ...DEFAULTS, ...parsed };
+      mainLogger.info('NtpCustomizationStore.load.ok', {
+        backgroundType: this.cache.backgroundType,
+        colorScheme: this.cache.colorScheme,
+        shortcutMode: this.cache.shortcutMode,
+        customShortcutsCount: this.cache.customShortcuts.length,
+      });
+    } catch {
+      mainLogger.info('NtpCustomizationStore.load.defaults', {
+        reason: 'file not found or parse error',
+      });
+      this.cache = { ...DEFAULTS };
+    }
+
+    return this.cache;
+  }
+
+  save(patch: Partial<NtpCustomization>): NtpCustomization {
+    const current = this.load();
+    const merged = { ...current, ...patch };
+    this.cache = merged;
+
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(merged, null, 2), 'utf-8');
+      mainLogger.info('NtpCustomizationStore.save.ok', {
+        keys: Object.keys(patch),
+      });
+    } catch (err) {
+      mainLogger.error('NtpCustomizationStore.save.failed', {
+        error: (err as Error).message,
+      });
+    }
+
+    return merged;
+  }
+
+  reset(): NtpCustomization {
+    this.cache = { ...DEFAULTS };
+    try {
+      if (fs.existsSync(this.filePath)) {
+        fs.unlinkSync(this.filePath);
+      }
+      mainLogger.info('NtpCustomizationStore.reset.ok');
+    } catch (err) {
+      mainLogger.warn('NtpCustomizationStore.reset.failed', {
+        error: (err as Error).message,
+      });
+    }
+    return this.cache;
+  }
+}

--- a/my-app/src/main/ntp/ipc.ts
+++ b/my-app/src/main/ntp/ipc.ts
@@ -1,0 +1,201 @@
+/**
+ * ntp/ipc.ts — IPC handlers for NTP customization.
+ * Mirrors the register/unregister pattern used by settings/ipc.ts.
+ */
+
+import { ipcMain } from 'electron';
+import { mainLogger } from '../logger';
+import { assertString } from '../ipc-validators';
+import type { NtpCustomizationStore, NtpCustomization, NtpShortcut } from './NtpCustomizationStore';
+
+// ---------------------------------------------------------------------------
+// Channel constants
+// ---------------------------------------------------------------------------
+
+const CH_GET          = 'ntp:get-customization';
+const CH_SET          = 'ntp:set-customization';
+const CH_RESET        = 'ntp:reset-customization';
+const CH_ADD_SHORTCUT = 'ntp:add-shortcut';
+const CH_EDIT_SHORTCUT = 'ntp:edit-shortcut';
+const CH_DELETE_SHORTCUT = 'ntp:delete-shortcut';
+const CH_PICK_IMAGE   = 'ntp:pick-background-image';
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let _store: NtpCustomizationStore | null = null;
+let _notifyShell: ((data: NtpCustomization) => void) | null = null;
+let _notifyNewTab: ((data: NtpCustomization) => void) | null = null;
+
+function getStore(): NtpCustomizationStore {
+  if (!_store) throw new Error('NtpCustomizationStore not initialised');
+  return _store;
+}
+
+function broadcastUpdate(data: NtpCustomization): void {
+  if (_notifyShell) _notifyShell(data);
+  if (_notifyNewTab) _notifyNewTab(data);
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleGet(): NtpCustomization {
+  mainLogger.info(CH_GET);
+  return getStore().load();
+}
+
+function handleSet(
+  _event: Electron.IpcMainInvokeEvent,
+  patch: Partial<NtpCustomization>,
+): NtpCustomization {
+  mainLogger.info(CH_SET, { keys: Object.keys(patch) });
+  const result = getStore().save(patch);
+  broadcastUpdate(result);
+  return result;
+}
+
+function handleReset(): NtpCustomization {
+  mainLogger.info(CH_RESET);
+  const result = getStore().reset();
+  broadcastUpdate(result);
+  return result;
+}
+
+function handleAddShortcut(
+  _event: Electron.IpcMainInvokeEvent,
+  shortcut: { name: string; url: string },
+): NtpCustomization {
+  const name = assertString(shortcut?.name ?? '', 'name', 200);
+  const url = assertString(shortcut?.url ?? '', 'url', 2000);
+  mainLogger.info(CH_ADD_SHORTCUT, { name, url });
+
+  const store = getStore();
+  const current = store.load();
+  const id = `sc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const newShortcut: NtpShortcut = { id, name, url };
+  const result = store.save({
+    customShortcuts: [...current.customShortcuts, newShortcut],
+  });
+  broadcastUpdate(result);
+  return result;
+}
+
+function handleEditShortcut(
+  _event: Electron.IpcMainInvokeEvent,
+  payload: { id: string; name: string; url: string },
+): NtpCustomization {
+  const id = assertString(payload?.id ?? '', 'id', 100);
+  const name = assertString(payload?.name ?? '', 'name', 200);
+  const url = assertString(payload?.url ?? '', 'url', 2000);
+  mainLogger.info(CH_EDIT_SHORTCUT, { id, name });
+
+  const store = getStore();
+  const current = store.load();
+  const result = store.save({
+    customShortcuts: current.customShortcuts.map((s) =>
+      s.id === id ? { ...s, name, url } : s,
+    ),
+  });
+  broadcastUpdate(result);
+  return result;
+}
+
+function handleDeleteShortcut(
+  _event: Electron.IpcMainInvokeEvent,
+  id: string,
+): NtpCustomization {
+  const validId = assertString(id, 'id', 100);
+  mainLogger.info(CH_DELETE_SHORTCUT, { id: validId });
+
+  const store = getStore();
+  const current = store.load();
+  const result = store.save({
+    customShortcuts: current.customShortcuts.filter((s) => s.id !== validId),
+  });
+  broadcastUpdate(result);
+  return result;
+}
+
+async function handlePickImage(): Promise<string | null> {
+  mainLogger.info(CH_PICK_IMAGE);
+
+  const { dialog } = await import('electron');
+  const result = await dialog.showOpenDialog({
+    title: 'Choose background image',
+    filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif'] }],
+    properties: ['openFile'],
+  });
+
+  if (result.canceled || result.filePaths.length === 0) {
+    mainLogger.info(`${CH_PICK_IMAGE}.canceled`);
+    return null;
+  }
+
+  const filePath = result.filePaths[0];
+  mainLogger.info(`${CH_PICK_IMAGE}.selected`, { filePath });
+
+  const fs = await import('node:fs');
+  const pathMod = await import('node:path');
+  const ext = pathMod.extname(filePath).toLowerCase().replace('.', '');
+  const mimeMap: Record<string, string> = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    webp: 'image/webp',
+    gif: 'image/gif',
+  };
+  const mime = mimeMap[ext] ?? 'image/png';
+
+  const buffer = fs.readFileSync(filePath);
+  const dataUrl = `data:${mime};base64,${buffer.toString('base64')}`;
+  mainLogger.info(`${CH_PICK_IMAGE}.ok`, { sizeBytes: buffer.length });
+  return dataUrl;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface RegisterNtpHandlersOptions {
+  store: NtpCustomizationStore;
+  notifyShell?: (data: NtpCustomization) => void;
+  notifyNewTab?: (data: NtpCustomization) => void;
+}
+
+export function registerNtpHandlers(opts: RegisterNtpHandlersOptions): void {
+  mainLogger.info('ntp.ipc.register');
+  _store = opts.store;
+  _notifyShell = opts.notifyShell ?? null;
+  _notifyNewTab = opts.notifyNewTab ?? null;
+
+  ipcMain.handle(CH_GET, handleGet);
+  ipcMain.handle(CH_SET, handleSet);
+  ipcMain.handle(CH_RESET, handleReset);
+  ipcMain.handle(CH_ADD_SHORTCUT, handleAddShortcut);
+  ipcMain.handle(CH_EDIT_SHORTCUT, handleEditShortcut);
+  ipcMain.handle(CH_DELETE_SHORTCUT, handleDeleteShortcut);
+  ipcMain.handle(CH_PICK_IMAGE, handlePickImage);
+
+  mainLogger.info('ntp.ipc.register.ok', { channelCount: 7 });
+}
+
+export function unregisterNtpHandlers(): void {
+  mainLogger.info('ntp.ipc.unregister');
+
+  ipcMain.removeHandler(CH_GET);
+  ipcMain.removeHandler(CH_SET);
+  ipcMain.removeHandler(CH_RESET);
+  ipcMain.removeHandler(CH_ADD_SHORTCUT);
+  ipcMain.removeHandler(CH_EDIT_SHORTCUT);
+  ipcMain.removeHandler(CH_DELETE_SHORTCUT);
+  ipcMain.removeHandler(CH_PICK_IMAGE);
+
+  _store = null;
+  _notifyShell = null;
+  _notifyNewTab = null;
+
+  mainLogger.info('ntp.ipc.unregister.ok');
+}

--- a/my-app/src/preload/newtab.ts
+++ b/my-app/src/preload/newtab.ts
@@ -9,4 +9,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     list: (): Promise<unknown> =>
       ipcRenderer.invoke('bookmarks:list'),
   },
+  ntp: {
+    get: (): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:get-customization'),
+    set: (patch: Record<string, unknown>): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:set-customization', patch),
+  },
+  on: {
+    ntpCustomizationUpdated: (
+      cb: (data: unknown) => void,
+    ): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, data: unknown) => cb(data);
+      ipcRenderer.on('ntp-customization-updated', handler);
+      return () => ipcRenderer.removeListener('ntp-customization-updated', handler);
+    },
+  },
 });

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -297,6 +297,31 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('menu:show-app-menu', bounds),
   },
 
+
+  // Issue #84 — NTP Customization
+  ntp: {
+    get: (): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:get-customization'),
+
+    set: (patch: Record<string, unknown>): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:set-customization', patch),
+
+    reset: (): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:reset-customization'),
+
+    addShortcut: (s: { name: string; url: string }): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:add-shortcut', s),
+
+    editShortcut: (s: { id: string; name: string; url: string }): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:edit-shortcut', s),
+
+    deleteShortcut: (id: string): Promise<unknown> =>
+      ipcRenderer.invoke('ntp:delete-shortcut', id),
+
+    pickImage: (): Promise<string | null> =>
+      ipcRenderer.invoke('ntp:pick-background-image'),
+  },
+
   // Event listeners
   on: {
     tabsState: (
@@ -524,6 +549,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
       const handler = (_e: Electron.IpcRendererEvent, downloads: DownloadItemDTO[]) => cb(downloads);
       ipcRenderer.on('downloads-state', handler);
       return () => ipcRenderer.removeListener('downloads-state', handler);
+    },
+
+    ntpCustomizationUpdated: (
+      cb: (data: unknown) => void,
+    ): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, data: unknown) => cb(data);
+      ipcRenderer.on('ntp-customization-updated', handler);
+      return () => ipcRenderer.removeListener('ntp-customization-updated', handler);
     },
   },
 

--- a/my-app/src/renderer/newtab/NewTab.tsx
+++ b/my-app/src/renderer/newtab/NewTab.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { BookmarkNode, PersistedBookmarks } from '../../main/bookmarks/BookmarkStore';
+import type { NtpCustomization, NtpShortcut } from '../../main/ntp/NtpCustomizationStore';
 
 const MAX_TILES = 8;
 
@@ -9,6 +10,13 @@ declare const electronAPI: {
   };
   bookmarks: {
     list: () => Promise<PersistedBookmarks>;
+  };
+  ntp: {
+    get: () => Promise<NtpCustomization>;
+    set: (patch: Partial<NtpCustomization>) => Promise<NtpCustomization>;
+  };
+  on: {
+    ntpCustomizationUpdated: (cb: (data: NtpCustomization) => void) => () => void;
   };
 };
 
@@ -30,6 +38,13 @@ function extractTiles(tree: PersistedBookmarks): Tile[] {
     }));
 }
 
+function shortcutsToTiles(shortcuts: NtpShortcut[]): Tile[] {
+  return shortcuts.slice(0, MAX_TILES).map((s) => ({
+    name: s.name,
+    url: s.url,
+  }));
+}
+
 function faviconUrl(pageUrl: string): string {
   try {
     const host = new URL(pageUrl).hostname;
@@ -47,16 +62,62 @@ function domainLabel(pageUrl: string): string {
   }
 }
 
+function getBackgroundStyle(config: NtpCustomization): React.CSSProperties {
+  if (config.backgroundType === 'uploaded-image' && config.backgroundImageDataUrl) {
+    return {
+      backgroundImage: `url(${config.backgroundImageDataUrl})`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+    };
+  }
+  if (config.backgroundType === 'solid-color' && config.backgroundColor) {
+    return { background: config.backgroundColor };
+  }
+  return {};
+}
+
 export function NewTab(): React.ReactElement {
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [tiles, setTiles] = useState<Tile[]>([]);
+  const [config, setConfig] = useState<NtpCustomization | null>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
-    electronAPI.bookmarks.list().then((tree) => {
-      setTiles(extractTiles(tree));
+
+    console.log('[NewTab] Loading NTP customization and bookmarks');
+
+    electronAPI.ntp.get().then((ntpConfig) => {
+      console.log('[NewTab] NTP config loaded:', ntpConfig.backgroundType, ntpConfig.shortcutMode);
+      setConfig(ntpConfig);
+
+      if (ntpConfig.shortcutMode === 'custom') {
+        setTiles(shortcutsToTiles(ntpConfig.customShortcuts));
+      } else {
+        electronAPI.bookmarks.list().then((tree) => {
+          setTiles(extractTiles(tree));
+        });
+      }
+    }).catch(() => {
+      console.warn('[NewTab] NTP customization not available, falling back to bookmarks');
+      electronAPI.bookmarks.list().then((tree) => {
+        setTiles(extractTiles(tree));
+      });
     });
+
+    const unsub = electronAPI.on.ntpCustomizationUpdated((data) => {
+      console.log('[NewTab] NTP customization updated:', data.backgroundType);
+      setConfig(data);
+      if (data.shortcutMode === 'custom') {
+        setTiles(shortcutsToTiles(data.customShortcuts));
+      } else {
+        electronAPI.bookmarks.list().then((tree) => {
+          setTiles(extractTiles(tree));
+        });
+      }
+    });
+
+    return unsub;
   }, []);
 
   const handleSubmit = useCallback(
@@ -74,8 +135,11 @@ export function NewTab(): React.ReactElement {
     electronAPI.tabs.navigateActive(url);
   }, []);
 
+  const bgStyle = config ? getBackgroundStyle(config) : {};
+  const showShortcuts = config ? config.shortcutsVisible : true;
+
   return (
-    <div className="newtab">
+    <div className="newtab" style={bgStyle}>
       <form className="newtab__search" onSubmit={handleSubmit}>
         <input
           ref={inputRef}
@@ -92,7 +156,7 @@ export function NewTab(): React.ReactElement {
         />
       </form>
 
-      {tiles.length > 0 && (
+      {showShortcuts && tiles.length > 0 && (
         <div className="newtab__tiles">
           {tiles.map((tile) => (
             <button

--- a/my-app/src/renderer/shell/CustomizePanel.tsx
+++ b/my-app/src/renderer/shell/CustomizePanel.tsx
@@ -1,0 +1,540 @@
+/**
+ * CustomizePanel: Chrome-parity "Customize this page" side panel.
+ * Four tabs: Background, Color & Theme, Shortcuts, Cards.
+ * Reads/writes NTP customization via electronAPI.ntp.* IPC channels.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { NtpCustomization, NtpShortcut } from '../../main/ntp/NtpCustomizationStore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+type CustomizeTab = 'background' | 'color' | 'shortcuts' | 'cards';
+
+const TAB_DEFS: Array<{ id: CustomizeTab; label: string }> = [
+  { id: 'background', label: 'Background' },
+  { id: 'color', label: 'Color & theme' },
+  { id: 'shortcuts', label: 'Shortcuts' },
+  { id: 'cards', label: 'Cards' },
+];
+
+const PRESET_BACKGROUNDS: string[] = [
+  '#202124', '#303134', '#3c4043',
+  '#174EA6', '#1A73E8', '#8AB4F8',
+  '#0D652D', '#1E8E3E', '#81C995',
+  '#E8710A', '#F29900', '#FDD663',
+  '#A50E0E', '#D93025', '#F28B82',
+  '#7627BB', '#A142F4', '#D7AEFB',
+];
+
+const ACCENT_PRESETS: string[] = [
+  '#c8f135', '#1A73E8', '#8AB4F8', '#1E8E3E',
+  '#81C995', '#F29900', '#FDD663', '#D93025',
+  '#F28B82', '#A142F4', '#D7AEFB', '#FF6D00',
+  '#EC407A', '#00BCD4', '#78909C', '#FFFFFF',
+];
+
+// ---------------------------------------------------------------------------
+// electronAPI type declaration
+// ---------------------------------------------------------------------------
+
+declare const electronAPI: {
+  ntp: {
+    get: () => Promise<NtpCustomization>;
+    set: (patch: Partial<NtpCustomization>) => Promise<NtpCustomization>;
+    reset: () => Promise<NtpCustomization>;
+    addShortcut: (s: { name: string; url: string }) => Promise<NtpCustomization>;
+    editShortcut: (s: { id: string; name: string; url: string }) => Promise<NtpCustomization>;
+    deleteShortcut: (id: string) => Promise<NtpCustomization>;
+    pickImage: () => Promise<string | null>;
+  };
+  on: {
+    ntpCustomizationUpdated: (cb: (data: NtpCustomization) => void) => () => void;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function CustomizePanel(): React.ReactElement {
+  const [tab, setTab] = useState<CustomizeTab>('background');
+  const [config, setConfig] = useState<NtpCustomization | null>(null);
+
+  useEffect(() => {
+    console.log('[CustomizePanel] Loading NTP customization');
+    electronAPI.ntp.get().then((data) => {
+      console.log('[CustomizePanel] Loaded:', data.backgroundType, data.colorScheme);
+      setConfig(data);
+    });
+    const unsub = electronAPI.on.ntpCustomizationUpdated((data) => {
+      console.log('[CustomizePanel] Updated via IPC:', data.backgroundType);
+      setConfig(data);
+    });
+    return unsub;
+  }, []);
+
+  const update = useCallback((patch: Partial<NtpCustomization>) => {
+    console.log('[CustomizePanel] Saving patch:', Object.keys(patch));
+    electronAPI.ntp.set(patch).then(setConfig);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    console.log('[CustomizePanel] Resetting to defaults');
+    electronAPI.ntp.reset().then(setConfig);
+  }, []);
+
+  if (!config) {
+    return <div className="customize-panel__loading">Loading...</div>;
+  }
+
+  return (
+    <div className="customize-panel">
+      <div className="customize-panel__tabs">
+        {TAB_DEFS.map((t) => (
+          <button
+            key={t.id}
+            className={`customize-panel__tab ${tab === t.id ? 'customize-panel__tab--active' : ''}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="customize-panel__body">
+        {tab === 'background' && <BackgroundTab config={config} onUpdate={update} />}
+        {tab === 'color' && <ColorTab config={config} onUpdate={update} />}
+        {tab === 'shortcuts' && <ShortcutsTab config={config} onUpdate={update} />}
+        {tab === 'cards' && <CardsTab config={config} onUpdate={update} />}
+      </div>
+
+      <div className="customize-panel__footer">
+        <button className="customize-panel__reset-btn" onClick={handleReset}>
+          Reset to default
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Background Tab
+// ---------------------------------------------------------------------------
+
+function BackgroundTab({
+  config,
+  onUpdate,
+}: {
+  config: NtpCustomization;
+  onUpdate: (patch: Partial<NtpCustomization>) => void;
+}): React.ReactElement {
+  const handleSolidColor = useCallback(
+    (color: string) => {
+      onUpdate({ backgroundType: 'solid-color', backgroundColor: color });
+    },
+    [onUpdate],
+  );
+
+  const handleDefault = useCallback(() => {
+    onUpdate({ backgroundType: 'default', backgroundImageDataUrl: '' });
+  }, [onUpdate]);
+
+  const handleUpload = useCallback(() => {
+    electronAPI.ntp.pickImage().then((dataUrl) => {
+      if (dataUrl) {
+        onUpdate({ backgroundType: 'uploaded-image', backgroundImageDataUrl: dataUrl });
+      }
+    });
+  }, [onUpdate]);
+
+  return (
+    <div className="customize-panel__section">
+      <div className="customize-panel__section-label">Background</div>
+
+      <button
+        className={`customize-panel__option-btn ${config.backgroundType === 'default' ? 'customize-panel__option-btn--active' : ''}`}
+        onClick={handleDefault}
+      >
+        <span className="customize-panel__option-swatch customize-panel__option-swatch--default" />
+        <span>Default</span>
+      </button>
+
+      <button className="customize-panel__option-btn" onClick={handleUpload}>
+        <span className="customize-panel__option-swatch customize-panel__option-swatch--upload">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M8 2v8M4 6l4-4 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M2 12h12" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </span>
+        <span>Upload image</span>
+      </button>
+
+      {config.backgroundType === 'uploaded-image' && config.backgroundImageDataUrl && (
+        <div className="customize-panel__preview">
+          <img
+            className="customize-panel__preview-img"
+            src={config.backgroundImageDataUrl}
+            alt="Background preview"
+          />
+        </div>
+      )}
+
+      <div className="customize-panel__section-label" style={{ marginTop: '12px' }}>
+        Solid colors
+      </div>
+      <div className="customize-panel__color-grid">
+        {PRESET_BACKGROUNDS.map((color) => (
+          <button
+            key={color}
+            className={`customize-panel__color-swatch ${
+              config.backgroundType === 'solid-color' && config.backgroundColor === color
+                ? 'customize-panel__color-swatch--active'
+                : ''
+            }`}
+            style={{ backgroundColor: color }}
+            onClick={() => handleSolidColor(color)}
+            title={color}
+          />
+        ))}
+      </div>
+
+      <div className="customize-panel__custom-color-row">
+        <label className="customize-panel__label">Custom color</label>
+        <input
+          type="color"
+          className="customize-panel__color-input"
+          value={config.backgroundColor}
+          onChange={(e) => handleSolidColor(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Color & Theme Tab
+// ---------------------------------------------------------------------------
+
+type ColorScheme = 'light' | 'dark' | 'system';
+
+const SCHEME_OPTIONS: Array<{ id: ColorScheme; label: string }> = [
+  { id: 'light', label: 'Light' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'system', label: 'Device' },
+];
+
+function ColorTab({
+  config,
+  onUpdate,
+}: {
+  config: NtpCustomization;
+  onUpdate: (patch: Partial<NtpCustomization>) => void;
+}): React.ReactElement {
+  return (
+    <div className="customize-panel__section">
+      <div className="customize-panel__section-label">Accent color</div>
+      <div className="customize-panel__color-grid">
+        {ACCENT_PRESETS.map((color) => (
+          <button
+            key={color}
+            className={`customize-panel__color-swatch ${
+              config.accentColor === color ? 'customize-panel__color-swatch--active' : ''
+            }`}
+            style={{ backgroundColor: color }}
+            onClick={() => onUpdate({ accentColor: color })}
+            title={color}
+          />
+        ))}
+      </div>
+
+      <div className="customize-panel__custom-color-row">
+        <label className="customize-panel__label">Custom accent</label>
+        <input
+          type="color"
+          className="customize-panel__color-input"
+          value={config.accentColor}
+          onChange={(e) => onUpdate({ accentColor: e.target.value })}
+        />
+      </div>
+
+      <div className="customize-panel__section-label" style={{ marginTop: '16px' }}>
+        Color scheme
+      </div>
+      <div className="customize-panel__scheme-group">
+        {SCHEME_OPTIONS.map((opt) => (
+          <button
+            key={opt.id}
+            className={`customize-panel__scheme-btn ${
+              config.colorScheme === opt.id ? 'customize-panel__scheme-btn--active' : ''
+            }`}
+            onClick={() => onUpdate({ colorScheme: opt.id })}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shortcuts Tab
+// ---------------------------------------------------------------------------
+
+function ShortcutsTab({
+  config,
+  onUpdate,
+}: {
+  config: NtpCustomization;
+  onUpdate: (patch: Partial<NtpCustomization>) => void;
+}): React.ReactElement {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editUrl, setEditUrl] = useState('');
+  const [addingNew, setAddingNew] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  const handleToggleVisibility = useCallback(() => {
+    onUpdate({ shortcutsVisible: !config.shortcutsVisible });
+  }, [config.shortcutsVisible, onUpdate]);
+
+  const handleModeChange = useCallback(
+    (mode: 'most-visited' | 'custom') => {
+      onUpdate({ shortcutMode: mode });
+    },
+    [onUpdate],
+  );
+
+  const handleStartAdd = useCallback(() => {
+    setAddingNew(true);
+    setEditName('');
+    setEditUrl('');
+    setTimeout(() => nameRef.current?.focus(), 50);
+  }, []);
+
+  const handleSaveNew = useCallback(() => {
+    if (!editName.trim() || !editUrl.trim()) return;
+    electronAPI.ntp.addShortcut({ name: editName.trim(), url: editUrl.trim() });
+    setAddingNew(false);
+    setEditName('');
+    setEditUrl('');
+  }, [editName, editUrl]);
+
+  const handleStartEdit = useCallback((s: NtpShortcut) => {
+    setEditingId(s.id);
+    setEditName(s.name);
+    setEditUrl(s.url);
+    setTimeout(() => nameRef.current?.focus(), 50);
+  }, []);
+
+  const handleSaveEdit = useCallback(() => {
+    if (!editingId || !editName.trim() || !editUrl.trim()) return;
+    electronAPI.ntp.editShortcut({ id: editingId, name: editName.trim(), url: editUrl.trim() });
+    setEditingId(null);
+  }, [editingId, editName, editUrl]);
+
+  const handleDelete = useCallback((id: string) => {
+    electronAPI.ntp.deleteShortcut(id);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setEditingId(null);
+    setAddingNew(false);
+    setEditName('');
+    setEditUrl('');
+  }, []);
+
+  return (
+    <div className="customize-panel__section">
+      <div className="customize-panel__toggle-row">
+        <span className="customize-panel__label">Show shortcuts</span>
+        <button
+          className={`customize-panel__toggle ${config.shortcutsVisible ? 'customize-panel__toggle--on' : ''}`}
+          onClick={handleToggleVisibility}
+          role="switch"
+          aria-checked={config.shortcutsVisible}
+        >
+          <span className="customize-panel__toggle-thumb" />
+        </button>
+      </div>
+
+      {config.shortcutsVisible && (
+        <>
+          <div className="customize-panel__section-label">Shortcut source</div>
+          <div className="customize-panel__radio-group">
+            <label className="customize-panel__radio">
+              <input
+                type="radio"
+                name="shortcutMode"
+                checked={config.shortcutMode === 'most-visited'}
+                onChange={() => handleModeChange('most-visited')}
+              />
+              <span>Most visited sites</span>
+            </label>
+            <label className="customize-panel__radio">
+              <input
+                type="radio"
+                name="shortcutMode"
+                checked={config.shortcutMode === 'custom'}
+                onChange={() => handleModeChange('custom')}
+              />
+              <span>My shortcuts</span>
+            </label>
+          </div>
+
+          {config.shortcutMode === 'custom' && (
+            <div className="customize-panel__shortcuts-list">
+              {config.customShortcuts.map((s) =>
+                editingId === s.id ? (
+                  <ShortcutForm
+                    key={s.id}
+                    nameRef={nameRef}
+                    editName={editName}
+                    editUrl={editUrl}
+                    onNameChange={setEditName}
+                    onUrlChange={setEditUrl}
+                    onSave={handleSaveEdit}
+                    onCancel={handleCancel}
+                  />
+                ) : (
+                  <div key={s.id} className="customize-panel__shortcut-row">
+                    <div className="customize-panel__shortcut-info">
+                      <span className="customize-panel__shortcut-name">{s.name}</span>
+                      <span className="customize-panel__shortcut-url">{s.url}</span>
+                    </div>
+                    <div className="customize-panel__shortcut-actions">
+                      <button
+                        className="customize-panel__icon-btn"
+                        onClick={() => handleStartEdit(s)}
+                        title="Edit"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                          <path d="M8.5 1.5l2 2-7 7H1.5v-2l7-7z" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round" />
+                        </svg>
+                      </button>
+                      <button
+                        className="customize-panel__icon-btn"
+                        onClick={() => handleDelete(s.id)}
+                        title="Delete"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                          <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ),
+              )}
+
+              {addingNew ? (
+                <ShortcutForm
+                  nameRef={nameRef}
+                  editName={editName}
+                  editUrl={editUrl}
+                  onNameChange={setEditName}
+                  onUrlChange={setEditUrl}
+                  onSave={handleSaveNew}
+                  onCancel={handleCancel}
+                />
+              ) : (
+                <button className="customize-panel__add-btn" onClick={handleStartAdd}>
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M6 2v8M2 6h8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                  </svg>
+                  Add shortcut
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ShortcutForm({
+  nameRef,
+  editName,
+  editUrl,
+  onNameChange,
+  onUrlChange,
+  onSave,
+  onCancel,
+}: {
+  nameRef: React.RefObject<HTMLInputElement | null>;
+  editName: string;
+  editUrl: string;
+  onNameChange: (v: string) => void;
+  onUrlChange: (v: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}): React.ReactElement {
+  return (
+    <div className="customize-panel__shortcut-form">
+      <input
+        ref={nameRef}
+        className="customize-panel__shortcut-input"
+        placeholder="Name"
+        value={editName}
+        onChange={(e) => onNameChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onSave();
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <input
+        className="customize-panel__shortcut-input"
+        placeholder="URL"
+        value={editUrl}
+        onChange={(e) => onUrlChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onSave();
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <div className="customize-panel__shortcut-form-actions">
+        <button className="customize-panel__text-btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="customize-panel__text-btn customize-panel__text-btn--primary" onClick={onSave}>
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cards Tab
+// ---------------------------------------------------------------------------
+
+function CardsTab({
+  config,
+  onUpdate,
+}: {
+  config: NtpCustomization;
+  onUpdate: (patch: Partial<NtpCustomization>) => void;
+}): React.ReactElement {
+  return (
+    <div className="customize-panel__section">
+      <div className="customize-panel__section-label">NTP Cards</div>
+      <p className="customize-panel__hint">
+        Cards appear on your New Tab page below the search bar and shortcuts.
+      </p>
+      <div className="customize-panel__toggle-row">
+        <span className="customize-panel__label">Show cards</span>
+        <button
+          className={`customize-panel__toggle ${config.cardsVisible ? 'customize-panel__toggle--on' : ''}`}
+          onClick={() => onUpdate({ cardsVisible: !config.cardsVisible })}
+          role="switch"
+          aria-checked={config.cardsVisible}
+        >
+          <span className="customize-panel__toggle-thumb" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/shell/SidePanel.tsx
+++ b/my-app/src/renderer/shell/SidePanel.tsx
@@ -1,18 +1,19 @@
 /**
  * SidePanel: toggleable side panel hosting built-in panels (Bookmarks, History,
- * Reading List). Positioned absolutely in the shell window, occupying the right
- * (or left) side below the chrome. The main process shrinks the WebContentsView
- * to reveal this panel behind it.
+ * Reading List, Customize). Positioned absolutely in the shell window, occupying
+ * the right (or left) side below the chrome. The main process shrinks the
+ * WebContentsView to reveal this panel behind it.
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { BookmarkNode, PersistedBookmarks } from '../../main/bookmarks/BookmarkStore';
+import { CustomizePanel } from './CustomizePanel';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-export type SidePanelId = 'bookmarks' | 'history' | 'reading-list';
+export type SidePanelId = 'bookmarks' | 'history' | 'reading-list' | 'customize';
 export type SidePanelPosition = 'left' | 'right';
 
 const MIN_PANEL_WIDTH = 280;
@@ -46,6 +47,16 @@ const PANEL_DEFS: Array<{ id: SidePanelId; label: string; icon: React.ReactNode 
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <rect x="3" y="2.5" width="10" height="11" rx="1" stroke="currentColor" strokeWidth="1.3" />
         <path d="M5.5 5.5h5M5.5 8h5M5.5 10.5h3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    id: 'customize',
+    label: 'Customize',
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M8 1.5a1 1 0 011 1v1.126a4.5 4.5 0 011.95 1.124l.975-.563a1 1 0 011.366.366l.5.866a1 1 0 01-.366 1.366l-.975.563A4.5 4.5 0 0113 8.5c0 .362-.043.715-.124 1.052l.975.563a1 1 0 01.366 1.366l-.5.866a1 1 0 01-1.366.366l-.975-.563a4.5 4.5 0 01-1.95 1.124V14.5a1 1 0 01-1 1H7a1 1 0 01-1-1v-1.126a4.5 4.5 0 01-1.95-1.124l-.975.563a1 1 0 01-1.366-.366l-.5-.866a1 1 0 01.366-1.366l.975-.563A4.5 4.5 0 013 8.5c0-.362.043-.715.124-1.052l-.975-.563a1 1 0 01-.366-1.366l.5-.866a1 1 0 011.366-.366l.975.563A4.5 4.5 0 016 3.626V2.5a1 1 0 011-1h1z" stroke="currentColor" strokeWidth="1.2" />
+        <circle cx="7.5" cy="8.5" r="2" stroke="currentColor" strokeWidth="1.2" />
       </svg>
     ),
   },
@@ -383,6 +394,7 @@ export function SidePanel({
         {activePanel === 'bookmarks' && <BookmarksPanel onNavigate={handleNavigate} />}
         {activePanel === 'history' && <HistoryPanel onNavigate={handleNavigate} />}
         {activePanel === 'reading-list' && <ReadingListPanel />}
+        {activePanel === 'customize' && <CustomizePanel />}
       </div>
     </div>
   );

--- a/my-app/src/renderer/shell/customize-panel.css
+++ b/my-app/src/renderer/shell/customize-panel.css
@@ -1,0 +1,535 @@
+/*
+ * Customize panel styles — Chrome-parity NTP customization side panel.
+ * All colors via CSS custom properties from theme.global.css.
+ */
+
+/* ---------------------------------------------------------------------------
+   Loading / container
+   --------------------------------------------------------------------------- */
+.customize-panel__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  color: var(--color-fg-secondary);
+  font-size: 13px;
+}
+
+.customize-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ---------------------------------------------------------------------------
+   Tab bar
+   --------------------------------------------------------------------------- */
+.customize-panel__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 0 4px;
+  flex-shrink: 0;
+  overflow-x: auto;
+  gap: 0;
+}
+
+.customize-panel__tab {
+  flex: 1;
+  padding: 8px 4px;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-tertiary);
+  font-size: 11px;
+  font-family: var(--font-ui);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out);
+  white-space: nowrap;
+  text-align: center;
+}
+
+.customize-panel__tab:hover {
+  color: var(--color-fg-secondary);
+}
+
+.customize-panel__tab--active {
+  color: var(--color-accent-default);
+  border-bottom-color: var(--color-accent-default);
+}
+
+/* ---------------------------------------------------------------------------
+   Body + Section
+   --------------------------------------------------------------------------- */
+.customize-panel__body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.customize-panel__section {
+  padding: 12px;
+}
+
+.customize-panel__section-label {
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-fg-tertiary);
+  margin-bottom: 8px;
+}
+
+.customize-panel__label {
+  font-size: 12px;
+  color: var(--color-fg-primary);
+}
+
+.customize-panel__hint {
+  font-size: 12px;
+  color: var(--color-fg-tertiary);
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+
+/* ---------------------------------------------------------------------------
+   Color grid (backgrounds + accents)
+   --------------------------------------------------------------------------- */
+.customize-panel__color-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.customize-panel__color-swatch {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-out);
+  padding: 0;
+}
+
+.customize-panel__color-swatch:hover {
+  border-color: var(--color-fg-tertiary);
+}
+
+.customize-panel__color-swatch--active {
+  border-color: var(--color-accent-default);
+  box-shadow: 0 0 0 1px var(--color-accent-default);
+}
+
+/* ---------------------------------------------------------------------------
+   Option buttons (default, upload)
+   --------------------------------------------------------------------------- */
+.customize-panel__option-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-fg-primary);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  margin-bottom: 6px;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__option-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.customize-panel__option-btn--active {
+  border-color: var(--color-accent-default);
+  background: rgba(200, 241, 53, 0.06);
+}
+
+.customize-panel__option-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.customize-panel__option-swatch--default {
+  background: linear-gradient(135deg, var(--slate-2), var(--slate-4));
+  border: 1px solid var(--color-border-subtle);
+}
+
+.customize-panel__option-swatch--upload {
+  background: var(--color-bg-overlay);
+  color: var(--color-fg-secondary);
+}
+
+/* ---------------------------------------------------------------------------
+   Custom color row (label + native input)
+   --------------------------------------------------------------------------- */
+.customize-panel__custom-color-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+}
+
+.customize-panel__color-input {
+  width: 32px;
+  height: 24px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+}
+
+.customize-panel__color-input::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.customize-panel__color-input::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+   Preview (uploaded image)
+   --------------------------------------------------------------------------- */
+.customize-panel__preview {
+  margin: 8px 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.customize-panel__preview-img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  display: block;
+}
+
+/* ---------------------------------------------------------------------------
+   Scheme buttons (light / dark / device)
+   --------------------------------------------------------------------------- */
+.customize-panel__scheme-group {
+  display: flex;
+  gap: 4px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.customize-panel__scheme-btn {
+  flex: 1;
+  padding: 7px 0;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__scheme-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.customize-panel__scheme-btn--active {
+  background: var(--color-accent-dim);
+  color: var(--color-accent-default);
+  font-weight: var(--font-weight-medium);
+}
+
+/* ---------------------------------------------------------------------------
+   Toggle switch
+   --------------------------------------------------------------------------- */
+.customize-panel__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+.customize-panel__toggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border: none;
+  border-radius: 10px;
+  background: var(--color-border-default);
+  cursor: pointer;
+  padding: 0;
+  transition: background var(--duration-fast) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.customize-panel__toggle--on {
+  background: var(--color-accent-default);
+}
+
+.customize-panel__toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-fg-primary);
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__toggle--on .customize-panel__toggle-thumb {
+  transform: translateX(16px);
+  background: var(--slate-1);
+}
+
+/* ---------------------------------------------------------------------------
+   Radio group
+   --------------------------------------------------------------------------- */
+.customize-panel__radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.customize-panel__radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--color-fg-primary);
+  cursor: pointer;
+}
+
+.customize-panel__radio input[type='radio'] {
+  accent-color: var(--color-accent-default);
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Shortcuts list
+   --------------------------------------------------------------------------- */
+.customize-panel__shortcuts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.customize-panel__shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__shortcut-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.customize-panel__shortcut-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.customize-panel__shortcut-name {
+  font-size: 12px;
+  color: var(--color-fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.customize-panel__shortcut-url {
+  font-size: 10px;
+  color: var(--color-fg-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.customize-panel__shortcut-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.customize-panel__icon-btn {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__icon-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-fg-primary);
+}
+
+/* ---------------------------------------------------------------------------
+   Shortcut form (add / edit)
+   --------------------------------------------------------------------------- */
+.customize-panel__shortcut-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  background: var(--color-bg-overlay);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.customize-panel__shortcut-input {
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-primary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__shortcut-input:focus {
+  border-color: var(--color-accent-default);
+}
+
+.customize-panel__shortcut-input::placeholder {
+  color: var(--color-fg-tertiary);
+}
+
+.customize-panel__shortcut-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* ---------------------------------------------------------------------------
+   Text buttons
+   --------------------------------------------------------------------------- */
+.customize-panel__text-btn {
+  padding: 4px 10px;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: 11px;
+  font-family: var(--font-ui);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__text-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.customize-panel__text-btn--primary {
+  color: var(--color-accent-default);
+  font-weight: var(--font-weight-medium);
+}
+
+/* ---------------------------------------------------------------------------
+   Add shortcut button
+   --------------------------------------------------------------------------- */
+.customize-panel__add-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__add-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--color-fg-tertiary);
+}
+
+/* ---------------------------------------------------------------------------
+   Footer (reset button)
+   --------------------------------------------------------------------------- */
+.customize-panel__footer {
+  padding: 8px 12px;
+  border-top: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.customize-panel__reset-btn {
+  width: 100%;
+  padding: 7px 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.customize-panel__reset-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-fg-primary);
+}
+
+/* ---------------------------------------------------------------------------
+   Reduced motion
+   --------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .customize-panel__tab,
+  .customize-panel__color-swatch,
+  .customize-panel__option-btn,
+  .customize-panel__scheme-btn,
+  .customize-panel__toggle,
+  .customize-panel__toggle-thumb,
+  .customize-panel__icon-btn,
+  .customize-panel__shortcut-input,
+  .customize-panel__text-btn,
+  .customize-panel__add-btn,
+  .customize-panel__reset-btn,
+  .customize-panel__shortcut-row {
+    transition: none;
+  }
+}

--- a/my-app/src/renderer/shell/index.tsx
+++ b/my-app/src/renderer/shell/index.tsx
@@ -20,7 +20,7 @@ import './components.css';
 import './downloads.css';
 import './sidepanel.css';
 import './share.css';
-import './signOut.css';
+import './customize-panel.css';
 
 window.addEventListener('error', (e) => {
   console.error('renderer.error', { message: e.message, file: e.filename, line: e.lineno });


### PR DESCRIPTION
Closes #84

## Summary
- Add **Customize** panel to the side panel system with four tabs: Background, Color & theme, Shortcuts, and Cards
- **Background tab**: solid color presets (18 colors), custom color picker, image upload via native file dialog
- **Color & theme tab**: accent color presets (16 colors), custom picker, light/dark/system scheme toggle
- **Shortcuts tab**: toggle visibility, switch between most-visited and custom shortcuts, add/edit/delete custom shortcuts
- **Cards tab**: show/hide NTP cards toggle
- `NtpCustomizationStore` persists settings to `userData/ntp-customization.json`
- IPC handlers with real-time broadcast to both shell and newtab renderers
- NTP page consumes customization: background style, shortcut source, and visibility

## Test plan
- [ ] Open side panel, switch to "Customize" via the panel picker dropdown
- [ ] Background tab: select solid colors, use custom picker, upload an image
- [ ] Color & theme tab: change accent color, switch between light/dark/device
- [ ] Shortcuts tab: toggle visibility, switch to custom mode, add/edit/delete shortcuts
- [ ] Cards tab: toggle cards visibility
- [ ] Verify NTP page updates in real-time when settings change
- [ ] Click "Reset to default" and verify all settings revert
- [ ] Restart app and verify settings persist

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chrome-like “Customize” side panel for the New Tab Page with controls for background, theme, shortcuts, and cards. Settings persist to disk and sync live to the NTP. Closes #84.

- **New Features**
  - Added “Customize” side panel with four tabs: Background, Color & theme, Shortcuts, Cards.
  - Background + theme: solid color presets, custom color pickers, image upload with preview, accent color presets, and light/dark/system scheme.
  - Shortcuts + cards: toggle shortcut visibility, switch most-visited vs custom, add/edit/delete custom shortcuts, and toggle NTP cards.
  - Persistence: `NtpCustomizationStore` saves to `userData/ntp-customization.json` and supports “Reset to default”.
  - Real-time sync: IPC handlers broadcast updates; preload bridges for shell/newtab; NTP applies background and shortcut mode/visibility instantly and on startup.

<sup>Written for commit 44e487e91dd07be5060f009e70675a00582be0a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

