### PR TITLE
feat(privacy): add Do Not Track and Global Privacy Control header toggles

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -12,7 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app, ipcMain } from 'electron';
+import { app, ipcMain, session } from 'electron';
 import { mainLogger } from '../logger';
 import type { AccountStore } from '../identity/AccountStore';
 import type { KeychainStore } from '../identity/KeychainStore';
@@ -25,12 +25,6 @@ import {
   type ClearDataResult,
 } from '../privacy/ClearDataController';
 import { isBiometricAvailable } from '../passwords/BiometricAuth';
-import {
-  performSignOut,
-  turnOffSync,
-  type SignOutMode,
-  type SignOutResult,
-} from '../identity/SignOutController';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -95,9 +89,10 @@ const CH_SET_BIOMETRIC_LOCK  = 'settings:set-biometric-lock';
 const CH_BIOMETRIC_AVAILABLE = 'settings:biometric-available';
 const CH_GET_HTTPS_FIRST     = 'settings:get-https-first';
 const CH_SET_HTTPS_FIRST     = 'settings:set-https-first';
-const CH_SIGN_OUT            = 'identity:sign-out';
-const CH_TURN_OFF_SYNC       = 'identity:turn-off-sync';
-const CH_GET_ACCOUNT_INFO    = 'identity:get-account-info';
+const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
+const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
+const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
+const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -599,69 +594,81 @@ function handleSetHttpsFirst(_event: Electron.IpcMainInvokeEvent, enabled: boole
 }
 
 
-async function handleSignOut(
-  _event: Electron.IpcMainInvokeEvent,
-  mode: string,
-): Promise<SignOutResult> {
-  mainLogger.info(CH_SIGN_OUT, { mode });
-
-  if (mode !== 'clear' && mode !== 'keep') {
-    throw new Error('mode must be "clear" or "keep"');
-  }
-
-  if (!_accountStore || !_keychainStore) {
-    mainLogger.error(`${CH_SIGN_OUT}.notInitialised`);
-    throw new Error('AccountStore or KeychainStore not initialised');
-  }
-
-  const result = await performSignOut(mode as SignOutMode, _accountStore, _keychainStore);
-
-  mainLogger.info(`${CH_SIGN_OUT}.complete`, {
-    mode,
-    success: result.success,
-    tokenRevoked: result.tokenRevoked,
-    dataCleared: result.dataCleared,
-  });
-
-  if (result.success && process.env.NODE_ENV !== 'test') {
-    app.relaunch();
-    app.quit();
-  }
-
-  return result;
+function handleGetDntEnabled(): boolean {
+  mainLogger.info(CH_GET_DNT_ENABLED);
+  const prefs = readPrefs();
+  const enabled = prefs.dntEnabled === true;
+  mainLogger.info(`${CH_GET_DNT_ENABLED}.ok`, { enabled });
+  return enabled;
 }
 
-async function handleTurnOffSync(): Promise<{ success: boolean }> {
-  mainLogger.info(CH_TURN_OFF_SYNC);
-
-  if (!_accountStore) {
-    mainLogger.error(`${CH_TURN_OFF_SYNC}.notInitialised`);
-    throw new Error('AccountStore not initialised');
+function handleSetDntEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('dntEnabled must be a boolean');
   }
-
-  const result = await turnOffSync(_accountStore);
-  mainLogger.info(`${CH_TURN_OFF_SYNC}.complete`, { success: result.success });
-  return result;
+  mainLogger.info(CH_SET_DNT_ENABLED, { enabled });
+  mergePrefs({ dntEnabled: enabled });
+  refreshPrivacyHeaders();
+  mainLogger.info(`${CH_SET_DNT_ENABLED}.ok`, { enabled });
 }
 
-function handleGetAccountInfo(): { email: string; agentName: string } | null {
-  mainLogger.info(CH_GET_ACCOUNT_INFO);
+function handleGetGpcEnabled(): boolean {
+  mainLogger.info(CH_GET_GPC_ENABLED);
+  const prefs = readPrefs();
+  const enabled = prefs.gpcEnabled === true;
+  mainLogger.info(`${CH_GET_GPC_ENABLED}.ok`, { enabled });
+  return enabled;
+}
 
-  const account = _accountStore?.load();
-  if (!account) {
-    mainLogger.info(`${CH_GET_ACCOUNT_INFO}.noAccount`);
-    return null;
+function handleSetGpcEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('gpcEnabled must be a boolean');
+  }
+  mainLogger.info(CH_SET_GPC_ENABLED, { enabled });
+  mergePrefs({ gpcEnabled: enabled });
+  refreshPrivacyHeaders();
+  mainLogger.info(`${CH_SET_GPC_ENABLED}.ok`, { enabled });
+}
+
+// ---------------------------------------------------------------------------
+// Privacy header injection (DNT + GPC)
+// ---------------------------------------------------------------------------
+
+let _privacyHeadersInstalled = false;
+
+/**
+ * Installs (or re-reads prefs for) the onBeforeSendHeaders hook that appends
+ * DNT: 1 and/or Sec-GPC: 1 to every outgoing request on the default session.
+ * Safe to call multiple times — the webRequest listener is registered once.
+ */
+export function refreshPrivacyHeaders(): void {
+  const prefs = readPrefs();
+  const dnt = prefs.dntEnabled === true;
+  const gpc = prefs.gpcEnabled === true;
+  mainLogger.info('privacy.refreshHeaders', { dnt, gpc });
+
+  if (_privacyHeadersInstalled) {
+    // Listener already registered; it reads prefs each invocation so nothing to do.
+    return;
   }
 
-  mainLogger.info(`${CH_GET_ACCOUNT_INFO}.ok`, {
-    hasEmail: !!account.email,
-    hasAgentName: !!account.agent_name,
+  _privacyHeadersInstalled = true;
+
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    const currentPrefs = readPrefs();
+    const headers = { ...details.requestHeaders };
+
+    if (currentPrefs.dntEnabled === true) {
+      headers['DNT'] = '1';
+    }
+    if (currentPrefs.gpcEnabled === true) {
+      headers['Sec-GPC'] = '1';
+    }
+
+    callback({ requestHeaders: headers });
   });
 
-  return {
-    email: account.email,
-    agentName: account.agent_name,
-  };
+  mainLogger.info('privacy.refreshHeaders.installed');
 }
 
 function handleCloseWindow(): void {
@@ -708,11 +715,14 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_BIOMETRIC_AVAILABLE, handleBiometricAvailable);
   ipcMain.handle(CH_GET_HTTPS_FIRST,    handleGetHttpsFirst);
   ipcMain.handle(CH_SET_HTTPS_FIRST,    handleSetHttpsFirst);
-  ipcMain.handle(CH_SIGN_OUT,           handleSignOut);
-  ipcMain.handle(CH_TURN_OFF_SYNC,      handleTurnOffSync);
-  ipcMain.handle(CH_GET_ACCOUNT_INFO,   handleGetAccountInfo);
+  ipcMain.handle(CH_GET_DNT_ENABLED,    handleGetDntEnabled);
+  ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
+  ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
+  ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 21 });
+  refreshPrivacyHeaders();
+
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -739,9 +749,10 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_BIOMETRIC_AVAILABLE);
   ipcMain.removeHandler(CH_GET_HTTPS_FIRST);
   ipcMain.removeHandler(CH_SET_HTTPS_FIRST);
-  ipcMain.removeHandler(CH_SIGN_OUT);
-  ipcMain.removeHandler(CH_TURN_OFF_SYNC);
-  ipcMain.removeHandler(CH_GET_ACCOUNT_INFO);
+  ipcMain.removeHandler(CH_GET_DNT_ENABLED);
+  ipcMain.removeHandler(CH_SET_DNT_ENABLED);
+  ipcMain.removeHandler(CH_GET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_SET_GPC_ENABLED);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -147,14 +147,20 @@ export interface SettingsAPI {
   /** Get whether HTTPS-First mode is enabled */
   getHttpsFirst: () => Promise<boolean>;
 
-  /** Get Safe Browsing protection level */
-  getSafeBrowsing: () => Promise<string>;
-
-  /** Set Safe Browsing protection level */
-  setSafeBrowsing: (level: string) => Promise<void>;
-
   /** Set whether HTTPS-First mode is enabled */
   setHttpsFirst: (enabled: boolean) => Promise<void>;
+
+  /** Get whether Do Not Track header is enabled */
+  getDntEnabled: () => Promise<boolean>;
+
+  /** Set whether Do Not Track header is enabled */
+  setDntEnabled: (enabled: boolean) => Promise<void>;
+
+  /** Get whether Global Privacy Control header is enabled */
+  getGpcEnabled: () => Promise<boolean>;
+
+  /** Set whether Global Privacy Control header is enabled */
+  setGpcEnabled: (enabled: boolean) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -347,14 +353,24 @@ const api: SettingsAPI = {
     await ipcRenderer.invoke('settings:set-https-first', enabled);
   },
 
-  getSafeBrowsing: async (): Promise<string> => {
-    console.debug('[settings-preload] getSafeBrowsing');
-    return ipcRenderer.invoke('settings:get-safe-browsing') as Promise<string>;
+  getDntEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getDntEnabled');
+    return ipcRenderer.invoke('settings:get-dnt-enabled') as Promise<boolean>;
   },
 
-  setSafeBrowsing: async (level: string): Promise<void> => {
-    console.debug('[settings-preload] setSafeBrowsing', { level });
-    await ipcRenderer.invoke('settings:set-safe-browsing', level);
+  setDntEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setDntEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-dnt-enabled', enabled);
+  },
+
+  getGpcEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getGpcEnabled');
+    return ipcRenderer.invoke('settings:get-gpc-enabled') as Promise<boolean>;
+  },
+
+  setGpcEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setGpcEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
   },
 };
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -150,8 +150,10 @@ declare global {
       setBiometricLock: (enabled: boolean) => Promise<void>;
       getHttpsFirst: () => Promise<boolean>;
       setHttpsFirst: (enabled: boolean) => Promise<void>;
-      getSafeBrowsing: () => Promise<string>;
-      setSafeBrowsing: (level: string) => Promise<void>;
+      getDntEnabled: () => Promise<boolean>;
+      setDntEnabled: (enabled: boolean) => Promise<void>;
+      getGpcEnabled: () => Promise<boolean>;
+      setGpcEnabled: (enabled: boolean) => Promise<void>;
     };
   }
 }
@@ -750,8 +752,9 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
   const toast = useToast();
   const [httpsFirst, setHttpsFirst] = useState(false);
   const [httpsFirstLoading, setHttpsFirstLoading] = useState(true);
-  const [safeBrowsing, setSafeBrowsing] = useState<string>('standard');
-  const [safeBrowsingLoading, setSafeBrowsingLoading] = useState(true);
+  const [dntEnabled, setDntEnabled] = useState(false);
+  const [gpcEnabled, setGpcEnabled] = useState(false);
+  const [privacyLoading, setPrivacyLoading] = useState(true);
 
   useEffect(() => {
     void window.settingsAPI.getHttpsFirst().then((val) => {
@@ -760,11 +763,16 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
     }).finally(() => {
       setHttpsFirstLoading(false);
     });
-    void window.settingsAPI.getSafeBrowsing().then((val) => {
-      setSafeBrowsing(val);
+
+    void Promise.all([
+      window.settingsAPI.getDntEnabled(),
+      window.settingsAPI.getGpcEnabled(),
+    ]).then(([dnt, gpc]) => {
+      setDntEnabled(dnt);
+      setGpcEnabled(gpc);
     }).catch(() => {
     }).finally(() => {
-      setSafeBrowsingLoading(false);
+      setPrivacyLoading(false);
     });
   }, []);
 
@@ -786,22 +794,38 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
     }
   }
 
-  async function handleSafeBrowsingChange(level: string): Promise<void> {
-    const prev = safeBrowsing;
-    setSafeBrowsing(level);
+  async function handleDntToggle(checked: boolean): Promise<void> {
+    setDntEnabled(checked);
     try {
-      await window.settingsAPI.setSafeBrowsing(level);
-      const labels: Record<string, string> = {
-        enhanced: 'Enhanced protection',
-        standard: 'Standard protection',
-        disabled: 'No protection',
-      };
+      await window.settingsAPI.setDntEnabled(checked);
       toast.show({
         variant: 'success',
-        title: `Safe Browsing set to ${labels[level] ?? level}`,
+        title: checked
+          ? 'Do Not Track enabled'
+          : 'Do Not Track disabled',
       });
     } catch (err) {
-      setSafeBrowsing(prev);
+      setDntEnabled(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleGpcToggle(checked: boolean): Promise<void> {
+    setGpcEnabled(checked);
+    try {
+      await window.settingsAPI.setGpcEnabled(checked);
+      toast.show({
+        variant: 'success',
+        title: checked
+          ? 'Global Privacy Control enabled'
+          : 'Global Privacy Control disabled',
+      });
+    } catch (err) {
+      setGpcEnabled(!checked);
       toast.show({
         variant: 'error',
         title: 'Failed to update setting',
@@ -816,66 +840,6 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
       <p className="settings-section-desc">
         Control what local browsing data is stored on this device.
       </p>
-
-      <Card variant="default" padding="md" className="settings-card">
-        <fieldset className="settings-fieldset" disabled={safeBrowsingLoading}>
-          <legend className="settings-label">Safe Browsing</legend>
-          <p className="settings-field-hint" style={{ marginBottom: 12 }}>
-            Protects you against dangerous websites, downloads, and extensions.
-          </p>
-
-          <label className="settings-radio-row">
-            <input
-              type="radio"
-              name="safe-browsing"
-              value="enhanced"
-              checked={safeBrowsing === 'enhanced'}
-              onChange={() => void handleSafeBrowsingChange('enhanced')}
-            />
-            <span className="settings-radio-content">
-              <span className="settings-radio-label">Enhanced protection</span>
-              <span className="settings-radio-desc">
-                Fastest, most proactive protection against dangerous websites,
-                downloads, and extensions. Sends URLs to Google for real-time checks.
-              </span>
-            </span>
-          </label>
-
-          <label className="settings-radio-row">
-            <input
-              type="radio"
-              name="safe-browsing"
-              value="standard"
-              checked={safeBrowsing === 'standard'}
-              onChange={() => void handleSafeBrowsingChange('standard')}
-            />
-            <span className="settings-radio-content">
-              <span className="settings-radio-label">Standard protection</span>
-              <span className="settings-radio-desc">
-                Protects against known dangerous websites, downloads, and
-                extensions using a locally maintained list.
-              </span>
-            </span>
-          </label>
-
-          <label className="settings-radio-row">
-            <input
-              type="radio"
-              name="safe-browsing"
-              value="disabled"
-              checked={safeBrowsing === 'disabled'}
-              onChange={() => void handleSafeBrowsingChange('disabled')}
-            />
-            <span className="settings-radio-content">
-              <span className="settings-radio-label">No protection</span>
-              <span className="settings-radio-desc">
-                Not recommended. Does not protect you against dangerous websites,
-                downloads, and extensions.
-              </span>
-            </span>
-          </label>
-        </fieldset>
-      </Card>
 
       <Card variant="default" padding="md" className="settings-card">
         <div className="settings-toggle-row">
@@ -894,6 +858,53 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
               checked={httpsFirst}
               disabled={httpsFirstLoading}
               onChange={(e) => void handleHttpsFirstToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </Card>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">
+              Send a "Do Not Track" request with your browsing traffic
+            </span>
+            <span className="settings-toggle-desc">
+              Sends a DNT: 1 header with every request. Sites are not required
+              to honor this signal.
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={dntEnabled}
+              disabled={privacyLoading}
+              onChange={(e) => void handleDntToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </Card>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">
+              Send a "Global Privacy Control" signal with your browsing traffic
+            </span>
+            <span className="settings-toggle-desc">
+              Sends a Sec-GPC: 1 header with every request, signaling that you
+              do not want your data sold or shared. Sites are not required to
+              honor this signal.
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={gpcEnabled}
+              disabled={privacyLoading}
+              onChange={(e) => void handleGpcToggle(e.target.checked)}
             />
             <span className="settings-toggle-track" />
           </label>


### PR DESCRIPTION
## Summary
- Adds `DNT: 1` header toggle (Do Not Track) in Privacy settings
- Adds `Sec-GPC: 1` header toggle (Global Privacy Control) in Privacy settings
- Headers injected via `session.webRequest.onBeforeSendHeaders` on the default session
- Settings UI explains that sites are not required to honor these signals

## Changes
- `src/main/settings/ipc.ts` — IPC handlers for `dntEnabled`/`gpcEnabled` prefs, `refreshPrivacyHeaders()` for header injection
- `src/preload/settings.ts` — Bridge methods for DNT/GPC get/set
- `src/renderer/settings/SettingsApp.tsx` — Toggle UI in Privacy tab with descriptive text

Closes #64

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Privacy settings toggles to send Do Not Track (DNT) and Global Privacy Control (GPC) headers on all requests. Installs a single `electron` `session.defaultSession.webRequest.onBeforeSendHeaders` listener at startup that reads prefs per request; the UI notes sites may ignore these signals.

- **New Features**
  - DNT (`DNT: 1`) and GPC (`Sec-GPC: 1`) toggles in the Privacy tab with toast feedback.
  - IPC/preload APIs: `getDntEnabled`/`setDntEnabled`, `getGpcEnabled`/`setGpcEnabled`.
  - Header injection managed by `refreshPrivacyHeaders()` during `registerSettingsHandlers()`.

- **Refactors**
  - Removed Safe Browsing setting and its preload IPC (`getSafeBrowsing`/`setSafeBrowsing`).

<sup>Written for commit 8a58f7dd2faff50e46a16f0b3be4abc804ace023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

