### PR TITLE
feat(shortcuts): Windows/Linux shortcut parity (F5, Shift+F5, F12)

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1057,10 +1057,28 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
           },
         },
         {
+          label: 'Reload (F5)',
+          accelerator: 'F5',
+          visible: false,
+          click: () => {
+            mainLogger.debug('shortcuts.reload.f5Shadow');
+            tabManager?.reloadActive();
+          },
+        },
+        {
           label: 'Force Reload This Page',
           accelerator: 'CommandOrControl+Shift+R',
           click: () => {
             mainLogger.debug('shortcuts.reloadHard');
+            tabManager?.reloadActiveIgnoringCache();
+          },
+        },
+        {
+          label: 'Force Reload (Shift+F5)',
+          accelerator: 'Shift+F5',
+          visible: false,
+          click: () => {
+            mainLogger.debug('shortcuts.reloadHard.shiftF5Shadow');
             tabManager?.reloadActiveIgnoringCache();
           },
         },
@@ -1132,6 +1150,15 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
               visible: false,
               click: () => {
                 mainLogger.debug('shortcuts.devTools.shiftI');
+                tabManager?.toggleDevToolsForActive();
+              },
+            },
+            {
+              label: 'Developer Tools (F12)',
+              accelerator: 'F12',
+              visible: false,
+              click: () => {
+                mainLogger.debug('shortcuts.devTools.f12Shadow');
                 tabManager?.toggleDevToolsForActive();
               },
             },


### PR DESCRIPTION
Closes #89

## Summary
- Add F5 shadow accelerator for page reload (mirrors Ctrl+R)
- Add Shift+F5 shadow accelerator for hard reload (mirrors Ctrl+Shift+R)
- Add F12 shadow accelerator for DevTools (mirrors Ctrl+Shift+I)

All other shortcuts in the checklist (Ctrl+T/N/W/Shift+N/Shift+T, Alt+←/→, Esc, F6, F7, F11, Ctrl+L) already work via existing `CommandOrControl` abstractions and `before-input-event` handlers.

## Test plan
- [ ] Verify F5 reloads the active tab on Windows/Linux
- [ ] Verify Shift+F5 hard-reloads (ignoring cache) on Windows/Linux
- [ ] Verify F12 toggles DevTools on Windows/Linux
- [ ] Verify existing Ctrl+R, Ctrl+Shift+R, Ctrl+Shift+I still work
- [ ] Verify no regression on macOS (shadow items are hidden, no conflicts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows/Linux shortcut parity by binding F5, Shift+F5, and F12 to reload, hard reload, and DevTools via hidden menu accelerators. Completes the shortcut parity requested in #89 without changing macOS behavior.

- New Features
  - F5 reloads the active tab (mirrors Ctrl+R).
  - Shift+F5 hard reloads, ignoring cache (mirrors Ctrl+Shift+R).
  - F12 toggles DevTools (mirrors Ctrl+Shift+I).
  - Implemented as hidden menu items (visible: false) so the UI doesn’t change and existing shortcuts still work.

<sup>Written for commit 3d80c2b4acb9ba10b3d81d2044b966d6fb09a728. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

