### PR TITLE
feat(permissions): cookies and site data settings

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -40,7 +40,7 @@ import { handleHlSubmit, handleHlCancel, teardown as teardownHl } from './hlPill
 import { getEngine, setEngine, type EngineId } from './hl/engine';
 // Track 5 — Settings
 import { openSettingsWindow, closeSettingsWindow, getSettingsWindow } from './settings/SettingsWindow';
-import { registerSettingsHandlers, unregisterSettingsHandlers, openClearDataDialogFromMenu } from './settings/ipc';
+import { registerSettingsHandlers, unregisterSettingsHandlers, openClearDataDialogFromMenu, clearCookiesOnQuitIfEnabled } from './settings/ipc';
 // Wave1 P3 — Bookmarks
 import { BookmarkStore } from './bookmarks/BookmarkStore';
 import { registerBookmarkHandlers, unregisterBookmarkHandlers } from './bookmarks/ipc';
@@ -599,6 +599,7 @@ app.whenReady().then(async () => {
       historyStore?.flushSync();
       permissionStore?.flushSync();
     }
+    await clearCookiesOnQuitIfEnabled();
     await teardownHl();
   });
 

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -66,6 +66,16 @@ const GOOGLE_SCOPE_LIST = [
 
 type ScopeName = typeof GOOGLE_SCOPE_LIST[number]['scope'];
 
+// Allowed values for third-party cookie policy (mirrors Chrome's cookie control)
+const ALLOWED_THIRD_PARTY_COOKIE_POLICIES = [
+  'allow-all',
+  'block-third-party',
+  'block-third-party-incognito',
+] as const;
+export type ThirdPartyCookiePolicy = typeof ALLOWED_THIRD_PARTY_COOKIE_POLICIES[number];
+
+const DEFAULT_THIRD_PARTY_COOKIE_POLICY: ThirdPartyCookiePolicy = 'allow-all';
+
 // IPC channels
 const CH_SAVE_API_KEY      = 'settings:save-api-key';
 const CH_LOAD_API_KEY      = 'settings:load-api-key';
@@ -93,6 +103,13 @@ const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_THIRD_PARTY_COOKIES    = 'settings:get-third-party-cookies';
+const CH_SET_THIRD_PARTY_COOKIES    = 'settings:set-third-party-cookies';
+const CH_GET_CLEAR_COOKIES_ON_CLOSE = 'settings:get-clear-cookies-on-close';
+const CH_SET_CLEAR_COOKIES_ON_CLOSE = 'settings:set-clear-cookies-on-close';
+const CH_GET_PER_SITE_DELETE_ON_EXIT    = 'settings:get-per-site-delete-on-exit';
+const CH_ADD_PER_SITE_DELETE_ON_EXIT    = 'settings:add-per-site-delete-on-exit';
+const CH_REMOVE_PER_SITE_DELETE_ON_EXIT = 'settings:remove-per-site-delete-on-exit';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -631,6 +648,77 @@ function handleSetGpcEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boole
 }
 
 // ---------------------------------------------------------------------------
+// Cookie settings handlers
+// ---------------------------------------------------------------------------
+
+function handleGetThirdPartyCookies(): ThirdPartyCookiePolicy {
+  mainLogger.info(CH_GET_THIRD_PARTY_COOKIES);
+  const prefs = readPrefs();
+  const policy = (prefs.thirdPartyCookies as ThirdPartyCookiePolicy | undefined) ?? DEFAULT_THIRD_PARTY_COOKIE_POLICY;
+  mainLogger.info(`${CH_GET_THIRD_PARTY_COOKIES}.ok`, { policy });
+  return policy;
+}
+
+function handleSetThirdPartyCookies(_event: Electron.IpcMainInvokeEvent, policy: string): void {
+  const validated = assertOneOf(policy, 'thirdPartyCookies', ALLOWED_THIRD_PARTY_COOKIE_POLICIES);
+  mainLogger.info(CH_SET_THIRD_PARTY_COOKIES, { policy: validated });
+  mergePrefs({ thirdPartyCookies: validated });
+  mainLogger.info(`${CH_SET_THIRD_PARTY_COOKIES}.ok`, { policy: validated });
+}
+
+function handleGetClearCookiesOnClose(): boolean {
+  mainLogger.info(CH_GET_CLEAR_COOKIES_ON_CLOSE);
+  const prefs = readPrefs();
+  const enabled = prefs.clearCookiesOnClose === true;
+  mainLogger.info(`${CH_GET_CLEAR_COOKIES_ON_CLOSE}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetClearCookiesOnClose(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('clearCookiesOnClose must be a boolean');
+  }
+  mainLogger.info(CH_SET_CLEAR_COOKIES_ON_CLOSE, { enabled });
+  mergePrefs({ clearCookiesOnClose: enabled });
+  mainLogger.info(`${CH_SET_CLEAR_COOKIES_ON_CLOSE}.ok`, { enabled });
+}
+
+function handleGetPerSiteDeleteOnExit(): string[] {
+  mainLogger.info(CH_GET_PER_SITE_DELETE_ON_EXIT);
+  const prefs = readPrefs();
+  const sites = Array.isArray(prefs.perSiteDeleteOnExit) ? (prefs.perSiteDeleteOnExit as string[]) : [];
+  mainLogger.info(`${CH_GET_PER_SITE_DELETE_ON_EXIT}.ok`, { count: sites.length });
+  return sites;
+}
+
+function handleAddPerSiteDeleteOnExit(_event: Electron.IpcMainInvokeEvent, origin: string): void {
+  const validated = assertString(origin, 'origin', 512);
+  mainLogger.info(CH_ADD_PER_SITE_DELETE_ON_EXIT, { origin: validated });
+  const prefs = readPrefs();
+  const existing: string[] = Array.isArray(prefs.perSiteDeleteOnExit)
+    ? (prefs.perSiteDeleteOnExit as string[])
+    : [];
+  if (!existing.includes(validated)) {
+    mergePrefs({ perSiteDeleteOnExit: [...existing, validated] });
+    mainLogger.info(`${CH_ADD_PER_SITE_DELETE_ON_EXIT}.ok`, { origin: validated, total: existing.length + 1 });
+  } else {
+    mainLogger.info(`${CH_ADD_PER_SITE_DELETE_ON_EXIT}.alreadyExists`, { origin: validated });
+  }
+}
+
+function handleRemovePerSiteDeleteOnExit(_event: Electron.IpcMainInvokeEvent, origin: string): void {
+  const validated = assertString(origin, 'origin', 512);
+  mainLogger.info(CH_REMOVE_PER_SITE_DELETE_ON_EXIT, { origin: validated });
+  const prefs = readPrefs();
+  const existing: string[] = Array.isArray(prefs.perSiteDeleteOnExit)
+    ? (prefs.perSiteDeleteOnExit as string[])
+    : [];
+  const updated = existing.filter((o) => o !== validated);
+  mergePrefs({ perSiteDeleteOnExit: updated });
+  mainLogger.info(`${CH_REMOVE_PER_SITE_DELETE_ON_EXIT}.ok`, { origin: validated, remaining: updated.length });
+}
+
+// ---------------------------------------------------------------------------
 // Privacy header injection (DNT + GPC)
 // ---------------------------------------------------------------------------
 
@@ -669,6 +757,48 @@ export function refreshPrivacyHeaders(): void {
   });
 
   mainLogger.info('privacy.refreshHeaders.installed');
+}
+
+/**
+ * Called on before-quit. If clearCookiesOnClose is enabled, clears all cookies
+ * and per-site delete-on-exit data from the default session.
+ */
+export async function clearCookiesOnQuitIfEnabled(): Promise<void> {
+  const prefs = readPrefs();
+  const clearOnClose = prefs.clearCookiesOnClose === true;
+  const perSiteSites: string[] = Array.isArray(prefs.perSiteDeleteOnExit)
+    ? (prefs.perSiteDeleteOnExit as string[])
+    : [];
+
+  if (clearOnClose) {
+    mainLogger.info('cookies.clearOnClose.start');
+    try {
+      await session.defaultSession.clearStorageData({ storages: ['cookies'] });
+      mainLogger.info('cookies.clearOnClose.done');
+    } catch (err) {
+      mainLogger.error('cookies.clearOnClose.failed', { error: (err as Error).message });
+    }
+  }
+
+  // Per-site delete-on-exit: clear cookies and storage for each registered origin
+  if (perSiteSites.length > 0) {
+    mainLogger.info('cookies.perSiteDeleteOnExit.start', { count: perSiteSites.length });
+    for (const origin of perSiteSites) {
+      try {
+        await session.defaultSession.clearStorageData({
+          origin,
+          storages: ['cookies', 'localstorage', 'indexdb', 'serviceworkers'],
+        });
+        mainLogger.info('cookies.perSiteDeleteOnExit.cleared', { origin });
+      } catch (err) {
+        mainLogger.error('cookies.perSiteDeleteOnExit.failed', {
+          origin,
+          error: (err as Error).message,
+        });
+      }
+    }
+    mainLogger.info('cookies.perSiteDeleteOnExit.done', { count: perSiteSites.length });
+  }
 }
 
 function handleCloseWindow(): void {
@@ -719,10 +849,17 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_THIRD_PARTY_COOKIES,    handleGetThirdPartyCookies);
+  ipcMain.handle(CH_SET_THIRD_PARTY_COOKIES,    handleSetThirdPartyCookies);
+  ipcMain.handle(CH_GET_CLEAR_COOKIES_ON_CLOSE, handleGetClearCookiesOnClose);
+  ipcMain.handle(CH_SET_CLEAR_COOKIES_ON_CLOSE, handleSetClearCookiesOnClose);
+  ipcMain.handle(CH_GET_PER_SITE_DELETE_ON_EXIT,    handleGetPerSiteDeleteOnExit);
+  ipcMain.handle(CH_ADD_PER_SITE_DELETE_ON_EXIT,    handleAddPerSiteDeleteOnExit);
+  ipcMain.handle(CH_REMOVE_PER_SITE_DELETE_ON_EXIT, handleRemovePerSiteDeleteOnExit);
 
   refreshPrivacyHeaders();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 32 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -753,6 +890,13 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_THIRD_PARTY_COOKIES);
+  ipcMain.removeHandler(CH_SET_THIRD_PARTY_COOKIES);
+  ipcMain.removeHandler(CH_GET_CLEAR_COOKIES_ON_CLOSE);
+  ipcMain.removeHandler(CH_SET_CLEAR_COOKIES_ON_CLOSE);
+  ipcMain.removeHandler(CH_GET_PER_SITE_DELETE_ON_EXIT);
+  ipcMain.removeHandler(CH_ADD_PER_SITE_DELETE_ON_EXIT);
+  ipcMain.removeHandler(CH_REMOVE_PER_SITE_DELETE_ON_EXIT);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -161,6 +161,26 @@ export interface SettingsAPI {
 
   /** Set whether Global Privacy Control header is enabled */
   setGpcEnabled: (enabled: boolean) => Promise<void>;
+  /** Get third-party cookie policy */
+  getThirdPartyCookies: () => Promise<'allow-all' | 'block-third-party' | 'block-third-party-incognito'>;
+
+  /** Set third-party cookie policy */
+  setThirdPartyCookies: (policy: 'allow-all' | 'block-third-party' | 'block-third-party-incognito') => Promise<void>;
+
+  /** Get whether cookies are cleared when all windows close */
+  getClearCookiesOnClose: () => Promise<boolean>;
+
+  /** Set whether cookies are cleared when all windows close */
+  setClearCookiesOnClose: (enabled: boolean) => Promise<void>;
+
+  /** Get the list of origins with per-site delete-on-exit */
+  getPerSiteDeleteOnExit: () => Promise<string[]>;
+
+  /** Add an origin to the per-site delete-on-exit list */
+  addPerSiteDeleteOnExit: (origin: string) => Promise<void>;
+
+  /** Remove an origin from the per-site delete-on-exit list */
+  removePerSiteDeleteOnExit: (origin: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +391,40 @@ const api: SettingsAPI = {
   setGpcEnabled: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setGpcEnabled', { enabled });
     await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
+  },
+  getThirdPartyCookies: async (): Promise<'allow-all' | 'block-third-party' | 'block-third-party-incognito'> => {
+    console.debug('[settings-preload] getThirdPartyCookies');
+    return ipcRenderer.invoke('settings:get-third-party-cookies') as Promise<'allow-all' | 'block-third-party' | 'block-third-party-incognito'>;
+  },
+
+  setThirdPartyCookies: async (policy: 'allow-all' | 'block-third-party' | 'block-third-party-incognito'): Promise<void> => {
+    console.debug('[settings-preload] setThirdPartyCookies', { policy });
+    await ipcRenderer.invoke('settings:set-third-party-cookies', policy);
+  },
+
+  getClearCookiesOnClose: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getClearCookiesOnClose');
+    return ipcRenderer.invoke('settings:get-clear-cookies-on-close') as Promise<boolean>;
+  },
+
+  setClearCookiesOnClose: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setClearCookiesOnClose', { enabled });
+    await ipcRenderer.invoke('settings:set-clear-cookies-on-close', enabled);
+  },
+
+  getPerSiteDeleteOnExit: async (): Promise<string[]> => {
+    console.debug('[settings-preload] getPerSiteDeleteOnExit');
+    return ipcRenderer.invoke('settings:get-per-site-delete-on-exit') as Promise<string[]>;
+  },
+
+  addPerSiteDeleteOnExit: async (origin: string): Promise<void> => {
+    console.debug('[settings-preload] addPerSiteDeleteOnExit', { origin });
+    await ipcRenderer.invoke('settings:add-per-site-delete-on-exit', origin);
+  },
+
+  removePerSiteDeleteOnExit: async (origin: string): Promise<void> => {
+    console.debug('[settings-preload] removePerSiteDeleteOnExit', { origin });
+    await ipcRenderer.invoke('settings:remove-per-site-delete-on-exit', origin);
   },
 };
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -33,6 +33,7 @@ const TAB_PROFILES     = 'profiles'    as const;
 const TAB_PRIVACY      = 'privacy'     as const;
 const TAB_PASSWORDS    = 'passwords'   as const;
 const TAB_ZOOM         = 'site-zoom'   as const;
+const TAB_COOKIES      = 'cookies'     as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -44,6 +45,7 @@ type TabId =
   | typeof TAB_PRIVACY
   | typeof TAB_PASSWORDS
   | typeof TAB_ZOOM
+  | typeof TAB_COOKIES
   | typeof TAB_PASSWORDS
   | typeof TAB_DANGER;
 
@@ -56,6 +58,7 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_PROFILES,   label: 'Profiles' },
   { id: TAB_PRIVACY,    label: 'Privacy and security' },
   { id: TAB_ZOOM,       label: 'Site Zoom' },
+  { id: TAB_COOKIES,    label: 'Cookies and site data' },
   { id: TAB_DANGER,     label: 'Danger Zone' },
 ];
 
@@ -154,6 +157,13 @@ declare global {
       setDntEnabled: (enabled: boolean) => Promise<void>;
       getGpcEnabled: () => Promise<boolean>;
       setGpcEnabled: (enabled: boolean) => Promise<void>;
+      getThirdPartyCookies: () => Promise<'allow-all' | 'block-third-party' | 'block-third-party-incognito'>;
+      setThirdPartyCookies: (policy: 'allow-all' | 'block-third-party' | 'block-third-party-incognito') => Promise<void>;
+      getClearCookiesOnClose: () => Promise<boolean>;
+      setClearCookiesOnClose: (enabled: boolean) => Promise<void>;
+      getPerSiteDeleteOnExit: () => Promise<string[]>;
+      addPerSiteDeleteOnExit: (origin: string) => Promise<void>;
+      removePerSiteDeleteOnExit: (origin: string) => Promise<void>;
     };
   }
 }
@@ -1525,6 +1535,255 @@ function PasswordsTab(): React.ReactElement {
   );
 }
 
+
+// ---------------------------------------------------------------------------
+// Cookies and site data tab
+// ---------------------------------------------------------------------------
+
+const THIRD_PARTY_COOKIE_OPTIONS: Array<{
+  value: 'allow-all' | 'block-third-party' | 'block-third-party-incognito';
+  label: string;
+  desc: string;
+}> = [
+  {
+    value: 'allow-all',
+    label: 'Allow all cookies',
+    desc: 'Sites can set and read cookies, including third-party cookies.',
+  },
+  {
+    value: 'block-third-party',
+    label: 'Block third-party cookies',
+    desc: 'Third-party cookies are blocked. This may affect sign-in on some sites.',
+  },
+  {
+    value: 'block-third-party-incognito',
+    label: 'Block third-party cookies in incognito',
+    desc: 'Third-party cookies are only blocked in incognito sessions.',
+  },
+];
+
+function CookiesTab(): React.ReactElement {
+  const toast = useToast();
+  const [thirdParty, setThirdParty] = useState<'allow-all' | 'block-third-party' | 'block-third-party-incognito'>('allow-all');
+  const [clearOnClose, setClearOnClose] = useState(false);
+  const [perSiteSites, setPerSiteSites] = useState<string[]>([]);
+  const [newSiteInput, setNewSiteInput] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void Promise.all([
+      window.settingsAPI.getThirdPartyCookies(),
+      window.settingsAPI.getClearCookiesOnClose(),
+      window.settingsAPI.getPerSiteDeleteOnExit(),
+    ]).then(([policy, clear, sites]) => {
+      setThirdParty(policy);
+      setClearOnClose(clear);
+      setPerSiteSites(sites);
+    }).catch(() => {
+      // defaults already set
+    }).finally(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleThirdPartyChange(
+    value: 'allow-all' | 'block-third-party' | 'block-third-party-incognito',
+  ): Promise<void> {
+    setThirdParty(value);
+    try {
+      await window.settingsAPI.setThirdPartyCookies(value);
+      toast.show({ variant: 'success', title: 'Cookie policy updated' });
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update cookie policy',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleClearOnCloseToggle(checked: boolean): Promise<void> {
+    setClearOnClose(checked);
+    try {
+      await window.settingsAPI.setClearCookiesOnClose(checked);
+      toast.show({
+        variant: 'success',
+        title: checked
+          ? 'Cookies will be cleared when all windows close'
+          : 'Cookies will be kept when windows close',
+      });
+    } catch (err) {
+      setClearOnClose(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleAddSite(): Promise<void> {
+    const site = newSiteInput.trim();
+    if (!site) return;
+    try {
+      await window.settingsAPI.addPerSiteDeleteOnExit(site);
+      setPerSiteSites((prev) => prev.includes(site) ? prev : [...prev, site]);
+      setNewSiteInput('');
+      toast.show({ variant: 'success', title: `Added ${site} to delete-on-exit list` });
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        title: 'Failed to add site',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleRemoveSite(origin: string): Promise<void> {
+    try {
+      await window.settingsAPI.removePerSiteDeleteOnExit(origin);
+      setPerSiteSites((prev) => prev.filter((o) => o !== origin));
+      toast.show({ variant: 'success', title: `Removed ${origin}` });
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        title: 'Failed to remove site',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="settings-section">
+        <h2 className="settings-section-title">Cookies and site data</h2>
+        <div className="settings-loading">
+          <Spinner size="md" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Cookies and site data</h2>
+      <p className="settings-section-desc">
+        Control how cookies are stored and when site data is deleted.
+      </p>
+
+      {/* Third-party cookie policy */}
+      <Card variant="default" padding="md" className="settings-card">
+        <fieldset className="settings-fieldset">
+          <legend className="settings-label">Third-party cookies</legend>
+          <p className="settings-field-hint">
+            Third-party cookies come from sites other than the one you are visiting.
+            CHIPS partitioned cookies (with the <code>Partitioned</code> attribute) are
+            always permitted regardless of this setting.
+          </p>
+          {THIRD_PARTY_COOKIE_OPTIONS.map((opt) => (
+            <label key={opt.value} className="settings-radio-row">
+              <input
+                type="radio"
+                name="third-party-cookies"
+                value={opt.value}
+                checked={thirdParty === opt.value}
+                onChange={() => void handleThirdPartyChange(opt.value)}
+              />
+              <span className="settings-radio-content">
+                <span className="settings-radio-label">{opt.label}</span>
+                <span className="settings-radio-desc">{opt.desc}</span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+      </Card>
+
+      {/* Clear on close */}
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">
+              Clear cookies and site data when you close all windows
+            </span>
+            <span className="settings-toggle-desc">
+              All cookies and site data will be deleted each time you quit the browser.
+              You will be signed out of most sites.
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={clearOnClose}
+              onChange={(e) => void handleClearOnCloseToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+      </Card>
+
+      {/* Per-site delete on exit */}
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-field">
+          <span className="settings-label">Delete data on exit for specific sites</span>
+          <p className="settings-field-hint">
+            Cookies and site data for these origins are deleted each time you close all windows,
+            even if "Clear cookies and site data when you close all windows" is off.
+          </p>
+        </div>
+
+        <div className="settings-input-row" style={{ marginBottom: 12 }}>
+          <input
+            className="settings-input"
+            type="text"
+            value={newSiteInput}
+            onChange={(e) => setNewSiteInput(e.target.value)}
+            placeholder="https://example.com"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleAddSite();
+            }}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void handleAddSite()}
+            disabled={!newSiteInput.trim()}
+          >
+            Add
+          </Button>
+        </div>
+
+        {perSiteSites.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--color-fg-tertiary)' }}>
+            No sites added.
+          </p>
+        ) : (
+          <div>
+            {perSiteSites.map((origin, idx) => (
+              <div
+                key={origin}
+                className={`settings-scope-row ${idx < perSiteSites.length - 1 ? 'settings-scope-row--bordered' : ''}`}
+              >
+                <div className="settings-scope-info">
+                  <span className="settings-scope-label">{origin}</span>
+                </div>
+                <div className="settings-scope-actions">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void handleRemoveSite(origin)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Danger Zone tab
 // ---------------------------------------------------------------------------
@@ -1680,6 +1939,7 @@ function SettingsInner(): React.ReactElement {
     [TAB_PROFILES]:   <ProfilesTab />,
     [TAB_PRIVACY]:    <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
     [TAB_ZOOM]:       <SiteZoomTab />,
+    [TAB_COOKIES]:    <CookiesTab />,
     [TAB_DANGER]:     <DangerZoneTab />,
   };
 


### PR DESCRIPTION
Closes #56

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Cookies and site data settings tab with controls for third‑party cookie policy, clear-on-close, and per‑site delete‑on‑exit. On app quit, cookies and site data are cleared based on these settings.

- **New Features**
  - New “Cookies and site data” tab with:
    - Third‑party cookie policy options: allow all, block third‑party, or block in incognito.
    - Toggle to clear cookies and site data when all windows close.
    - Per‑site delete‑on‑exit list (add/remove origins).
  - On quit, clears:
    - All cookies if clear‑on‑close is enabled.
    - For listed sites: cookies, localStorage, IndexedDB, and service workers.
  - Added IPC channels and preload methods to get/set these settings, and wired `clearCookiesOnQuitIfEnabled()` into app shutdown.

<sup>Written for commit 124d46e1505c1d8c5a8fc155e7dee7802930b0c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

