### PR TITLE
feat(permissions): File System Access API

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -60,6 +60,7 @@ import {
 // Permissions framework
 import { PermissionStore } from './permissions/PermissionStore';
 import { PermissionManager } from './permissions/PermissionManager';
+import { FileSystemAccessStore } from './permissions/FileSystemAccessStore';
 import { registerPermissionHandlers, unregisterPermissionHandlers } from './permissions/ipc';
 // Issue #71 — Extensions
 import { ExtensionManager } from './extensions/ExtensionManager';
@@ -143,6 +144,7 @@ let passwordStore: PasswordStore | null = null;
 let profileStore: ProfileStore | null = null;
 let permissionStore: PermissionStore | null = null;
 let permissionManager: PermissionManager | null = null;
+let fsStore: FileSystemAccessStore | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
 let downloadManager: DownloadManager | null = null;
@@ -185,6 +187,7 @@ function openShellAndWire(profileId?: string): BrowserWindow {
     const tm = tabManager;
     permissionManager = new PermissionManager({
       store: permissionStore,
+      fsStore: fsStore ?? new FileSystemAccessStore(getProfileDataDir(pid)),
       getShellWindow: () => shellWindow,
       getTabIdForWebContents: (wcId: number) => tm.getTabIdForWebContentsId(wcId),
     });
@@ -195,6 +198,7 @@ function openShellAndWire(profileId?: string): BrowserWindow {
       store: permissionStore,
       manager: permissionManager,
       getShellWindow: () => shellWindow,
+      fsStore: fsStore ?? undefined,
     });
   }
 
@@ -353,6 +357,7 @@ app.whenReady().then(async () => {
   // only PermissionStore accepts a data dir today.
   bookmarkStore = new BookmarkStore();
   permissionStore = new PermissionStore(getProfileDataDir(activeProfileId));
+  fsStore = new FileSystemAccessStore(getProfileDataDir(activeProfileId));
   registerBookmarkHandlers({
     store: bookmarkStore,
     getShellWindow: () => shellWindow,

--- a/my-app/src/main/permissions/FileSystemAccessStore.ts
+++ b/my-app/src/main/permissions/FileSystemAccessStore.ts
@@ -1,0 +1,155 @@
+/**
+ * FileSystemAccessStore — persistent per-origin, per-path grants for the
+ * File System Access API (showOpenFilePicker / showSaveFilePicker /
+ * showDirectoryPicker + FileSystemHandle.requestPermission()).
+ *
+ * Storage: userData/fs-access-grants.json (debounced 300ms writes).
+ * Each grant records the origin, the absolute file-system path, whether
+ * the grant covers readwrite (vs read-only), and timestamps.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { mainLogger } from '../logger';
+
+const FS_GRANTS_FILE_NAME = 'fs-access-grants.json';
+const DEBOUNCE_MS = 300;
+
+export type FsAccessMode = 'read' | 'readwrite';
+
+export interface FsAccessGrant {
+  origin: string;
+  /** Absolute path on the host file system */
+  filePath: string;
+  mode: FsAccessMode;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface PersistedFsGrants {
+  version: 1;
+  grants: FsAccessGrant[];
+}
+
+function makeEmpty(): PersistedFsGrants {
+  return { version: 1, grants: [] };
+}
+
+export class FileSystemAccessStore {
+  private readonly filePath: string;
+  private state: PersistedFsGrants;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor(dataDir?: string) {
+    this.filePath = path.join(dataDir ?? app.getPath('userData'), FS_GRANTS_FILE_NAME);
+    mainLogger.info('FileSystemAccessStore.constructor', { filePath: this.filePath });
+    this.state = this.load();
+    mainLogger.info('FileSystemAccessStore.init', { grantCount: this.state.grants.length });
+  }
+
+  private load(): PersistedFsGrants {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedFsGrants;
+      if (parsed.version !== 1 || !Array.isArray(parsed.grants)) {
+        mainLogger.warn('FileSystemAccessStore.load.invalid', { msg: 'Resetting fs grants' });
+        return makeEmpty();
+      }
+      mainLogger.info('FileSystemAccessStore.load.ok', { grantCount: parsed.grants.length });
+      return parsed;
+    } catch {
+      mainLogger.info('FileSystemAccessStore.load.fresh', { msg: 'No fs-access-grants.json — starting fresh' });
+      return makeEmpty();
+    }
+  }
+
+  private schedulePersist(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2), 'utf-8');
+      mainLogger.info('FileSystemAccessStore.flushSync.ok');
+    } catch (err) {
+      mainLogger.error('FileSystemAccessStore.flushSync.failed', { error: (err as Error).message });
+    }
+    this.dirty = false;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Queries
+  // -------------------------------------------------------------------------
+
+  hasGrant(origin: string, filePath: string): boolean {
+    return this.state.grants.some((g) => g.origin === origin && g.filePath === filePath);
+  }
+
+  getGrantsForOrigin(origin: string): FsAccessGrant[] {
+    return this.state.grants.filter((g) => g.origin === origin);
+  }
+
+  getAllGrants(): FsAccessGrant[] {
+    return [...this.state.grants];
+  }
+
+  // -------------------------------------------------------------------------
+  // Mutations
+  // -------------------------------------------------------------------------
+
+  addGrant(origin: string, filePath: string, mode: FsAccessMode = 'read'): void {
+    const existing = this.state.grants.find(
+      (g) => g.origin === origin && g.filePath === filePath,
+    );
+    if (existing) {
+      existing.mode = mode;
+      existing.updatedAt = Date.now();
+      mainLogger.info('FileSystemAccessStore.updateGrant', { origin, filePath, mode });
+    } else {
+      this.state.grants.push({
+        origin,
+        filePath,
+        mode,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      mainLogger.info('FileSystemAccessStore.addGrant', { origin, filePath, mode });
+    }
+    this.schedulePersist();
+  }
+
+  removeGrant(origin: string, filePath: string): boolean {
+    const before = this.state.grants.length;
+    this.state.grants = this.state.grants.filter(
+      (g) => !(g.origin === origin && g.filePath === filePath),
+    );
+    if (this.state.grants.length < before) {
+      mainLogger.info('FileSystemAccessStore.removeGrant', { origin, filePath });
+      this.schedulePersist();
+      return true;
+    }
+    return false;
+  }
+
+  clearOrigin(origin: string): void {
+    this.state.grants = this.state.grants.filter((g) => g.origin !== origin);
+    mainLogger.info('FileSystemAccessStore.clearOrigin', { origin });
+    this.schedulePersist();
+  }
+
+  clearAll(): void {
+    this.state.grants = [];
+    mainLogger.info('FileSystemAccessStore.clearAll');
+    this.schedulePersist();
+  }
+}

--- a/my-app/src/main/permissions/PermissionManager.ts
+++ b/my-app/src/main/permissions/PermissionManager.ts
@@ -9,6 +9,7 @@
 import { BrowserWindow, Session, session, systemPreferences } from 'electron';
 import { mainLogger } from '../logger';
 import { PermissionStore, PermissionType, PermissionState } from './PermissionStore';
+import { FileSystemAccessStore } from './FileSystemAccessStore';
 
 // Map Electron's permission strings to our PermissionType enum
 const ELECTRON_PERMISSION_MAP: Record<string, PermissionType> = {
@@ -32,6 +33,8 @@ const ELECTRON_PERMISSION_MAP: Record<string, PermissionType> = {
   'payment-handler': 'payment-handler',
   'background-sync': 'background-sync',
   'protocol-handler': 'protocol-handler',
+  // File System Access API — Electron surfaces this as 'fileSystem'
+  'fileSystem': 'fileSystem',
 };
 
 // Permissions that are auto-granted without prompting.
@@ -62,6 +65,8 @@ export interface PermissionPromptRequest {
   isMainFrame: boolean;
   combinedTypes?: PermissionType[];
   quietUI?: boolean;
+  // For fileSystem prompts: the path being requested
+  filePath?: string;
 }
 
 export type PermissionDecision = 'allow' | 'allow-once' | 'deny';
@@ -83,6 +88,7 @@ interface DeferredMediaRequest {
 
 export class PermissionManager {
   private store: PermissionStore;
+  private fsStore: FileSystemAccessStore;
   private getShellWindow: () => BrowserWindow | null;
   private getTabIdForWebContents: (wcId: number) => string | null;
   private pending: Map<string, PendingPrompt> = new Map();
@@ -93,10 +99,12 @@ export class PermissionManager {
 
   constructor(opts: {
     store: PermissionStore;
+    fsStore?: FileSystemAccessStore;
     getShellWindow: () => BrowserWindow | null;
     getTabIdForWebContents: (wcId: number) => string | null;
   }) {
     this.store = opts.store;
+    this.fsStore = opts.fsStore ?? new FileSystemAccessStore();
     this.getShellWindow = opts.getShellWindow;
     this.getTabIdForWebContents = opts.getTabIdForWebContents;
 
@@ -222,6 +230,7 @@ export class PermissionManager {
     permissionType: PermissionType,
     isMainFrame: boolean,
     callback: (granted: boolean) => void,
+    extra?: { filePath?: string },
   ): void {
     const promptId = `perm-${++this.promptCounter}`;
     const request: PermissionPromptRequest = {
@@ -234,6 +243,10 @@ export class PermissionManager {
 
     if (permissionType === 'notifications') {
       request.quietUI = this.shouldUseQuietUI(origin, isMainFrame);
+    }
+
+    if (extra?.filePath) {
+      request.filePath = extra.filePath;
     }
 
     this.pending.set(promptId, { request, resolve: callback });
@@ -275,6 +288,22 @@ export class PermissionManager {
         return;
       }
 
+      // File System Access API: check persistent path-level grants first
+      if (permissionType === 'fileSystem') {
+        const filePath = (details as unknown as Record<string, unknown>)?.filePath as string | undefined;
+        mainLogger.info('PermissionManager.fileSystem.request', { origin, filePath });
+
+        if (filePath && this.fsStore.hasGrant(origin, filePath)) {
+          mainLogger.info('PermissionManager.fileSystem.persistentGrant', { origin, filePath });
+          callback(true);
+          return;
+        }
+
+        // Fall through to prompt with filePath attached
+        this.dispatchSinglePrompt(origin, tabId, 'fileSystem', isMainFrame, callback, { filePath });
+        return;
+      }
+
       if (this.hasSessionGrant(tabId, origin, permissionType)) {
         mainLogger.info('PermissionManager.sessionGrant', { origin, permissionType, tabId });
         callback(true);
@@ -311,6 +340,14 @@ export class PermissionManager {
       if (osCheck === 'denied') return false;
 
       const origin = this.extractOrigin(requestingOrigin);
+
+      // fileSystem check: allow if site has any persistent grant
+      if (permissionType === 'fileSystem') {
+        const hasSomeGrant = this.fsStore.getGrantsForOrigin(origin).length > 0;
+        mainLogger.info('PermissionManager.fileSystem.check', { origin, hasSomeGrant });
+        return hasSomeGrant;
+      }
+
       const stored = this.store.getSitePermission(origin, permissionType);
       return stored === 'allow';
     });
@@ -335,6 +372,7 @@ export class PermissionManager {
       permissionType: request.permissionType,
       combinedTypes: request.combinedTypes,
       quietUI: request.quietUI,
+      filePath: request.filePath,
     });
     win.webContents.send('permission-prompt', request);
   }
@@ -357,12 +395,18 @@ export class PermissionManager {
       origin: request.origin,
       permissionType: request.permissionType,
       combinedTypes: request.combinedTypes,
+      filePath: request.filePath,
     });
 
     switch (decision) {
       case 'allow':
         for (const t of types) {
-          this.store.setSitePermission(request.origin, t, 'allow');
+          if (t === 'fileSystem' && request.filePath) {
+            // Persistent path-level grant
+            this.fsStore.addGrant(request.origin, request.filePath);
+          } else {
+            this.store.setSitePermission(request.origin, t, 'allow');
+          }
         }
         p.resolve(true);
         if (p.pairedResolve) p.pairedResolve(true);
@@ -378,7 +422,9 @@ export class PermissionManager {
         break;
       case 'deny':
         for (const t of types) {
-          this.store.setSitePermission(request.origin, t, 'deny');
+          if (t !== 'fileSystem') {
+            this.store.setSitePermission(request.origin, t, 'deny');
+          }
         }
         if (types.includes('notifications')) {
           this.recordNotificationDenial();
@@ -408,11 +454,11 @@ export class PermissionManager {
     }
 
     // Also dismiss any pending prompts for this tab
-    for (const [id, p] of this.pending) {
-      if (p.request.tabId === tabId) {
+    for (const [id, pending] of this.pending) {
+      if (pending.request.tabId === tabId) {
         mainLogger.info('PermissionManager.dismissPending', { promptId: id, tabId });
-        p.resolve(false);
-        if (p.pairedResolve) p.pairedResolve(false);
+        pending.resolve(false);
+        if (pending.pairedResolve) pending.pairedResolve(false);
         this.pending.delete(id);
         const win = this.getShellWindow();
         if (win && !win.isDestroyed()) {

--- a/my-app/src/main/permissions/PermissionStore.ts
+++ b/my-app/src/main/permissions/PermissionStore.ts
@@ -34,6 +34,7 @@ export type PermissionType =
   | 'payment-handler'
   | 'background-sync'
   | 'protocol-handler'
+  | 'fileSystem'
   | 'unknown';
 
 export interface PermissionRecord {
@@ -68,6 +69,7 @@ const DEFAULT_PERMISSION_STATES: Record<PermissionType, PermissionState> = {
   'payment-handler': 'allow',
   'background-sync': 'allow',
   'protocol-handler': 'ask',
+  fileSystem: 'ask',
   unknown: 'ask',
 };
 

--- a/my-app/src/main/permissions/ipc.ts
+++ b/my-app/src/main/permissions/ipc.ts
@@ -8,16 +8,18 @@ import { mainLogger } from '../logger';
 import { PermissionStore, PermissionType, PermissionState } from './PermissionStore';
 import { PermissionManager, PermissionDecision } from './PermissionManager';
 import { ProtocolHandlerStore } from './ProtocolHandlerStore';
+import { FileSystemAccessStore } from './FileSystemAccessStore';
 
 export interface RegisterPermissionHandlersOptions {
   store: PermissionStore;
   manager: PermissionManager;
   getShellWindow: () => BrowserWindow | null;
   protocolHandlerStore?: ProtocolHandlerStore;
+  fsStore?: FileSystemAccessStore;
 }
 
 export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptions): void {
-  const { store, manager, protocolHandlerStore } = opts;
+  const { store, manager, protocolHandlerStore, fsStore } = opts;
 
   ipcMain.handle('permissions:respond', (_e, promptId: string, decision: string) => {
     mainLogger.info('permissions:respond', { promptId, decision });
@@ -60,6 +62,34 @@ export function registerPermissionHandlers(opts: RegisterPermissionHandlersOptio
   ipcMain.handle('permissions:reset-all', () => {
     store.resetAllSitePermissions();
   });
+
+  // File System Access API grant management
+  if (fsStore) {
+    ipcMain.handle('fs-access:get-grants', () => {
+      mainLogger.info('fs-access:get-grants');
+      return fsStore.getAllGrants();
+    });
+
+    ipcMain.handle('fs-access:get-grants-for-origin', (_e, origin: string) => {
+      mainLogger.info('fs-access:get-grants-for-origin', { origin });
+      return fsStore.getGrantsForOrigin(origin);
+    });
+
+    ipcMain.handle('fs-access:remove-grant', (_e, origin: string, filePath: string) => {
+      mainLogger.info('fs-access:remove-grant', { origin, filePath });
+      return fsStore.removeGrant(origin, filePath);
+    });
+
+    ipcMain.handle('fs-access:clear-origin', (_e, origin: string) => {
+      mainLogger.info('fs-access:clear-origin', { origin });
+      fsStore.clearOrigin(origin);
+    });
+
+    ipcMain.handle('fs-access:clear-all', () => {
+      mainLogger.info('fs-access:clear-all');
+      fsStore.clearAll();
+    });
+  }
 
   // Protocol handler management (chrome://settings/handlers parity)
   if (protocolHandlerStore) {
@@ -117,6 +147,11 @@ export function unregisterPermissionHandlers(): void {
   ipcMain.removeHandler('permissions:set-default');
   ipcMain.removeHandler('permissions:get-all');
   ipcMain.removeHandler('permissions:reset-all');
+  ipcMain.removeHandler('fs-access:get-grants');
+  ipcMain.removeHandler('fs-access:get-grants-for-origin');
+  ipcMain.removeHandler('fs-access:remove-grant');
+  ipcMain.removeHandler('fs-access:clear-origin');
+  ipcMain.removeHandler('fs-access:clear-all');
   ipcMain.removeHandler('protocol-handlers:get-all');
   ipcMain.removeHandler('protocol-handlers:get-for-protocol');
   ipcMain.removeHandler('protocol-handlers:get-for-origin');

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -161,6 +161,18 @@ export interface SettingsAPI {
 
   /** Set whether Global Privacy Control header is enabled */
   setGpcEnabled: (enabled: boolean) => Promise<void>;
+
+  /** List all File System Access API persistent grants */
+  getFsAccessGrants: () => Promise<Array<{ origin: string; filePath: string; mode: string; createdAt: number; updatedAt: number }>>;
+
+  /** Remove a specific File System Access grant */
+  removeFsAccessGrant: (origin: string, filePath: string) => Promise<boolean>;
+
+  /** Clear all File System Access grants for an origin */
+  clearFsAccessOrigin: (origin: string) => Promise<void>;
+
+  /** Clear all File System Access grants */
+  clearAllFsAccessGrants: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +383,26 @@ const api: SettingsAPI = {
   setGpcEnabled: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setGpcEnabled', { enabled });
     await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
+  },
+
+  getFsAccessGrants: async () => {
+    console.debug('[settings-preload] getFsAccessGrants');
+    return ipcRenderer.invoke('fs-access:get-grants');
+  },
+
+  removeFsAccessGrant: async (origin: string, filePath: string) => {
+    console.debug('[settings-preload] removeFsAccessGrant', { origin, filePath });
+    return ipcRenderer.invoke('fs-access:remove-grant', origin, filePath);
+  },
+
+  clearFsAccessOrigin: async (origin: string) => {
+    console.debug('[settings-preload] clearFsAccessOrigin', { origin });
+    await ipcRenderer.invoke('fs-access:clear-origin', origin);
+  },
+
+  clearAllFsAccessGrants: async () => {
+    console.debug('[settings-preload] clearAllFsAccessGrants');
+    await ipcRenderer.invoke('fs-access:clear-all');
   },
 };
 

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -322,6 +322,24 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('ntp:pick-background-image'),
   },
 
+  // Issue #55 — File System Access API grant management
+  fsAccess: {
+    getGrants: (): Promise<import('../main/permissions/FileSystemAccessStore').FsAccessGrant[]> =>
+      ipcRenderer.invoke('fs-access:get-grants'),
+
+    getGrantsForOrigin: (origin: string): Promise<import('../main/permissions/FileSystemAccessStore').FsAccessGrant[]> =>
+      ipcRenderer.invoke('fs-access:get-grants-for-origin', origin),
+
+    removeGrant: (origin: string, filePath: string): Promise<boolean> =>
+      ipcRenderer.invoke('fs-access:remove-grant', origin, filePath),
+
+    clearOrigin: (origin: string): Promise<void> =>
+      ipcRenderer.invoke('fs-access:clear-origin', origin),
+
+    clearAll: (): Promise<void> =>
+      ipcRenderer.invoke('fs-access:clear-all'),
+  },
+
   // Event listeners
   on: {
     tabsState: (

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -33,6 +33,7 @@ const TAB_PROFILES     = 'profiles'    as const;
 const TAB_PRIVACY      = 'privacy'     as const;
 const TAB_PASSWORDS    = 'passwords'   as const;
 const TAB_ZOOM         = 'site-zoom'   as const;
+const TAB_FS_ACCESS    = 'fs-access'    as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -44,6 +45,7 @@ type TabId =
   | typeof TAB_PRIVACY
   | typeof TAB_PASSWORDS
   | typeof TAB_ZOOM
+  | typeof TAB_FS_ACCESS
   | typeof TAB_PASSWORDS
   | typeof TAB_DANGER;
 
@@ -56,6 +58,7 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_PROFILES,   label: 'Profiles' },
   { id: TAB_PRIVACY,    label: 'Privacy and security' },
   { id: TAB_ZOOM,       label: 'Site Zoom' },
+  { id: TAB_FS_ACCESS,  label: 'File System Access' },
   { id: TAB_DANGER,     label: 'Danger Zone' },
 ];
 
@@ -154,6 +157,10 @@ declare global {
       setDntEnabled: (enabled: boolean) => Promise<void>;
       getGpcEnabled: () => Promise<boolean>;
       setGpcEnabled: (enabled: boolean) => Promise<void>;
+      getFsAccessGrants: () => Promise<Array<{ origin: string; filePath: string; mode: string; createdAt: number; updatedAt: number }>>;
+      removeFsAccessGrant: (origin: string, filePath: string) => Promise<boolean>;
+      clearFsAccessOrigin: (origin: string) => Promise<void>;
+      clearAllFsAccessGrants: () => Promise<void>;
     };
   }
 }
@@ -1526,6 +1533,134 @@ function PasswordsTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// File System Access tab
+// ---------------------------------------------------------------------------
+
+interface FsGrant {
+  origin: string;
+  filePath: string;
+  mode: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+function FileSystemAccessTab(): React.ReactElement {
+  const toast = useToast();
+  const [grants, setGrants] = useState<FsGrant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  const loadGrants = useCallback(async () => {
+    const data = await window.settingsAPI.getFsAccessGrants();
+    setGrants(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { void loadGrants(); }, [loadGrants]);
+
+  const filtered = grants.filter((g) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return g.origin.toLowerCase().includes(q) || g.filePath.toLowerCase().includes(q);
+  });
+
+  async function handleRemove(origin: string, filePath: string): Promise<void> {
+    const ok = await window.settingsAPI.removeFsAccessGrant(origin, filePath);
+    if (ok) {
+      setGrants((prev) => prev.filter((g) => !(g.origin === origin && g.filePath === filePath)));
+      toast.show({ variant: 'success', title: 'Grant removed' });
+    }
+  }
+
+  async function handleClearAll(): Promise<void> {
+    await window.settingsAPI.clearAllFsAccessGrants();
+    setGrants([]);
+    toast.show({ variant: 'success', title: 'All file system grants cleared' });
+  }
+
+  if (loading) {
+    return (
+      <div className="settings-section">
+        <h2 className="settings-section-title">File System Access</h2>
+        <div className="settings-loading">
+          <Spinner size="md" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">File System Access</h2>
+      <p className="settings-section-desc">
+        Sites that have been granted persistent access to files or directories on your
+        device via the File System Access API. Removing a grant revokes that access.
+      </p>
+
+      <div className="settings-field" style={{ marginBottom: 16 }}>
+        <input
+          className="settings-input"
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by site or path..."
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card variant="outline" padding="md" className="settings-card">
+          <p style={{ color: 'var(--color-fg-tertiary)', fontSize: 13 }}>
+            {grants.length === 0
+              ? 'No persistent file system grants.'
+              : 'No matching grants.'}
+          </p>
+        </Card>
+      ) : (
+        <>
+          <Card variant="default" padding="none" className="settings-card">
+            {filtered.map((grant, idx) => (
+              <div
+                key={`${grant.origin}::${grant.filePath}`}
+                className={`settings-scope-row ${idx < filtered.length - 1 ? 'settings-scope-row--bordered' : ''}`}
+              >
+                <div className="settings-scope-info">
+                  <span className="settings-scope-label">{grant.origin}</span>
+                  <code className="settings-scope-name" style={{ wordBreak: 'break-all' }}>
+                    {grant.filePath}
+                  </code>
+                  <span style={{ fontSize: 11, color: 'var(--color-fg-tertiary)' }}>
+                    {grant.mode === 'readwrite' ? 'Read & write' : 'Read only'}
+                  </span>
+                </div>
+                <div className="settings-scope-actions">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void handleRemove(grant.origin, grant.filePath)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </Card>
+
+          <div style={{ marginTop: 12 }}>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleClearAll()}
+            >
+              Clear all grants
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Danger Zone tab
 // ---------------------------------------------------------------------------
 
@@ -1680,6 +1815,7 @@ function SettingsInner(): React.ReactElement {
     [TAB_PROFILES]:   <ProfilesTab />,
     [TAB_PRIVACY]:    <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
     [TAB_ZOOM]:       <SiteZoomTab />,
+    [TAB_FS_ACCESS]:  <FileSystemAccessTab />,
     [TAB_DANGER]:     <DangerZoneTab />,
   };
 

--- a/my-app/src/renderer/shell/PermissionBar.tsx
+++ b/my-app/src/renderer/shell/PermissionBar.tsx
@@ -29,6 +29,7 @@ const PERMISSION_LABELS: Record<string, string> = {
   'payment-handler': 'handle payment requests',
   'background-sync': 'sync data in the background',
   'protocol-handler': 'handle links for a protocol',
+  fileSystem: 'access files on your device',
   unknown: 'use a feature',
 };
 
@@ -48,6 +49,7 @@ const PERMISSION_ICONS: Record<string, string> = {
   'background-sync': 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
   'protocol-handler': 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
   'idle-detection': 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  fileSystem: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z',
 };
 
 interface PermissionPromptData {
@@ -58,6 +60,7 @@ interface PermissionPromptData {
   isMainFrame: boolean;
   combinedTypes?: string[];
   quietUI?: boolean;
+  filePath?: string;
 }
 
 declare const electronAPI: {
@@ -79,6 +82,10 @@ function getPromptLabel(data: PermissionPromptData): string {
   if (data.combinedTypes && data.combinedTypes.length > 1) {
     const key = data.combinedTypes.sort().join('+');
     return COMBINED_LABELS[key] ?? data.combinedTypes.map((t) => PERMISSION_LABELS[t] ?? t).join(' and ');
+  }
+  if (data.permissionType === 'fileSystem' && data.filePath) {
+    const name = data.filePath.split('/').pop() ?? data.filePath;
+    return `access "${name}" on your device`;
   }
   return PERMISSION_LABELS[data.permissionType] ?? PERMISSION_LABELS.unknown;
 }


### PR DESCRIPTION
Closes #55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent per-origin, per-path permissions for the File System Access API with prompt handling and a settings UI to view and revoke grants. Closes #55.

- **New Features**
  - Added `FileSystemAccessStore` to persist grants in `fs-access-grants.json` with debounced writes.
  - Updated `PermissionStore` and `PermissionManager` with new `fileSystem` type:
    - Auto-allow when a matching path grant exists.
    - Prompts include the requested `filePath`; “Allow” persists a path-level grant.
  - Exposed IPC/preload APIs to list, remove, or clear grants (all or by origin).
  - New “File System Access” settings tab to search, view, remove, and clear grants.
  - Permission bar shows a file-specific label and icon for `fileSystem`.
  - Wired `FileSystemAccessStore` into app startup and permission handlers.

<sup>Written for commit 8f0f3081576792597074c1ef41b4e731f3196348. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

