### PR TITLE
feat(privacy): Privacy Sandbox toggles

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -94,6 +94,16 @@ const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
 
+// Privacy Sandbox channels
+const CH_GET_TOPICS_ENABLED              = 'settings:get-topics-enabled';
+const CH_SET_TOPICS_ENABLED              = 'settings:set-topics-enabled';
+const CH_GET_PROTECTED_AUDIENCE_ENABLED  = 'settings:get-protected-audience-enabled';
+const CH_SET_PROTECTED_AUDIENCE_ENABLED  = 'settings:set-protected-audience-enabled';
+const CH_GET_ATTRIBUTION_REPORTING       = 'settings:get-attribution-reporting-enabled';
+const CH_SET_ATTRIBUTION_REPORTING       = 'settings:set-attribution-reporting-enabled';
+const CH_GET_FENCED_FRAMES_ENABLED       = 'settings:get-fenced-frames-enabled';
+const CH_SET_FENCED_FRAMES_ENABLED       = 'settings:set-fenced-frames-enabled';
+
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
 // ---------------------------------------------------------------------------
@@ -630,6 +640,79 @@ function handleSetGpcEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boole
   mainLogger.info(`${CH_SET_GPC_ENABLED}.ok`, { enabled });
 }
 
+
+// ---------------------------------------------------------------------------
+// Privacy Sandbox handlers (Topics, Protected Audience, Attribution Reporting, Fenced Frames)
+// ---------------------------------------------------------------------------
+
+function handleGetTopicsEnabled(): boolean {
+  mainLogger.info(CH_GET_TOPICS_ENABLED);
+  const prefs = readPrefs();
+  const enabled = prefs.topicsEnabled === true;
+  mainLogger.info(`${CH_GET_TOPICS_ENABLED}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetTopicsEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('topicsEnabled must be a boolean');
+  }
+  mainLogger.info(CH_SET_TOPICS_ENABLED, { enabled });
+  mergePrefs({ topicsEnabled: enabled });
+  mainLogger.info(`${CH_SET_TOPICS_ENABLED}.ok`, { enabled });
+}
+
+function handleGetProtectedAudienceEnabled(): boolean {
+  mainLogger.info(CH_GET_PROTECTED_AUDIENCE_ENABLED);
+  const prefs = readPrefs();
+  const enabled = prefs.protectedAudienceEnabled === true;
+  mainLogger.info(`${CH_GET_PROTECTED_AUDIENCE_ENABLED}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetProtectedAudienceEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('protectedAudienceEnabled must be a boolean');
+  }
+  mainLogger.info(CH_SET_PROTECTED_AUDIENCE_ENABLED, { enabled });
+  mergePrefs({ protectedAudienceEnabled: enabled });
+  mainLogger.info(`${CH_SET_PROTECTED_AUDIENCE_ENABLED}.ok`, { enabled });
+}
+
+function handleGetAttributionReportingEnabled(): boolean {
+  mainLogger.info(CH_GET_ATTRIBUTION_REPORTING);
+  const prefs = readPrefs();
+  const enabled = prefs.attributionReportingEnabled === true;
+  mainLogger.info(`${CH_GET_ATTRIBUTION_REPORTING}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetAttributionReportingEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('attributionReportingEnabled must be a boolean');
+  }
+  mainLogger.info(CH_SET_ATTRIBUTION_REPORTING, { enabled });
+  mergePrefs({ attributionReportingEnabled: enabled });
+  mainLogger.info(`${CH_SET_ATTRIBUTION_REPORTING}.ok`, { enabled });
+}
+
+function handleGetFencedFramesEnabled(): boolean {
+  mainLogger.info(CH_GET_FENCED_FRAMES_ENABLED);
+  const prefs = readPrefs();
+  const enabled = prefs.fencedFramesEnabled === true;
+  mainLogger.info(`${CH_GET_FENCED_FRAMES_ENABLED}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetFencedFramesEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('fencedFramesEnabled must be a boolean');
+  }
+  mainLogger.info(CH_SET_FENCED_FRAMES_ENABLED, { enabled });
+  mergePrefs({ fencedFramesEnabled: enabled });
+  mainLogger.info(`${CH_SET_FENCED_FRAMES_ENABLED}.ok`, { enabled });
+}
+
 // ---------------------------------------------------------------------------
 // Privacy header injection (DNT + GPC)
 // ---------------------------------------------------------------------------
@@ -719,10 +802,18 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_TOPICS_ENABLED,             handleGetTopicsEnabled);
+  ipcMain.handle(CH_SET_TOPICS_ENABLED,             handleSetTopicsEnabled);
+  ipcMain.handle(CH_GET_PROTECTED_AUDIENCE_ENABLED, handleGetProtectedAudienceEnabled);
+  ipcMain.handle(CH_SET_PROTECTED_AUDIENCE_ENABLED, handleSetProtectedAudienceEnabled);
+  ipcMain.handle(CH_GET_ATTRIBUTION_REPORTING,      handleGetAttributionReportingEnabled);
+  ipcMain.handle(CH_SET_ATTRIBUTION_REPORTING,      handleSetAttributionReportingEnabled);
+  ipcMain.handle(CH_GET_FENCED_FRAMES_ENABLED,      handleGetFencedFramesEnabled);
+  ipcMain.handle(CH_SET_FENCED_FRAMES_ENABLED,      handleSetFencedFramesEnabled);
 
   refreshPrivacyHeaders();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 33 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -753,6 +844,14 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_TOPICS_ENABLED);
+  ipcMain.removeHandler(CH_SET_TOPICS_ENABLED);
+  ipcMain.removeHandler(CH_GET_PROTECTED_AUDIENCE_ENABLED);
+  ipcMain.removeHandler(CH_SET_PROTECTED_AUDIENCE_ENABLED);
+  ipcMain.removeHandler(CH_GET_ATTRIBUTION_REPORTING);
+  ipcMain.removeHandler(CH_SET_ATTRIBUTION_REPORTING);
+  ipcMain.removeHandler(CH_GET_FENCED_FRAMES_ENABLED);
+  ipcMain.removeHandler(CH_SET_FENCED_FRAMES_ENABLED);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -200,6 +200,30 @@ export interface SettingsAPI {
   /** Set whether Global Privacy Control header is enabled */
   setGpcEnabled: (enabled: boolean) => Promise<void>;
 
+  /** Get whether Topics API (ad topics) is enabled — Privacy Sandbox */
+  getTopicsEnabled: () => Promise<boolean>;
+
+  /** Set whether Topics API (ad topics) is enabled — Privacy Sandbox */
+  setTopicsEnabled: (enabled: boolean) => Promise<void>;
+
+  /** Get whether Protected Audience API (site-suggested ads) is enabled — Privacy Sandbox */
+  getProtectedAudienceEnabled: () => Promise<boolean>;
+
+  /** Set whether Protected Audience API (site-suggested ads) is enabled — Privacy Sandbox */
+  setProtectedAudienceEnabled: (enabled: boolean) => Promise<void>;
+
+  /** Get whether Attribution Reporting API (ad measurement) is enabled — Privacy Sandbox */
+  getAttributionReportingEnabled: () => Promise<boolean>;
+
+  /** Set whether Attribution Reporting API (ad measurement) is enabled — Privacy Sandbox */
+  setAttributionReportingEnabled: (enabled: boolean) => Promise<void>;
+
+  /** Get whether Fenced Frames are enabled — Privacy Sandbox */
+  getFencedFramesEnabled: () => Promise<boolean>;
+
+  /** Set whether Fenced Frames are enabled — Privacy Sandbox */
+  setFencedFramesEnabled: (enabled: boolean) => Promise<void>;
+
   /** Get all global content category defaults */
   getContentCategoryDefaults: () => Promise<Record<ContentCategory, CategoryState>>;
 
@@ -433,6 +457,46 @@ const api: SettingsAPI = {
   setGpcEnabled: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setGpcEnabled', { enabled });
     await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
+  },
+
+  getTopicsEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getTopicsEnabled');
+    return ipcRenderer.invoke('settings:get-topics-enabled') as Promise<boolean>;
+  },
+
+  setTopicsEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setTopicsEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-topics-enabled', enabled);
+  },
+
+  getProtectedAudienceEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getProtectedAudienceEnabled');
+    return ipcRenderer.invoke('settings:get-protected-audience-enabled') as Promise<boolean>;
+  },
+
+  setProtectedAudienceEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setProtectedAudienceEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-protected-audience-enabled', enabled);
+  },
+
+  getAttributionReportingEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getAttributionReportingEnabled');
+    return ipcRenderer.invoke('settings:get-attribution-reporting-enabled') as Promise<boolean>;
+  },
+
+  setAttributionReportingEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setAttributionReportingEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-attribution-reporting-enabled', enabled);
+  },
+
+  getFencedFramesEnabled: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getFencedFramesEnabled');
+    return ipcRenderer.invoke('settings:get-fenced-frames-enabled') as Promise<boolean>;
+  },
+
+  setFencedFramesEnabled: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setFencedFramesEnabled', { enabled });
+    await ipcRenderer.invoke('settings:set-fenced-frames-enabled', enabled);
   },
 
   getContentCategoryDefaults: async (): Promise<Record<ContentCategory, CategoryState>> => {

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -35,6 +35,7 @@ const TAB_PASSWORDS    = 'passwords'        as const;
 const TAB_ZOOM         = 'site-zoom'        as const;
 const TAB_CONTENT      = 'content'          as const;
 const TAB_PERMISSIONS  = 'permissions'     as const;
+const TAB_AD_PRIVACY   = 'ad-privacy'       as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -47,6 +48,7 @@ type TabId =
   | typeof TAB_ZOOM
   | typeof TAB_CONTENT
   | typeof TAB_PERMISSIONS
+  | typeof TAB_AD_PRIVACY
   | typeof TAB_DANGER;
 
 const TABS: Array<{ id: TabId; label: string }> = [
@@ -60,6 +62,7 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_ZOOM,       label: 'Site Zoom' },
   { id: TAB_CONTENT,    label: 'Content' },
   { id: TAB_PERMISSIONS, label: 'Permissions' },
+  { id: TAB_AD_PRIVACY,  label: 'Ad privacy' },
   { id: TAB_DANGER,     label: 'Danger Zone' },
 ];
 
@@ -158,6 +161,14 @@ declare global {
       setDntEnabled: (enabled: boolean) => Promise<void>;
       getGpcEnabled: () => Promise<boolean>;
       setGpcEnabled: (enabled: boolean) => Promise<void>;
+      getTopicsEnabled: () => Promise<boolean>;
+      setTopicsEnabled: (enabled: boolean) => Promise<void>;
+      getProtectedAudienceEnabled: () => Promise<boolean>;
+      setProtectedAudienceEnabled: (enabled: boolean) => Promise<void>;
+      getAttributionReportingEnabled: () => Promise<boolean>;
+      setAttributionReportingEnabled: (enabled: boolean) => Promise<void>;
+      getFencedFramesEnabled: () => Promise<boolean>;
+      setFencedFramesEnabled: (enabled: boolean) => Promise<void>;
       getContentCategoryDefaults: () => Promise<Record<string, string>>;
       setContentCategoryDefault: (category: string, state: string) => Promise<void>;
       getContentCategorySite: (origin: string) => Promise<Array<{ origin: string; category: string; state: string; updatedAt: number }>>;
@@ -2032,6 +2043,134 @@ function DangerZoneTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Ad privacy tab — Privacy Sandbox toggles (issue #65)
+// ---------------------------------------------------------------------------
+
+const AD_PRIVACY_TOGGLES = [
+  {
+    key: 'topics'             as const,
+    label: 'Ad topics',
+    description:
+      'Allow sites to use the Topics API to suggest ads based on browsing interests. ' +
+      'Topics are derived locally on your device and shared with participating sites.',
+    getter: 'getTopicsEnabled'              as const,
+    setter: 'setTopicsEnabled'              as const,
+  },
+  {
+    key: 'protectedAudience'  as const,
+    label: 'Site-suggested ads',
+    description:
+      'Allow sites to use the Protected Audience API to show ads based on previous ' +
+      'site visits. Ad auctions run locally on your device without sharing browsing history.',
+    getter: 'getProtectedAudienceEnabled'   as const,
+    setter: 'setProtectedAudienceEnabled'   as const,
+  },
+  {
+    key: 'attributionReporting' as const,
+    label: 'Ad measurement',
+    description:
+      'Allow sites to use the Attribution Reporting API to measure ad effectiveness. ' +
+      'Reports are generated privately on your device; no cross-site data is shared.',
+    getter: 'getAttributionReportingEnabled' as const,
+    setter: 'setAttributionReportingEnabled' as const,
+  },
+  {
+    key: 'fencedFrames'       as const,
+    label: 'Fenced frames',
+    description:
+      'Allow sites to load ad content in isolated fenced frames that cannot communicate ' +
+      'with the surrounding page, protecting your browsing data from advertisers.',
+    getter: 'getFencedFramesEnabled'        as const,
+    setter: 'setFencedFramesEnabled'        as const,
+  },
+] as const;
+
+type AdPrivacyKey = typeof AD_PRIVACY_TOGGLES[number]['key'];
+
+function AdPrivacyTab(): React.ReactElement {
+  const toast = useToast();
+  const [values, setValues] = useState<Record<AdPrivacyKey, boolean>>({
+    topics: false,
+    protectedAudience: false,
+    attributionReporting: false,
+    fencedFrames: false,
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void Promise.all(
+      AD_PRIVACY_TOGGLES.map((t) => window.settingsAPI[t.getter]()),
+    ).then(([topics, protectedAudience, attributionReporting, fencedFrames]) => {
+      setValues({ topics, protectedAudience, attributionReporting, fencedFrames });
+      setLoading(false);
+    }).catch(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleToggle(key: AdPrivacyKey, checked: boolean): Promise<void> {
+    setValues((prev) => ({ ...prev, [key]: checked }));
+    const toggle = AD_PRIVACY_TOGGLES.find((t) => t.key === key);
+    if (!toggle) return;
+    try {
+      await window.settingsAPI[toggle.setter](checked);
+      toast.show({
+        variant: 'success',
+        title: checked ? `${toggle.label} enabled` : `${toggle.label} disabled`,
+      });
+    } catch (err) {
+      setValues((prev) => ({ ...prev, [key]: !checked }));
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="settings-section">
+        <h2 className="settings-section-title">Ad privacy</h2>
+        <div className="settings-loading">
+          <Spinner size="md" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Ad privacy</h2>
+      <p className="settings-section-desc">
+        These settings control Privacy Sandbox APIs that let sites show relevant
+        ads without third-party tracking. All processing happens locally on your
+        device.
+      </p>
+
+      {AD_PRIVACY_TOGGLES.map((toggle) => (
+        <Card key={toggle.key} variant="default" padding="md" className="settings-card">
+          <div className="settings-toggle-row">
+            <div className="settings-toggle-info">
+              <span className="settings-toggle-label">{toggle.label}</span>
+              <span className="settings-toggle-desc">{toggle.description}</span>
+            </div>
+            <label className="settings-toggle">
+              <input
+                type="checkbox"
+                checked={values[toggle.key]}
+                onChange={(e) => void handleToggle(toggle.key, e.target.checked)}
+              />
+              <span className="settings-toggle-track" />
+            </label>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Inner app (uses useToast — must be inside ToastProvider)
 // ---------------------------------------------------------------------------
 
@@ -2093,6 +2232,7 @@ function SettingsInner(): React.ReactElement {
     [TAB_PRIVACY]:    <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
     [TAB_ZOOM]:       <SiteZoomTab />,
     [TAB_PERMISSIONS]: <PermissionsTab />,
+    [TAB_AD_PRIVACY]:  <AdPrivacyTab />,
     [TAB_CONTENT]:    <ContentCategoriesTab />,
     [TAB_DANGER]:     <DangerZoneTab />,
   };


### PR DESCRIPTION
Closes #65

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Privacy Sandbox toggles in Settings to control ad privacy features, closing #65. Users can enable Topics, Protected Audience, Attribution Reporting, and Fenced Frames from a new Ad privacy tab.

- New Features
  - Added “Ad privacy” tab with four toggles (Topics, Protected Audience, Attribution Reporting, Fenced Frames).
  - Persist each toggle in preferences via `mergePrefs()` and expose get/set IPC handlers in `my-app/src/main/settings/ipc.ts`.
  - Added preload bridge methods in `my-app/src/preload/settings.ts` and wired UI in `SettingsApp.tsx` with optimistic updates and toasts.

<sup>Written for commit 0cbdbdd90cd5876e5173460346e9302bd7446927. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

