### PR TITLE
feat(security): mixed content handling

### DIFF
--- a/my-app/src/main/mixed-content/MixedContentController.ts
+++ b/my-app/src/main/mixed-content/MixedContentController.ts
@@ -1,0 +1,152 @@
+/**
+ * MixedContentController — mixed content detection and per-site exception storage.
+ *
+ * Mixed content definitions (aligned with Chrome/spec):
+ *   Active mixed content  — script, iframe, XHR, object, embed loaded over HTTP
+ *                           while the page is HTTPS. Chromium blocks these by default.
+ *   Passive mixed content — images, audio, video loaded over HTTP on an HTTPS page.
+ *                           Chromium allows these but downgrades the security indicator.
+ *
+ * What this controller does:
+ *   1. Parses Chromium console-messages that start with the known mixed-content prefix
+ *      and classifies them as active vs passive.
+ *   2. Persists per-site exceptions (origin → 'allow') in preferences.json so the user
+ *      can grant explicit exceptions from the Site Settings panel.
+ *   3. Exposes helpers for the preload/IPC layers to read/write those exceptions.
+ *
+ * Console message format injected by Chromium:
+ *   "Mixed Content: The page at 'https://example.com' was loaded over HTTPS, but
+ *    requested an insecure <type> '<url>'. ..."
+ *
+ * Detection relies on the well-known Chromium log lines. See:
+ *   https://developer.chrome.com/docs/web-platform/mixed-content
+ */
+
+import { mainLogger } from '../logger';
+import { readPrefs, mergePrefs } from '../settings/ipc';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIXED_CONTENT_LOG_PREFIX = 'Mixed Content:';
+
+// Passive resource types mentioned in the Chromium mixed-content log lines.
+// Everything else (script, stylesheet, iframe, XHR, fetch, object, embed)
+// is treated as active.
+const PASSIVE_RESOURCE_TYPES = new Set([
+  'image',
+  'video',
+  'audio',
+  'img',
+  'source',
+]);
+
+// Regexp to extract the resource type from a Chromium mixed-content log line.
+// Example: "...but requested an insecure image 'http://...'"
+// Example: "...but requested an insecure script 'http://...'"
+const RESOURCE_TYPE_RE = /but requested an insecure (\w+)\b/i;
+
+// Prefs key for per-site exceptions: Record<origin, 'allow'>
+const PREFS_KEY = 'mixedContentExceptions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MixedContentLevel = 'none' | 'passive' | 'active';
+
+export interface MixedContentStatus {
+  level: MixedContentLevel;
+  /** True if the user has explicitly allowed mixed content for this origin. */
+  hasException: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Per-site exception storage (backed by preferences.json)
+// ---------------------------------------------------------------------------
+
+function loadExceptions(): Record<string, 'allow'> {
+  try {
+    const prefs = readPrefs();
+    const raw = prefs[PREFS_KEY];
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      return raw as Record<string, 'allow'>;
+    }
+  } catch {
+    // fall through
+  }
+  return {};
+}
+
+function saveExceptions(exceptions: Record<string, 'allow'>): void {
+  mergePrefs({ [PREFS_KEY]: exceptions });
+}
+
+/**
+ * Grant a per-site exception: allow mixed content for the given origin.
+ */
+export function allowMixedContentForOrigin(origin: string): void {
+  mainLogger.info('MixedContentController.allowForOrigin', { origin });
+  const exceptions = loadExceptions();
+  exceptions[origin] = 'allow';
+  saveExceptions(exceptions);
+}
+
+/**
+ * Revoke a per-site exception for the given origin.
+ */
+export function revokeMixedContentException(origin: string): boolean {
+  const exceptions = loadExceptions();
+  if (!(origin in exceptions)) return false;
+  delete exceptions[origin];
+  saveExceptions(exceptions);
+  mainLogger.info('MixedContentController.revokeException', { origin });
+  return true;
+}
+
+/**
+ * Returns true if the user has granted an explicit mixed-content exception
+ * for the given origin.
+ */
+export function hasMixedContentException(origin: string): boolean {
+  const exceptions = loadExceptions();
+  return exceptions[origin] === 'allow';
+}
+
+/**
+ * Returns all origins that have mixed-content exceptions.
+ */
+export function getAllMixedContentExceptions(): string[] {
+  return Object.keys(loadExceptions());
+}
+
+// ---------------------------------------------------------------------------
+// Console message analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Inspect a console-message string from a WebContents and determine whether
+ * it is a Chromium mixed-content warning. Returns the level if it is one,
+ * or 'none' if it is unrelated to mixed content.
+ */
+export function classifyMixedContentMessage(message: string): MixedContentLevel {
+  if (!message.startsWith(MIXED_CONTENT_LOG_PREFIX)) return 'none';
+
+  const match = RESOURCE_TYPE_RE.exec(message);
+  if (!match) {
+    // Unknown format — treat conservatively as active.
+    mainLogger.debug('MixedContentController.classify.unknownFormat', {
+      preview: message.slice(0, 120),
+    });
+    return 'active';
+  }
+
+  const resourceType = match[1].toLowerCase();
+  const level: MixedContentLevel = PASSIVE_RESOURCE_TYPES.has(resourceType)
+    ? 'passive'
+    : 'active';
+
+  mainLogger.info('MixedContentController.classify', { resourceType, level });
+  return level;
+}

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -25,6 +25,12 @@ import {
   type ClearDataResult,
 } from '../privacy/ClearDataController';
 import { isBiometricAvailable } from '../passwords/BiometricAuth';
+import {
+  allowMixedContentForOrigin,
+  revokeMixedContentException,
+  hasMixedContentException,
+  getAllMixedContentExceptions,
+} from '../mixed-content/MixedContentController';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -93,6 +99,9 @@ const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_MIXED_CONTENT_EXCEPTIONS = 'settings:get-mixed-content-exceptions';
+const CH_SET_MIXED_CONTENT_EXCEPTION  = 'settings:set-mixed-content-exception';
+const CH_REMOVE_MIXED_CONTENT_EXCEPTION = 'settings:remove-mixed-content-exception';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -145,7 +154,7 @@ export function readPrefs(): Preferences {
   }
 }
 
-function mergePrefs(patch: Partial<Preferences>): void {
+export function mergePrefs(patch: Partial<Preferences>): void {
   const prefsPath = getPrefsPath();
   const existing = readPrefs();
   const merged = { ...existing, ...patch };
@@ -683,6 +692,39 @@ function handleCloseWindow(): void {
 // Public API
 // ---------------------------------------------------------------------------
 
+function handleGetMixedContentExceptions(): string[] {
+  mainLogger.info(CH_GET_MIXED_CONTENT_EXCEPTIONS);
+  const origins = getAllMixedContentExceptions();
+  mainLogger.info(`${CH_GET_MIXED_CONTENT_EXCEPTIONS}.ok`, { count: origins.length });
+  return origins;
+}
+
+function handleSetMixedContentException(
+  _event: Electron.IpcMainInvokeEvent,
+  origin: string,
+  allow: boolean,
+): void {
+  const validated = assertString(origin, 'origin', 512);
+  mainLogger.info(CH_SET_MIXED_CONTENT_EXCEPTION, { origin: validated, allow });
+  if (allow) {
+    allowMixedContentForOrigin(validated);
+  } else {
+    revokeMixedContentException(validated);
+  }
+  mainLogger.info(`${CH_SET_MIXED_CONTENT_EXCEPTION}.ok`, { origin: validated, allow });
+}
+
+function handleRemoveMixedContentException(
+  _event: Electron.IpcMainInvokeEvent,
+  origin: string,
+): boolean {
+  const validated = assertString(origin, 'origin', 512);
+  mainLogger.info(CH_REMOVE_MIXED_CONTENT_EXCEPTION, { origin: validated });
+  const removed = revokeMixedContentException(validated);
+  mainLogger.info(`${CH_REMOVE_MIXED_CONTENT_EXCEPTION}.ok`, { origin: validated, removed });
+  return removed;
+}
+
 export interface RegisterSettingsHandlersOptions {
   accountStore:  AccountStore;
   keychainStore: KeychainStore;
@@ -719,6 +761,9 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_MIXED_CONTENT_EXCEPTIONS,  handleGetMixedContentExceptions);
+  ipcMain.handle(CH_SET_MIXED_CONTENT_EXCEPTION,   handleSetMixedContentException);
+  ipcMain.handle(CH_REMOVE_MIXED_CONTENT_EXCEPTION, handleRemoveMixedContentException);
 
   refreshPrivacyHeaders();
 
@@ -753,6 +798,9 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_MIXED_CONTENT_EXCEPTIONS);
+  ipcMain.removeHandler(CH_SET_MIXED_CONTENT_EXCEPTION);
+  ipcMain.removeHandler(CH_REMOVE_MIXED_CONTENT_EXCEPTION);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -44,6 +44,12 @@ import {
   type ThreatType,
 } from '../safebrowsing/SafeBrowsingController';
 
+import {
+  classifyMixedContentMessage,
+  hasMixedContentException,
+  type MixedContentLevel,
+} from '../mixed-content/MixedContentController';
+
 // Forge VitePlugin globals for the new-tab page (injected at build time)
 declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
 declare const NEWTAB_VITE_NAME: string | undefined;
@@ -76,6 +82,9 @@ export interface TabState {
   zoomLevel: number;
   pinned: boolean;
   audible: boolean;
+  /** 'none' = fully secure, 'passive' = passive mixed content (images/video/audio),
+   *  'active' = active mixed content (scripts/iframes/XHR) — Chromium blocks active. */
+  mixedContent: MixedContentLevel;
 }
 
 export interface TabManagerState {
@@ -1459,6 +1468,8 @@ export class TabManager {
 
     wc.on('did-navigate', (_e, url) => {
       mainLogger.info('TabManager.tab.navigate', { tabId, url });
+      // Reset mixed-content status on full navigation.
+      this.mixedContentLevels.delete(tabId);
       if (url.startsWith('https://')) {
         clearPendingUpgrade(tabId);
       }
@@ -1544,6 +1555,25 @@ export class TabManager {
         mainLogger.info('TabManager.tab.safeBrowsingBack', { tabId });
         return;
       }
+      // Mixed content detection: Chromium emits well-known console messages for
+      // both passive (image/video/audio) and active (script/iframe/XHR) mixed content.
+      const mcLevel = classifyMixedContentMessage(message);
+      if (mcLevel !== 'none') {
+        const currentLevel = this.mixedContentLevels.get(tabId) ?? 'none';
+        // Upgrade level: active > passive > none
+        if (mcLevel === 'active' || currentLevel === 'none') {
+          this.mixedContentLevels.set(tabId, mcLevel);
+          mainLogger.info('TabManager.tab.mixedContent', { tabId, level: mcLevel });
+          this.sendTabUpdate(tabId);
+        }
+        // Emit developer console warning (separate from Chromium's own warning).
+        mainLogger.debug('TabManager.tab.mixedContent.warn', {
+          tabId,
+          level: mcLevel,
+          url: wc.getURL(),
+        });
+      }
+
       if (!message.startsWith(FORM_DETECTOR_PREFIX)) return;
       try {
         const json = message.slice(FORM_DETECTOR_PREFIX.length);
@@ -1596,6 +1626,7 @@ export class TabManager {
     // Handle target_lost for active tab agent enforcement
     wc.on('destroyed', () => {
       mainLogger.info('TabManager.tab.destroyed', { tabId });
+      this.mixedContentLevels.delete(tabId);
       if (!this.win.isDestroyed() && !this.win.webContents.isDestroyed()) {
         this.win.webContents.send('target-lost', { tabId });
       }
@@ -1674,6 +1705,7 @@ export class TabManager {
       zoomLevel: view.webContents.getZoomLevel(),
       pinned: this.pinnedTabs.has(tabId),
       audible: view.webContents.isCurrentlyAudible(),
+      mixedContent: this.mixedContentLevels.get(tabId) ?? 'none',
     };
     this.safeSend('tab-updated', state);
   }

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -223,6 +223,14 @@ export interface SettingsAPI {
 
   /** Reset all per-site overrides */
   resetAllContentCategoryOverrides: () => Promise<void>;
+
+  // Mixed content exceptions
+  /** List all origins that have a mixed-content exception */
+  getMixedContentExceptions: () => Promise<string[]>;
+  /** Grant or revoke a mixed-content exception for an origin */
+  setMixedContentException: (origin: string, allow: boolean) => Promise<void>;
+  /** Remove a mixed-content exception for an origin; returns true if it existed */
+  removeMixedContentException: (origin: string) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------
@@ -473,6 +481,21 @@ const api: SettingsAPI = {
   resetAllContentCategoryOverrides: async (): Promise<void> => {
     console.debug('[settings-preload] resetAllContentCategoryOverrides');
     await ipcRenderer.invoke('content-categories:reset-all');
+  },
+
+  getMixedContentExceptions: async (): Promise<string[]> => {
+    console.debug('[settings-preload] getMixedContentExceptions');
+    return ipcRenderer.invoke('settings:get-mixed-content-exceptions') as Promise<string[]>;
+  },
+
+  setMixedContentException: async (origin: string, allow: boolean): Promise<void> => {
+    console.debug('[settings-preload] setMixedContentException', { origin, allow });
+    await ipcRenderer.invoke('settings:set-mixed-content-exception', origin, allow);
+  },
+
+  removeMixedContentException: async (origin: string): Promise<boolean> => {
+    console.debug('[settings-preload] removeMixedContentException', { origin });
+    return ipcRenderer.invoke('settings:remove-mixed-content-exception', origin) as Promise<boolean>;
   },
 
 };

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -166,6 +166,9 @@ declare global {
       getAllContentCategoryOverrides: () => Promise<Array<{ origin: string; category: string; state: string; updatedAt: number }>>;
       clearContentCategoryOrigin: (origin: string) => Promise<void>;
       resetAllContentCategoryOverrides: () => Promise<void>;
+      getMixedContentExceptions: () => Promise<string[]>;
+      setMixedContentException: (origin: string, allow: boolean) => Promise<void>;
+      removeMixedContentException: (origin: string) => Promise<boolean>;
       scanAutoRevokePermissions: () => Promise<{
         candidates: Array<{
           origin: string;
@@ -764,6 +767,81 @@ function ProfilesTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Mixed content exceptions sub-section (used inside PrivacyTab)
+// ---------------------------------------------------------------------------
+
+function MixedContentSection(): React.ReactElement {
+  const toast = useToast();
+  const [exceptions, setExceptions] = React.useState<string[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  const loadExceptions = React.useCallback(async () => {
+    try {
+      const origins = await window.settingsAPI.getMixedContentExceptions();
+      setExceptions(origins);
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to load mixed content exceptions', message: (err as Error).message });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => { void loadExceptions(); }, [loadExceptions]);
+
+  async function handleRemove(origin: string): Promise<void> {
+    try {
+      await window.settingsAPI.removeMixedContentException(origin);
+      setExceptions((prev) => prev.filter((o) => o !== origin));
+      toast.show({ variant: 'success', title: 'Exception removed', message: origin });
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to remove exception', message: (err as Error).message });
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-loading"><Spinner size="md" /></div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="default" padding="none" className="settings-card">
+      <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--color-border-subtle)' }}>
+        <p style={{ fontWeight: 600, marginBottom: 4 }}>Mixed content exceptions</p>
+        <p style={{ fontSize: 13, color: 'var(--color-fg-secondary)' }}>
+          Sites below are allowed to load passive mixed content (images, video, audio over HTTP)
+          without a security warning. Active mixed content (scripts, iframes, XHR) is always blocked.
+        </p>
+      </div>
+      {exceptions.length === 0 ? (
+        <div style={{ padding: 16, color: 'var(--color-fg-tertiary)', fontSize: 13 }}>
+          No exceptions. Sites that load passive mixed content will show a "Not secure" chip in the address bar.
+        </div>
+      ) : (
+        exceptions.map((origin, idx) => (
+          <div
+            key={origin}
+            className={`settings-scope-row ${idx < exceptions.length - 1 ? 'settings-scope-row--bordered' : ''}`}
+          >
+            <div className="settings-scope-info">
+              <span className="settings-scope-label">{origin}</span>
+              <span className="settings-scope-name">Allowed to load passive mixed content</span>
+            </div>
+            <div className="settings-scope-actions">
+              <Button variant="ghost" size="sm" onClick={() => void handleRemove(origin)}>
+                Remove
+              </Button>
+            </div>
+          </div>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Privacy and security tab
 // ---------------------------------------------------------------------------
 
@@ -953,6 +1031,11 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
           </Button>
         </div>
       </Card>
+
+      <h3 className="settings-section-title" style={{ marginTop: 24, fontSize: 14 }}>
+        Site settings
+      </h3>
+      <MixedContentSection />
 
       <ClearDataDialog
         open={openDialog}

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -19,6 +19,8 @@ const INSECURE_RE = /^http:\/\//i;
 // renders them as empty so the "Search or enter address" placeholder shows.
 const BLANK_RE = /^(data:|about:blank$)/i;
 
+type MixedContentLevel = 'none' | 'passive' | 'active';
+
 interface URLBarProps {
   url: string;
   isLoading: boolean;
@@ -27,6 +29,8 @@ interface URLBarProps {
   onFocusClear: () => void;
   isBookmarked: boolean;
   onToggleBookmark: () => void;
+  /** Mixed-content status for the active tab. 'passive' shows 'Not secure' chip. */
+  mixedContent?: MixedContentLevel;
 }
 
 function getSecurityStatus(url: string): 'secure' | 'insecure' | 'none' {
@@ -58,6 +62,7 @@ export function URLBar({
   onFocusClear,
   isBookmarked,
   onToggleBookmark,
+  mixedContent = 'none',
 }: URLBarProps): React.ReactElement {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(() => displayUrl(url));
@@ -119,14 +124,28 @@ export function URLBar({
   );
 
   const security = getSecurityStatus(url);
+  // Show 'Not secure' chip for passive mixed content on HTTPS pages.
+  // Active mixed content is blocked by Chromium so no extra UI is needed beyond
+  // the existing insecure indicator (though we still downgrade the visual).
+  const effectiveSecurity: 'secure' | 'insecure' | 'none' | 'mixed-passive' =
+    security === 'secure' && mixedContent === 'passive'
+      ? 'mixed-passive'
+      : security === 'secure' && mixedContent === 'active'
+        ? 'insecure'
+        : security;
   // Hide the star on blank/new-tab URLs — nothing meaningful to bookmark.
   const starVisible = !!url && !BLANK_RE.test(url);
 
   return (
-    <div className={`url-bar url-bar--${security}`}>
+    <div className={`url-bar url-bar--${effectiveSecurity}`}>
       {/* Security icon */}
-      <span className="url-bar__security" aria-label={security}>
-        {security === 'secure' && (
+      <span className="url-bar__security" aria-label={effectiveSecurity}>
+        {effectiveSecurity === 'mixed-passive' && (
+          <span className="url-bar__chip url-bar__chip--warn" title="This page contains insecure content (images, video, or audio loaded over HTTP)">
+            Not secure
+          </span>
+        )}
+        {effectiveSecurity === 'secure' && (
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
             <rect x="2" y="5" width="8" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
             <path
@@ -137,7 +156,7 @@ export function URLBar({
             />
           </svg>
         )}
-        {security === 'insecure' && (
+        {(effectiveSecurity === 'insecure') && (
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
             <path
               d="M6 2L10.5 10H1.5L6 2Z"

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -538,6 +538,7 @@ export function WindowChrome(): React.ReactElement {
           onFocusClear={handleUrlFocusClear}
           isBookmarked={!!existingBookmark}
           onToggleBookmark={handleStarClick}
+          mixedContent={activeTab?.mixedContent ?? 'none'}
         />
 
         {zoomPercent !== 100 && (

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -362,6 +362,29 @@
   color: var(--color-fg-tertiary);
 }
 
+.url-bar--mixed-passive .url-bar__security {
+  color: var(--color-status-warning, #e8a020);
+}
+
+/* "Not secure" chip shown for passive mixed content */
+.url-bar__chip {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.url-bar__chip--warn {
+  background: rgba(232, 160, 32, 0.14);
+  color: var(--color-status-warning, #e8a020);
+  border: 1px solid rgba(232, 160, 32, 0.28);
+}
+
 .url-bar__security {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Adds `MixedContentController` that parses Chromium console-message warnings and classifies them as `active` (script/iframe/XHR — blocked by Chromium) or `passive` (images/video/audio — allowed but warned)
- Wires detection into `TabManager`: per-tab mixed-content level is tracked, reset on navigation, and included in `TabState` sent to the renderer
- `URLBar` shows an amber **"Not secure"** chip for passive mixed content on HTTPS pages; degrades to the red insecure indicator for active mixed content
- Settings → Privacy tab gains a **Mixed content exceptions** panel: list and remove per-site exceptions persisted in `preferences.json`
- Full IPC chain: `MixedContentController` → `settings/ipc.ts` handlers → `preload/settings.ts` → `SettingsApp.tsx`

## Test plan

- [ ] Load an HTTPS page with passive mixed content (e.g. HTTP image) — URL bar shows amber "Not secure" chip
- [ ] Load an HTTPS page with active mixed content (e.g. HTTP script) — URL bar degrades to insecure/red indicator (Chromium blocks the request)
- [ ] Developer console shows Chromium's built-in mixed-content warning on affected pages
- [ ] Open Settings → Privacy and security → Mixed content exceptions — section renders
- [ ] After granting an exception via `setMixedContentException`, it appears in the list and persists across sessions (stored in preferences.json)
- [ ] Clicking Remove on an exception calls `removeMixedContentException` and the row disappears
- [ ] Navigating away from a mixed-content page resets the URL bar chip

Closes #63

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mixed content detection and UI that align with Chrome: warn for passive content and degrade security for active content. Addresses issue #63 by surfacing clear URL bar signals and adding per-site exception management.

- **New Features**
  - Detects mixed content by parsing Chromium console messages and classifies it as active or passive.
  - Tracks per-tab mixed-content level in `TabState`; resets on navigation.
  - Shows an amber “Not secure” chip for passive mixed content on HTTPS pages; active mixed content downgrades to the insecure indicator.
  - Adds a Mixed content exceptions panel in Settings → Privacy to list and remove per-site exceptions, persisted in `preferences.json`.
  - Wires new IPC and preload APIs to get/set/remove exceptions end-to-end.

<sup>Written for commit 97474e5d17aca32cf504387d36dc31bf4802a4f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

