### PR TITLE
feat(ui): status bar on link hover

### DIFF
--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -1600,6 +1600,14 @@ export class TabManager {
       this.safeSend('find-result', payload);
     });
 
+    // Issue #86 — Status bar: forward hovered link URL to shell renderer.
+    // Only emit for the active tab so inactive tabs don't clobber the bar.
+    wc.on('update-target-url', (_e, url) => {
+      if (tabId !== this.activeTabId) return;
+      mainLogger.debug('TabManager.tab.updateTargetUrl', { tabId, url: url.slice(0, 120) });
+      this.safeSend('link-hover', { url });
+    });
+
     // Handle target_lost for active tab agent enforcement
     wc.on('destroyed', () => {
       mainLogger.info('TabManager.tab.destroyed', { tabId });

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -607,6 +607,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('device-picker-dismiss', handler);
       return () => ipcRenderer.removeListener('device-picker-dismiss', handler);
     },
+
+    // Issue #86 — Status bar: hovered link URL from the active tab's webContents
+    linkHover: (
+      cb: (payload: { url: string }) => void,
+    ): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, payload: { url: string }) => cb(payload);
+      ipcRenderer.on('link-hover', handler);
+      return () => ipcRenderer.removeListener('link-hover', handler);
+    },
   },
 
   // Profiles — current profile info + switch

--- a/my-app/src/renderer/shell/StatusBar.tsx
+++ b/my-app/src/renderer/shell/StatusBar.tsx
@@ -1,0 +1,20 @@
+/**
+ * StatusBar — Issue #86
+ * Chrome-parity bottom-left URL preview that appears while hovering a link.
+ * Renders only when a non-empty hovered URL is provided.
+ */
+
+import React from 'react';
+
+interface StatusBarProps {
+  url: string;
+}
+
+export function StatusBar({ url }: StatusBarProps): React.ReactElement | null {
+  if (!url) return null;
+  return (
+    <div className="status-bar" role="status" aria-live="polite">
+      <span className="status-bar__url">{url}</span>
+    </div>
+  );
+}

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -11,6 +11,7 @@ import { URLBar } from './URLBar';
 import { BookmarksBar } from './BookmarksBar';
 import { BookmarkDialog } from './BookmarkDialog';
 import { FindBar } from './FindBar';
+import { StatusBar } from './StatusBar';
 import { PasswordPromptBar } from './PasswordPromptBar';
 import { PermissionBar } from './PermissionBar';
 import { DevicePickerBar } from './DevicePickerBar';
@@ -141,6 +142,7 @@ declare const electronAPI: {
     downloadProgress: (cb: (dl: DownloadItemDTO) => void) => () => void;
     downloadDone: (cb: (dl: DownloadItemDTO) => void) => () => void;
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
+    linkHover: (cb: (payload: { url: string }) => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -161,6 +163,7 @@ export function WindowChrome(): React.ReactElement {
   const [tabs, setTabs] = useState<TabState[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [urlBarFocused, setUrlBarFocused] = useState(false);
+  const [hoveredUrl, setHoveredUrl] = useState('');
   const [zoomPercent, setZoomPercent] = useState(100);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -283,6 +286,10 @@ export function WindowChrome(): React.ReactElement {
       setUrlBarFocused(true);
     });
 
+    const unsubLinkHover = electronAPI.on.linkHover(({ url }) => {
+      setHoveredUrl(url);
+    });
+
     const unsubZoomChanged = electronAPI.on.zoomChanged(({ percent }) => {
       setZoomPercent(percent);
     });
@@ -315,6 +322,7 @@ export function WindowChrome(): React.ReactElement {
       unsubTabActivated();
       unsubFaviconUpdated();
       unsubFocusUrl();
+      unsubLinkHover();
       unsubZoomChanged();
       unsubTargetLost();
       unsubBookmarksUpdated();
@@ -616,6 +624,7 @@ export function WindowChrome(): React.ReactElement {
       <DevicePickerBar />
       <PasswordPromptBar activeTabId={activeTabId} />
       <FindBar activeTabId={activeTabId} />
+      <StatusBar url={hoveredUrl} />
     </div>
   );
 }

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -1796,3 +1796,35 @@
   pointer-events: none;
   opacity: 0.9;
 }
+
+/* ---------------------------------------------------------------------------
+   StatusBar — Issue #86: bottom-left URL preview on link hover
+   Positioned fixed so it overlays page content, matching Chrome behaviour.
+   Not shown inside PWA windows (handled by omitting the component there).
+   --------------------------------------------------------------------------- */
+.status-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  max-width: 60%;
+  height: 20px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  background: var(--color-bg-elevated);
+  border-top: 1px solid var(--color-border-subtle);
+  border-right: 1px solid var(--color-border-subtle);
+  border-top-right-radius: var(--radius-sm);
+  z-index: 9998;
+  pointer-events: none;
+}
+
+.status-bar__url {
+  font-size: 11px;
+  color: var(--color-fg-secondary);
+  font-family: var(--font-ui);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1;
+}


### PR DESCRIPTION
Closes #86

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chrome-style status bar that shows the hovered link URL at the bottom-left of the window. Implements the link-hover status preview requested in Linear #86.

- **New Features**
  - Emits the hovered link URL from the active tab (`update-target-url`) and forwards it to the shell via IPC `link-hover`.
  - Exposes `electronAPI.on.linkHover` in preload for renderer subscriptions.
  - Adds a `StatusBar` component and styles; shows while hovering and hides otherwise.
  - Integrates into `WindowChrome` with `hoveredUrl` state and proper listener cleanup.
  - Not displayed in PWA windows.

<sup>Written for commit ded527ad7e81c2b494d8b306eab60c8819a29ec2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

