### PR TITLE
feat(devtools): remote debugging chrome://inspect

### DIFF
--- a/my-app/src/main/chrome/ipc.ts
+++ b/my-app/src/main/chrome/ipc.ts
@@ -1,10 +1,102 @@
 /**
  * IPC handlers for chrome:// internal pages.
- * Exposes version, GPU, accessibility, and sandbox info to the renderer.
+ * Exposes version, GPU, accessibility, sandbox, and remote inspect info to the renderer.
  */
 
 import { app, ipcMain } from 'electron';
+import http from 'node:http';
 import { mainLogger } from '../logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InspectTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+  devtoolsFrontendUrl?: string;
+  description?: string;
+  host: string;
+  port: number;
+}
+
+export interface NetworkTarget {
+  host: string;
+  port: number;
+}
+
+// ---------------------------------------------------------------------------
+// Network targets persistence (in-memory for session lifetime)
+// ---------------------------------------------------------------------------
+
+const networkTargets: NetworkTarget[] = [
+  { host: 'localhost', port: 9222 },
+];
+
+// ---------------------------------------------------------------------------
+// HTTP helper: fetch JSON from a remote debugging endpoint
+// ---------------------------------------------------------------------------
+
+function fetchJsonFromTarget(host: string, port: number, urlPath: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: host,
+      port,
+      path: urlPath,
+      method: 'GET',
+      timeout: 3000,
+    };
+    const req = http.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (err) {
+          reject(new Error(`JSON parse error from ${host}:${port}${urlPath}: ${String(err)}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error(`Timeout connecting to ${host}:${port}`));
+    });
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Discover targets from a single host:port
+// ---------------------------------------------------------------------------
+
+async function discoverTargets(host: string, port: number): Promise<InspectTarget[]> {
+  try {
+    const raw = await fetchJsonFromTarget(host, port, '/json');
+    if (!Array.isArray(raw)) return [];
+    return (raw as Record<string, unknown>[]).map((t) => ({
+      id: String(t.id ?? ''),
+      type: String(t.type ?? 'page'),
+      title: String(t.title ?? t.url ?? ''),
+      url: String(t.url ?? ''),
+      webSocketDebuggerUrl: t.webSocketDebuggerUrl ? String(t.webSocketDebuggerUrl) : undefined,
+      devtoolsFrontendUrl: t.devtoolsFrontendUrl ? String(t.devtoolsFrontendUrl) : undefined,
+      description: t.description ? String(t.description) : undefined,
+      host,
+      port,
+    }));
+  } catch (err) {
+    mainLogger.debug('chrome.ipc.discoverTargets.failed', { host, port, error: String(err) });
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IPC channels
+// ---------------------------------------------------------------------------
 
 const CHANNELS = [
   'chrome:version-info',
@@ -12,6 +104,10 @@ const CHANNELS = [
   'chrome:accessibility-info',
   'chrome:sandbox-info',
   'chrome:open-page',
+  'chrome:inspect-targets',
+  'chrome:inspect-add-target',
+  'chrome:inspect-remove-target',
+  'chrome:inspect-get-network-targets',
 ] as const;
 
 export function registerChromeHandlers(
@@ -75,6 +171,43 @@ export function registerChromeHandlers(
     } else {
       openInternalPage(page);
     }
+  });
+
+  ipcMain.handle('chrome:inspect-targets', async () => {
+    mainLogger.debug('chrome.ipc.inspectTargets', { targetCount: networkTargets.length });
+    const results = await Promise.all(
+      networkTargets.map((t) => discoverTargets(t.host, t.port)),
+    );
+    const targets = results.flat();
+    mainLogger.info('chrome.ipc.inspectTargets.result', { found: targets.length });
+    return { targets, networkTargets: [...networkTargets] };
+  });
+
+  ipcMain.handle('chrome:inspect-get-network-targets', () => {
+    mainLogger.debug('chrome.ipc.inspectGetNetworkTargets');
+    return [...networkTargets];
+  });
+
+  ipcMain.handle('chrome:inspect-add-target', (_event, host: string, port: number) => {
+    mainLogger.info('chrome.ipc.inspectAddTarget', { host, port });
+    const already = networkTargets.some((t) => t.host === host && t.port === port);
+    if (!already) {
+      networkTargets.push({ host, port });
+      mainLogger.info('chrome.ipc.inspectAddTarget.added', { host, port, total: networkTargets.length });
+    } else {
+      mainLogger.debug('chrome.ipc.inspectAddTarget.duplicate', { host, port });
+    }
+    return [...networkTargets];
+  });
+
+  ipcMain.handle('chrome:inspect-remove-target', (_event, host: string, port: number) => {
+    mainLogger.info('chrome.ipc.inspectRemoveTarget', { host, port });
+    const idx = networkTargets.findIndex((t) => t.host === host && t.port === port);
+    if (idx !== -1) {
+      networkTargets.splice(idx, 1);
+      mainLogger.info('chrome.ipc.inspectRemoveTarget.removed', { host, port, remaining: networkTargets.length });
+    }
+    return [...networkTargets];
   });
 }
 

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -110,6 +110,8 @@ declare const HISTORY_VITE_DEV_SERVER_URL: string | undefined;
 declare const HISTORY_VITE_NAME: string | undefined;
 declare const DOWNLOADS_VITE_DEV_SERVER_URL: string | undefined;
 declare const DOWNLOADS_VITE_NAME: string | undefined;
+declare const CHROME_PAGES_VITE_DEV_SERVER_URL: string | undefined;
+declare const CHROME_PAGES_VITE_NAME: string | undefined;
 
 const CHROME_URL_RE = /^chrome:\/\/([a-z-]+)\/?$/i;
 
@@ -732,11 +734,17 @@ export class TabManager {
   openInternalPage(page: string): void {
     mainLogger.info('TabManager.openInternalPage', { page });
 
+    // Pages served by the chrome_pages renderer (chrome.html) use the chrome.js preload
+    // and pass the page name as a hash fragment for client-side routing.
+    const CHROME_PAGES_PAGES = new Set([
+      'about', 'version', 'gpu', 'accessibility', 'sandbox', 'dino', 'inspect',
+    ]);
+
     const preloadMap: Record<string, string> = {
       history: 'history.js',
       downloads: 'downloads.js',
     };
-    const preloadFile = preloadMap[page] ?? 'history.js';
+    const preloadFile = CHROME_PAGES_PAGES.has(page) ? 'chrome.js' : (preloadMap[page] ?? 'history.js');
     const preloadPath = path.join(__dirname, preloadFile);
     mainLogger.debug('TabManager.openInternalPage.preload', { page, preloadFile, preloadPath });
 
@@ -774,6 +782,15 @@ export class TabManager {
         const name = typeof DOWNLOADS_VITE_NAME !== 'undefined' ? DOWNLOADS_VITE_NAME : 'downloads';
         url = 'file://' + path.join(__dirname, '..', '..', 'renderer', name, 'downloads.html');
       }
+    } else if (CHROME_PAGES_PAGES.has(page)) {
+      let baseUrl: string;
+      if (typeof CHROME_PAGES_VITE_DEV_SERVER_URL !== 'undefined' && CHROME_PAGES_VITE_DEV_SERVER_URL) {
+        baseUrl = CHROME_PAGES_VITE_DEV_SERVER_URL + '/src/renderer/chrome/chrome.html';
+      } else {
+        const name = typeof CHROME_PAGES_VITE_NAME !== 'undefined' ? CHROME_PAGES_VITE_NAME : 'chrome_pages';
+        baseUrl = 'file://' + path.join(__dirname, '..', '..', 'renderer', name, 'chrome.html');
+      }
+      url = `${baseUrl}#${page}`;
     } else {
       mainLogger.warn('TabManager.openInternalPage.unknownPage', { page });
       return;

--- a/my-app/src/preload/chrome.ts
+++ b/my-app/src/preload/chrome.ts
@@ -1,9 +1,13 @@
 /**
  * Preload script for chrome:// internal pages.
- * Exposes a safe contextBridge API for system info, downloads, and navigation.
+ * Exposes a safe contextBridge API for system info, downloads, navigation,
+ * and remote debugging target discovery (chrome://inspect).
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
+import type { InspectTarget, NetworkTarget } from '../main/chrome/ipc';
+
+export type { InspectTarget, NetworkTarget };
 
 contextBridge.exposeInMainWorld('chromeAPI', {
   getPage: (): string => {
@@ -31,4 +35,17 @@ contextBridge.exposeInMainWorld('chromeAPI', {
 
   openInternalPage: (page: string): Promise<void> =>
     ipcRenderer.invoke('chrome:open-page', page),
+
+  // chrome://inspect — remote debugging target discovery
+  getInspectTargets: (): Promise<{ targets: InspectTarget[]; networkTargets: NetworkTarget[] }> =>
+    ipcRenderer.invoke('chrome:inspect-targets'),
+
+  getNetworkTargets: (): Promise<NetworkTarget[]> =>
+    ipcRenderer.invoke('chrome:inspect-get-network-targets'),
+
+  addNetworkTarget: (host: string, port: number): Promise<NetworkTarget[]> =>
+    ipcRenderer.invoke('chrome:inspect-add-target', host, port),
+
+  removeNetworkTarget: (host: string, port: number): Promise<NetworkTarget[]> =>
+    ipcRenderer.invoke('chrome:inspect-remove-target', host, port),
 });

--- a/my-app/src/renderer/chrome/ChromePages.tsx
+++ b/my-app/src/renderer/chrome/ChromePages.tsx
@@ -1,4 +1,25 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types (mirrored from main/chrome/ipc.ts — no import across the IPC boundary)
+// ---------------------------------------------------------------------------
+
+interface InspectTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+  devtoolsFrontendUrl?: string;
+  description?: string;
+  host: string;
+  port: number;
+}
+
+interface NetworkTarget {
+  host: string;
+  port: number;
+}
 
 declare const chromeAPI: {
   getPage: () => string;
@@ -9,6 +30,10 @@ declare const chromeAPI: {
   getSandboxInfo: () => Promise<Record<string, unknown>>;
   navigateTo: (url: string) => Promise<void>;
   openInternalPage: (page: string) => Promise<void>;
+  getInspectTargets: () => Promise<{ targets: InspectTarget[]; networkTargets: NetworkTarget[] }>;
+  getNetworkTargets: () => Promise<NetworkTarget[]>;
+  addNetworkTarget: (host: string, port: number) => Promise<NetworkTarget[]>;
+  removeNetworkTarget: (host: string, port: number) => Promise<NetworkTarget[]>;
 };
 
 // ---------------------------------------------------------------------------
@@ -32,9 +57,9 @@ const CHROME_PAGES: ChromePageDef[] = [
   { name: 'settings', description: 'Browser settings', implemented: true },
   { name: 'history', description: 'Browsing history', implemented: true },
   { name: 'extensions', description: 'Manage browser extensions', implemented: true },
+  { name: 'inspect', description: 'DevTools remote debugging targets', implemented: true },
   { name: 'bookmarks', description: 'Bookmark manager', implemented: false },
   { name: 'flags', description: 'Experimental features', implemented: false },
-  { name: 'inspect', description: 'DevTools targets', implemented: false },
   { name: 'components', description: 'Installed browser components', implemented: false },
   { name: 'net-internals', description: 'Network diagnostic tools', implemented: false },
   { name: 'network-errors', description: 'Network error code reference', implemented: false },
@@ -266,6 +291,211 @@ function DinoPage(): React.ReactElement {
   );
 }
 
+// ---------------------------------------------------------------------------
+// InspectPage — chrome://inspect
+// ---------------------------------------------------------------------------
+
+const TARGET_TYPE_LABELS: Record<string, string> = {
+  page: 'Page',
+  iframe: 'Frame',
+  worker: 'Worker',
+  service_worker: 'Service Worker',
+  browser: 'Browser',
+  other: 'Other',
+};
+
+function InspectPage(): React.ReactElement {
+  const [targets, setTargets] = useState<InspectTarget[]>([]);
+  const [networkTargets, setNetworkTargets] = useState<NetworkTarget[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Add target form state
+  const [addHost, setAddHost] = useState('');
+  const [addPort, setAddPort] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await chromeAPI.getInspectTargets();
+      setTargets(result.targets);
+      setNetworkTargets(result.networkTargets);
+      setError(null);
+    } catch (err) {
+      console.error('InspectPage.refresh.failed', err);
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    refreshIntervalRef.current = setInterval(() => { void refresh(); }, 2000);
+    return () => {
+      if (refreshIntervalRef.current !== null) {
+        clearInterval(refreshIntervalRef.current);
+      }
+    };
+  }, [refresh]);
+
+  const handleRemoveTarget = useCallback(async (host: string, port: number) => {
+    const updated = await chromeAPI.removeNetworkTarget(host, port);
+    setNetworkTargets(updated);
+    void refresh();
+  }, [refresh]);
+
+  const handleAddTarget = useCallback(async () => {
+    setAddError(null);
+    const host = addHost.trim() || 'localhost';
+    const portNum = parseInt(addPort, 10);
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      setAddError('Port must be a number between 1 and 65535');
+      return;
+    }
+    const updated = await chromeAPI.addNetworkTarget(host, portNum);
+    setNetworkTargets(updated);
+    setAddHost('');
+    setAddPort('');
+    void refresh();
+  }, [addHost, addPort, refresh]);
+
+  const handleInspect = useCallback((target: InspectTarget) => {
+    if (target.devtoolsFrontendUrl) {
+      chromeAPI.navigateTo(target.devtoolsFrontendUrl).catch(console.error);
+    } else if (target.webSocketDebuggerUrl) {
+      const devtoolsUrl = `devtools://devtools/bundled/inspector.html?ws=${encodeURIComponent(target.webSocketDebuggerUrl.replace(/^ws:\/\//, ''))}`;
+      chromeAPI.navigateTo(devtoolsUrl).catch(console.error);
+    }
+  }, []);
+
+  // Group targets by host:port
+  const targetsByEndpoint = new Map<string, InspectTarget[]>();
+  for (const t of targets) {
+    const key = `${t.host}:${t.port}`;
+    if (!targetsByEndpoint.has(key)) targetsByEndpoint.set(key, []);
+    targetsByEndpoint.get(key)!.push(t);
+  }
+
+  return (
+    <div className="cp cp--inspect">
+      <h1 className="cp__title">Inspect</h1>
+      <p className="cp__subtitle">Remote debugging targets discovered on configured network endpoints</p>
+
+      {error && <p className="cp__error">{error}</p>}
+
+      {/* Network targets configuration */}
+      <section className="insp__section">
+        <h2 className="insp__section-title">Network Targets</h2>
+        <p className="insp__section-desc">
+          Discover and inspect pages on the following TCP/IP endpoints:
+        </p>
+        <div className="insp__target-list">
+          {networkTargets.map((nt) => (
+            <div key={`${nt.host}:${nt.port}`} className="insp__network-row">
+              <span className="insp__network-addr">{nt.host}:{nt.port}</span>
+              <button
+                type="button"
+                className="insp__remove-btn"
+                onClick={() => { void handleRemoveTarget(nt.host, nt.port); }}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="insp__add-form">
+          <input
+            type="text"
+            className="insp__input"
+            placeholder="Host (default: localhost)"
+            value={addHost}
+            onChange={(e) => setAddHost(e.target.value)}
+          />
+          <input
+            type="number"
+            className="insp__input insp__input--port"
+            placeholder="Port"
+            value={addPort}
+            onChange={(e) => setAddPort(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { void handleAddTarget(); } }}
+            min={1}
+            max={65535}
+          />
+          <button
+            type="button"
+            className="insp__add-btn"
+            onClick={() => { void handleAddTarget(); }}
+          >
+            Add
+          </button>
+        </div>
+        {addError && <p className="insp__add-error">{addError}</p>}
+      </section>
+
+      {/* Discovered targets */}
+      <section className="insp__section">
+        <div className="insp__section-header">
+          <h2 className="insp__section-title">Pages</h2>
+          <button
+            type="button"
+            className="insp__refresh-btn"
+            onClick={() => { void refresh(); }}
+            disabled={loading}
+          >
+            {loading ? 'Refreshing...' : 'Refresh'}
+          </button>
+        </div>
+
+        {targets.length === 0 && !loading && (
+          <p className="cp__empty">
+            No debuggable targets found. Make sure the target is running with remote debugging enabled.
+          </p>
+        )}
+
+        {loading && targets.length === 0 && (
+          <div className="cp__loading">Scanning endpoints...</div>
+        )}
+
+        {Array.from(targetsByEndpoint.entries()).map(([endpoint, endpointTargets]) => (
+          <div key={endpoint} className="insp__endpoint-group">
+            <div className="insp__endpoint-label">{endpoint}</div>
+            <div className="insp__cards">
+              {endpointTargets.map((t) => (
+                <div key={`${t.host}:${t.port}:${t.id}`} className="insp__card">
+                  <div className="insp__card-header">
+                    <span className="insp__card-type">
+                      {TARGET_TYPE_LABELS[t.type] ?? t.type}
+                    </span>
+                    {t.webSocketDebuggerUrl || t.devtoolsFrontendUrl ? (
+                      <button
+                        type="button"
+                        className="insp__inspect-btn"
+                        onClick={() => handleInspect(t)}
+                      >
+                        inspect
+                      </button>
+                    ) : (
+                      <span className="insp__inspect-unavailable">not inspectable</span>
+                    )}
+                  </div>
+                  <div className="insp__card-title">{t.title || '(untitled)'}</div>
+                  <div className="insp__card-url">{t.url}</div>
+                  {t.description && (
+                    <div className="insp__card-desc">{t.description}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}
+
 function StubPage({ name }: { name: string }): React.ReactElement {
   const def = CHROME_PAGES.find((p) => p.name === name);
   return (
@@ -309,6 +539,8 @@ export function ChromePages(): React.ReactElement {
       return <SandboxPage />;
     case 'dino':
       return <DinoPage />;
+    case 'inspect':
+      return <InspectPage />;
     default:
       return <StubPage name={page} />;
   }

--- a/my-app/src/renderer/chrome/chrome.css
+++ b/my-app/src/renderer/chrome/chrome.css
@@ -293,3 +293,244 @@
   background-color: var(--color-surface-interactive-hover);
   border-color: var(--color-border-strong);
 }
+
+/* ---------------------------------------------------------------------------
+   Inspect page (chrome://inspect)
+--------------------------------------------------------------------------- */
+
+.cp--inspect {
+  max-width: 860px;
+}
+
+.insp__section {
+  margin-bottom: 40px;
+}
+
+.insp__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.insp__section-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  margin: 0 0 12px;
+}
+
+.insp__section-header .insp__section-title {
+  margin: 0;
+}
+
+.insp__section-desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-secondary);
+  margin: 0 0 12px;
+}
+
+.insp__target-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.insp__network-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.insp__network-addr {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-primary);
+  flex: 1;
+}
+
+.insp__remove-btn {
+  font-size: var(--font-size-xs);
+  color: var(--color-status-danger);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 2px 10px;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  transition: background-color 80ms ease, border-color 80ms ease;
+}
+
+.insp__remove-btn:hover {
+  background-color: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.3);
+}
+
+.insp__add-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.insp__input {
+  padding: 6px 10px;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-primary);
+  outline: none;
+  flex: 1;
+  transition: border-color 80ms ease;
+}
+
+.insp__input:focus {
+  border-color: var(--color-accent-default);
+}
+
+.insp__input--port {
+  flex: 0 0 90px;
+  width: 90px;
+}
+
+.insp__add-btn {
+  padding: 6px 16px;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  background: var(--color-accent-default);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 80ms ease;
+}
+
+.insp__add-btn:hover {
+  opacity: 0.85;
+}
+
+.insp__add-error {
+  font-size: var(--font-size-xs);
+  color: var(--color-status-danger);
+  margin: 6px 0 0;
+}
+
+.insp__refresh-btn {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-secondary);
+  background: none;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  transition: background-color 80ms ease;
+}
+
+.insp__refresh-btn:hover:not(:disabled) {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.insp__refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.insp__endpoint-group {
+  margin-bottom: 16px;
+}
+
+.insp__endpoint-label {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--color-fg-tertiary);
+  padding: 4px 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  margin-bottom: 8px;
+}
+
+.insp__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.insp__card {
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-elevated);
+}
+
+.insp__card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.insp__card-type {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.insp__inspect-btn {
+  font-size: var(--font-size-sm);
+  color: var(--color-accent-default);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 80ms ease;
+}
+
+.insp__inspect-btn:hover {
+  text-decoration-color: var(--color-accent-default);
+}
+
+.insp__inspect-unavailable {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  font-style: italic;
+}
+
+.insp__card-title {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.insp__card-url {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--color-fg-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.insp__card-desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-secondary);
+  margin-top: 4px;
+}


### PR DESCRIPTION
Closes #79

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `chrome://inspect` page for remote debugging. It discovers targets on configurable TCP endpoints (default `localhost:9222`), lets you manage endpoints, and opens DevTools for a target.

- New Features
  - New Inspect page with target cards grouped by endpoint; “inspect” opens the DevTools frontend (or builds one from `webSocketDebuggerUrl`).
  - Endpoint management UI (add/remove host:port) with session-only persistence and auto-refresh every 2s.
  - Main IPC: `chrome:inspect-targets`, `chrome:inspect-add-target`, `chrome:inspect-remove-target`, `chrome:inspect-get-network-targets`; polls `/json` with a 3s timeout.
  - Preload exposes `getInspectTargets`, `getNetworkTargets`, `addNetworkTarget`, `removeNetworkTarget`.
  - Tab routing for chrome pages via `chrome.html#<page>` using `chrome.js` preload; adds `CHROME_PAGES_VITE_DEV_SERVER_URL` and `CHROME_PAGES_VITE_NAME`.
  - New styles for inspect layout and controls.

<sup>Written for commit 9c9a05ff8e9bc6b358b7bb8a2b377a4173d027d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

