### PR TITLE
feat(privacy): Secure DNS (DoH)

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -93,6 +93,38 @@ const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_DOH_MODE        = 'settings:get-doh-mode';
+const CH_SET_DOH_MODE        = 'settings:set-doh-mode';
+const CH_GET_DOH_PROVIDER    = 'settings:get-doh-provider';
+const CH_SET_DOH_PROVIDER    = 'settings:set-doh-provider';
+const CH_GET_DOH_CUSTOM_URI  = 'settings:get-doh-custom-uri';
+const CH_SET_DOH_CUSTOM_URI  = 'settings:set-doh-custom-uri';
+
+// ---------------------------------------------------------------------------
+// DoH — built-in provider URI templates (RFC 8484)
+// ---------------------------------------------------------------------------
+
+const DOH_PROVIDERS: Readonly<Record<string, string>> = {
+  google:        'https://dns.google/dns-query{?dns}',
+  cloudflare:    'https://cloudflare-dns.com/dns-query{?dns}',
+  quad9:         'https://dns.quad9.net/dns-query{?dns}',
+  nextdns:       'https://dns.nextdns.io/{?dns}',
+  cleanbrowsing: 'https://doh.cleanbrowsing.org/doh/family-filter/{?dns}',
+};
+
+const DOH_MODE_OFF    = 'off'       as const;
+const DOH_MODE_AUTO   = 'automatic' as const;
+const DOH_MODE_SECURE = 'secure'    as const;
+
+type DohMode = typeof DOH_MODE_OFF | typeof DOH_MODE_AUTO | typeof DOH_MODE_SECURE;
+
+const ALLOWED_DOH_MODES     = [DOH_MODE_OFF, DOH_MODE_AUTO, DOH_MODE_SECURE] as const;
+const ALLOWED_DOH_PROVIDERS = ['google', 'cloudflare', 'quad9', 'nextdns', 'cleanbrowsing', 'custom'] as const;
+type DohProvider = typeof ALLOWED_DOH_PROVIDERS[number];
+
+const DEFAULT_DOH_MODE: DohMode         = DOH_MODE_AUTO;
+const DEFAULT_DOH_PROVIDER: DohProvider = 'cloudflare';
+const DOH_CUSTOM_URI_MAX_LENGTH         = 512;
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -631,6 +663,109 @@ function handleSetGpcEnabled(_event: Electron.IpcMainInvokeEvent, enabled: boole
 }
 
 // ---------------------------------------------------------------------------
+// DoH handler implementations
+// ---------------------------------------------------------------------------
+
+function handleGetDohMode(): DohMode {
+  mainLogger.info(CH_GET_DOH_MODE);
+  const prefs = readPrefs();
+  const mode = (prefs.dohMode as DohMode | undefined) ?? DEFAULT_DOH_MODE;
+  mainLogger.info(`${CH_GET_DOH_MODE}.ok`, { mode });
+  return mode;
+}
+
+function handleSetDohMode(_event: Electron.IpcMainInvokeEvent, mode: string): void {
+  const validated = assertOneOf(mode, 'dohMode', ALLOWED_DOH_MODES);
+  mainLogger.info(CH_SET_DOH_MODE, { mode: validated });
+  mergePrefs({ dohMode: validated });
+  applyDohConfig();
+  mainLogger.info(`${CH_SET_DOH_MODE}.ok`, { mode: validated });
+}
+
+function handleGetDohProvider(): DohProvider {
+  mainLogger.info(CH_GET_DOH_PROVIDER);
+  const prefs = readPrefs();
+  const provider = (prefs.dohProvider as DohProvider | undefined) ?? DEFAULT_DOH_PROVIDER;
+  mainLogger.info(`${CH_GET_DOH_PROVIDER}.ok`, { provider });
+  return provider;
+}
+
+function handleSetDohProvider(_event: Electron.IpcMainInvokeEvent, provider: string): void {
+  const validated = assertOneOf(provider, 'dohProvider', ALLOWED_DOH_PROVIDERS);
+  mainLogger.info(CH_SET_DOH_PROVIDER, { provider: validated });
+  mergePrefs({ dohProvider: validated });
+  applyDohConfig();
+  mainLogger.info(`${CH_SET_DOH_PROVIDER}.ok`, { provider: validated });
+}
+
+function handleGetDohCustomUri(): string {
+  mainLogger.info(CH_GET_DOH_CUSTOM_URI);
+  const prefs = readPrefs();
+  const uri = typeof prefs.dohCustomUri === 'string' ? prefs.dohCustomUri : '';
+  mainLogger.info(`${CH_GET_DOH_CUSTOM_URI}.ok`, { hasUri: uri.length > 0 });
+  return uri;
+}
+
+function handleSetDohCustomUri(_event: Electron.IpcMainInvokeEvent, uri: string): void {
+  const validated = assertString(uri, 'dohCustomUri', DOH_CUSTOM_URI_MAX_LENGTH);
+  mainLogger.info(CH_SET_DOH_CUSTOM_URI, { uriLength: validated.length });
+  mergePrefs({ dohCustomUri: validated });
+  applyDohConfig();
+  mainLogger.info(`${CH_SET_DOH_CUSTOM_URI}.ok`, { uriLength: validated.length });
+}
+
+// ---------------------------------------------------------------------------
+// DoH application — calls session.defaultSession.configureDohServers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads current DoH preferences and applies them to the default session.
+ * Called at startup (via registerSettingsHandlers) and on every change.
+ *
+ * Electron's configureDohServers accepts a JSON string:
+ *   { "servers": ["https://...{?dns}"], "mode": "automatic"|"secure"|"off" }
+ */
+export function applyDohConfig(): void {
+  const prefs    = readPrefs();
+  const mode     = (prefs.dohMode as DohMode | undefined) ?? DEFAULT_DOH_MODE;
+  const provider = (prefs.dohProvider as DohProvider | undefined) ?? DEFAULT_DOH_PROVIDER;
+  const customUri = typeof prefs.dohCustomUri === 'string' ? prefs.dohCustomUri : '';
+
+  mainLogger.info('doh.applyConfig', { mode, provider });
+
+  if (mode === DOH_MODE_OFF) {
+    try {
+      session.defaultSession.configureDohServers(
+        JSON.stringify({ servers: [], mode: 'off' }),
+      );
+      mainLogger.info('doh.applyConfig.off');
+    } catch (err) {
+      mainLogger.warn('doh.applyConfig.off.failed', { error: (err as Error).message });
+    }
+    return;
+  }
+
+  const serverUri =
+    provider === 'custom'
+      ? customUri
+      : DOH_PROVIDERS[provider] ?? DOH_PROVIDERS[DEFAULT_DOH_PROVIDER];
+
+  if (!serverUri) {
+    mainLogger.warn('doh.applyConfig.noUri', { provider });
+    return;
+  }
+
+  try {
+    session.defaultSession.configureDohServers(
+      JSON.stringify({ servers: [serverUri], mode }),
+    );
+    mainLogger.info('doh.applyConfig.ok', { mode, provider, uriLength: serverUri.length });
+  } catch (err) {
+    mainLogger.warn('doh.applyConfig.failed', { error: (err as Error).message });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Privacy header injection (DNT + GPC)
 // ---------------------------------------------------------------------------
 
@@ -719,10 +854,17 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_DOH_MODE,       handleGetDohMode);
+  ipcMain.handle(CH_SET_DOH_MODE,       handleSetDohMode);
+  ipcMain.handle(CH_GET_DOH_PROVIDER,   handleGetDohProvider);
+  ipcMain.handle(CH_SET_DOH_PROVIDER,   handleSetDohProvider);
+  ipcMain.handle(CH_GET_DOH_CUSTOM_URI, handleGetDohCustomUri);
+  ipcMain.handle(CH_SET_DOH_CUSTOM_URI, handleSetDohCustomUri);
 
   refreshPrivacyHeaders();
+  applyDohConfig();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 31 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -753,6 +895,12 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_DOH_MODE);
+  ipcMain.removeHandler(CH_SET_DOH_MODE);
+  ipcMain.removeHandler(CH_GET_DOH_PROVIDER);
+  ipcMain.removeHandler(CH_SET_DOH_PROVIDER);
+  ipcMain.removeHandler(CH_GET_DOH_CUSTOM_URI);
+  ipcMain.removeHandler(CH_SET_DOH_CUSTOM_URI);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -93,6 +93,13 @@ export interface SiteCategoryOverride {
   updatedAt: number;
 }
 
+// ---------------------------------------------------------------------------
+// DoH types
+// ---------------------------------------------------------------------------
+
+export type DohMode = 'off' | 'automatic' | 'secure';
+export type DohProvider = 'google' | 'cloudflare' | 'quad9' | 'nextdns' | 'cleanbrowsing' | 'custom';
+
 export interface SettingsAPI {
   /** Save API key to Keychain (never logged) */
   saveApiKey: (key: string) => Promise<void>;
@@ -223,6 +230,28 @@ export interface SettingsAPI {
 
   /** Reset all per-site overrides */
   resetAllContentCategoryOverrides: () => Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // Secure DNS (DoH)
+  // ---------------------------------------------------------------------------
+
+  /** Get the current DNS-over-HTTPS mode */
+  getDohMode: () => Promise<DohMode>;
+
+  /** Set the DNS-over-HTTPS mode */
+  setDohMode: (mode: DohMode) => Promise<void>;
+
+  /** Get the selected DoH provider */
+  getDohProvider: () => Promise<DohProvider>;
+
+  /** Set the DoH provider */
+  setDohProvider: (provider: DohProvider) => Promise<void>;
+
+  /** Get the custom DoH URI template (used when provider is 'custom') */
+  getDohCustomUri: () => Promise<string>;
+
+  /** Set the custom DoH URI template */
+  setDohCustomUri: (uri: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -473,6 +502,40 @@ const api: SettingsAPI = {
   resetAllContentCategoryOverrides: async (): Promise<void> => {
     console.debug('[settings-preload] resetAllContentCategoryOverrides');
     await ipcRenderer.invoke('content-categories:reset-all');
+  },
+
+  // ---------------------------------------------------------------------------
+  // Secure DNS (DoH)
+  // ---------------------------------------------------------------------------
+
+  getDohMode: async (): Promise<DohMode> => {
+    console.debug('[settings-preload] getDohMode');
+    return ipcRenderer.invoke('settings:get-doh-mode') as Promise<DohMode>;
+  },
+
+  setDohMode: async (mode: DohMode): Promise<void> => {
+    console.debug('[settings-preload] setDohMode', { mode });
+    await ipcRenderer.invoke('settings:set-doh-mode', mode);
+  },
+
+  getDohProvider: async (): Promise<DohProvider> => {
+    console.debug('[settings-preload] getDohProvider');
+    return ipcRenderer.invoke('settings:get-doh-provider') as Promise<DohProvider>;
+  },
+
+  setDohProvider: async (provider: DohProvider): Promise<void> => {
+    console.debug('[settings-preload] setDohProvider', { provider });
+    await ipcRenderer.invoke('settings:set-doh-provider', provider);
+  },
+
+  getDohCustomUri: async (): Promise<string> => {
+    console.debug('[settings-preload] getDohCustomUri');
+    return ipcRenderer.invoke('settings:get-doh-custom-uri') as Promise<string>;
+  },
+
+  setDohCustomUri: async (uri: string): Promise<void> => {
+    console.debug('[settings-preload] setDohCustomUri', { uriLength: uri.length });
+    await ipcRenderer.invoke('settings:set-doh-custom-uri', uri);
   },
 
 };

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -79,6 +79,40 @@ const PAGE_ZOOM_OPTIONS = [
 ] as const;
 
 // ---------------------------------------------------------------------------
+// DoH constants
+// ---------------------------------------------------------------------------
+
+type DohMode = 'off' | 'automatic' | 'secure';
+type DohProvider = 'google' | 'cloudflare' | 'quad9' | 'nextdns' | 'cleanbrowsing' | 'custom';
+
+const DOH_MODE_OPTIONS: Array<{ value: DohMode; label: string; desc: string }> = [
+  {
+    value: 'off',
+    label: 'Off',
+    desc: 'Use your system DNS provider without encryption.',
+  },
+  {
+    value: 'automatic',
+    label: 'With your current service provider',
+    desc: 'Automatically upgrade to DNS-over-HTTPS if your provider supports it.',
+  },
+  {
+    value: 'secure',
+    label: 'With a specific provider',
+    desc: 'Always use DNS-over-HTTPS with the selected provider.',
+  },
+];
+
+const DOH_PROVIDER_OPTIONS: Array<{ value: DohProvider; label: string }> = [
+  { value: 'cloudflare',    label: 'Cloudflare (1.1.1.1)' },
+  { value: 'google',        label: 'Google (8.8.8.8)' },
+  { value: 'quad9',         label: 'Quad9 (9.9.9.9)' },
+  { value: 'nextdns',       label: 'NextDNS' },
+  { value: 'cleanbrowsing', label: 'CleanBrowsing (Family Filter)' },
+  { value: 'custom',        label: 'Custom...' },
+];
+
+// ---------------------------------------------------------------------------
 // Types (mirror preload shape)
 // ---------------------------------------------------------------------------
 
@@ -178,6 +212,13 @@ declare global {
       }>;
       applyAutoRevokePermissions: (revocations: Array<{ origin: string; permissionType: string }>) => Promise<number>;
       optOutAutoRevoke: (origin: string, permissionType: string) => Promise<void>;
+      // Secure DNS (DoH)
+      getDohMode: () => Promise<DohMode>;
+      setDohMode: (mode: DohMode) => Promise<void>;
+      getDohProvider: () => Promise<DohProvider>;
+      setDohProvider: (provider: DohProvider) => Promise<void>;
+      getDohCustomUri: () => Promise<string>;
+      setDohCustomUri: (uri: string) => Promise<void>;
     };
   }
 }
@@ -764,6 +805,165 @@ function ProfilesTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Secure DNS section — rendered inside PrivacyTab
+// ---------------------------------------------------------------------------
+
+function SecureDnsSection(): React.ReactElement {
+  const toast = useToast();
+  const [dohMode, setDohMode]           = useState<DohMode>('automatic');
+  const [dohProvider, setDohProvider]   = useState<DohProvider>('cloudflare');
+  const [customUri, setCustomUri]       = useState('');
+  const [loading, setLoading]           = useState(true);
+  const [savingUri, setSavingUri]       = useState(false);
+
+  useEffect(() => {
+    void Promise.all([
+      window.settingsAPI.getDohMode(),
+      window.settingsAPI.getDohProvider(),
+      window.settingsAPI.getDohCustomUri(),
+    ]).then(([mode, provider, uri]) => {
+      setDohMode(mode);
+      setDohProvider(provider);
+      setCustomUri(uri);
+    }).catch(() => {
+      // silently fall back to defaults
+    }).finally(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleModeChange(mode: DohMode): Promise<void> {
+    const prev = dohMode;
+    setDohMode(mode);
+    try {
+      await window.settingsAPI.setDohMode(mode);
+      const modeLabel = DOH_MODE_OPTIONS.find((o) => o.value === mode)?.label ?? mode;
+      toast.show({ variant: 'success', title: `Secure DNS: ${modeLabel}` });
+    } catch (err) {
+      setDohMode(prev);
+      toast.show({ variant: 'error', title: 'Failed to update Secure DNS mode', message: (err as Error).message });
+    }
+  }
+
+  async function handleProviderChange(provider: DohProvider): Promise<void> {
+    const prev = dohProvider;
+    setDohProvider(provider);
+    try {
+      await window.settingsAPI.setDohProvider(provider);
+      const providerLabel = DOH_PROVIDER_OPTIONS.find((o) => o.value === provider)?.label ?? provider;
+      toast.show({ variant: 'success', title: `DNS provider: ${providerLabel}` });
+    } catch (err) {
+      setDohProvider(prev);
+      toast.show({ variant: 'error', title: 'Failed to update DNS provider', message: (err as Error).message });
+    }
+  }
+
+  async function handleSaveCustomUri(): Promise<void> {
+    setSavingUri(true);
+    try {
+      await window.settingsAPI.setDohCustomUri(customUri.trim());
+      toast.show({ variant: 'success', title: 'Custom DNS URI saved' });
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to save custom URI', message: (err as Error).message });
+    } finally {
+      setSavingUri(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card variant="default" padding="md" className="settings-card">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Spinner size="sm" />
+          <span style={{ fontSize: 13, color: 'var(--color-fg-secondary)' }}>Loading DNS settings…</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="default" padding="md" className="settings-card">
+      <div className="settings-field">
+        <span className="settings-label">Use secure DNS</span>
+        <p className="settings-field-hint">
+          DNS-over-HTTPS (DoH) encrypts your DNS queries so your ISP cannot
+          see which sites you look up.
+        </p>
+      </div>
+
+      <fieldset className="settings-fieldset" style={{ marginTop: 12 }}>
+        <legend className="settings-label" style={{ marginBottom: 8 }}>Mode</legend>
+        {DOH_MODE_OPTIONS.map((opt) => (
+          <label key={opt.value} className="settings-radio-row" style={{ marginBottom: 4 }}>
+            <input
+              type="radio"
+              name="doh-mode"
+              value={opt.value}
+              checked={dohMode === opt.value}
+              onChange={() => void handleModeChange(opt.value)}
+            />
+            <span className="settings-radio-content">
+              <span className="settings-radio-label">{opt.label}</span>
+              <span className="settings-radio-desc">{opt.desc}</span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+
+      {dohMode === 'secure' && (
+        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div className="settings-field">
+            <label className="settings-label" htmlFor="doh-provider-select">Provider</label>
+            <select
+              id="doh-provider-select"
+              className="settings-select"
+              value={dohProvider}
+              onChange={(e) => void handleProviderChange(e.target.value as DohProvider)}
+            >
+              {DOH_PROVIDER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {dohProvider === 'custom' && (
+            <div className="settings-field">
+              <label className="settings-label" htmlFor="doh-custom-uri">
+                Custom DoH URI template
+              </label>
+              <p className="settings-field-hint">
+                Must be an RFC 8484 URI template, e.g.
+                {' '}<code style={{ fontSize: 11 }}>https://example.com/dns-query{'{?dns}'}</code>
+              </p>
+              <div className="settings-input-row">
+                <input
+                  id="doh-custom-uri"
+                  className="settings-input"
+                  type="text"
+                  value={customUri}
+                  onChange={(e) => setCustomUri(e.target.value)}
+                  placeholder="https://example.com/dns-query{?dns}"
+                  spellCheck={false}
+                />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleSaveCustomUri()}
+                  loading={savingUri}
+                  disabled={!customUri.trim()}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Privacy and security tab
 // ---------------------------------------------------------------------------
 
@@ -934,6 +1134,8 @@ function PrivacyTab({ openDialog, onDialogChange }: PrivacyTabProps): React.Reac
           </label>
         </div>
       </Card>
+
+      <SecureDnsSection />
 
       <Card variant="default" padding="md" className="settings-card">
         <div className="settings-privacy-row">


### PR DESCRIPTION
Closes #62

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Secure DNS (DNS-over-HTTPS) settings with Off, Automatic, and Secure modes, including provider selection and a custom URI template. Applies DoH at startup and on changes for encrypted DNS lookups; closes #62.

- **New Features**
  - Privacy tab: new “Secure DNS” section with modes Off, Automatic, and Secure. In Secure mode, choose Cloudflare (default), Google, Quad9, NextDNS, CleanBrowsing, or a custom RFC 8484 URI.
  - IPC/preload: added `settings:get-doh-mode`/`set-doh-mode`, `settings:get-doh-provider`/`set-doh-provider`, and `settings:get-doh-custom-uri`/`set-doh-custom-uri`; values persisted via existing settings store.
  - Application: applies configuration through `session.defaultSession.configureDohServers()` on startup and after each change (default mode `automatic`, default provider `cloudflare`).

<sup>Written for commit d096b048eaa586b39cce7370ad6fea5a33b6fdb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

