### PR TITLE
feat(a11y): screen reader and ARIA passthrough

### DIFF
--- a/my-app/src/renderer/shell/SidePanel.tsx
+++ b/my-app/src/renderer/shell/SidePanel.tsx
@@ -211,6 +211,7 @@ function HistoryPanel({ onNavigate }: { onNavigate: (url: string) => void }): Re
           className="side-panel__search"
           type="text"
           placeholder="Search history…"
+          aria-label="Search history"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
@@ -357,6 +358,8 @@ export function SidePanel({
     <div
       className={`side-panel side-panel--${position}`}
       style={{ width: `${width}px` }}
+      role="complementary"
+      aria-label={`${activeDef.label} side panel`}
     >
       {/* Resize divider */}
       <div
@@ -381,6 +384,7 @@ export function SidePanel({
             className="side-panel__close-btn"
             onClick={onClose}
             title="Close side panel"
+            aria-label="Close side panel"
           >
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
               <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
@@ -433,17 +437,22 @@ function PanelPicker({
         className="side-panel__picker-btn"
         onClick={() => setOpen((prev) => !prev)}
         title="Switch panel"
+        aria-label="Switch side panel"
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
           <path d="M3.5 5.25L7 8.75l3.5-3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
       {open && (
-        <div className="side-panel__picker-menu">
+        <div className="side-panel__picker-menu" role="listbox" aria-label="Side panel options">
           {panels.map((p) => (
             <button
               key={p.id}
               className={`side-panel__picker-item ${p.id === activePanel ? 'side-panel__picker-item--active' : ''}`}
+              role="option"
+              aria-selected={p.id === activePanel}
               onClick={() => {
                 onSelect(p.id);
                 setOpen(false);

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -504,8 +504,20 @@ export function WindowChrome(): React.ReactElement {
   // ---------------------------------------------------------------------------
   return (
     <div className="window-chrome">
+      {/* Screen-reader live region: announces page title and loading state */}
+      <div
+        className="window-chrome__sr-status"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {(activeTab?.isLoading ?? false)
+          ? `Loading${activeTab?.title ? `: ${activeTab.title}` : ''}`
+          : (activeTab?.title ?? '')}
+      </div>
+
       {/* Tab strip row */}
-      <div className="window-chrome__tab-row">
+      <div className="window-chrome__tab-row" role="navigation" aria-label="Tab bar">
         <div className="window-chrome__traffic-light-spacer" aria-hidden="true" />
 
         <TabStrip
@@ -519,7 +531,7 @@ export function WindowChrome(): React.ReactElement {
       </div>
 
       {/* Toolbar row */}
-      <div className="window-chrome__toolbar">
+      <div className="window-chrome__toolbar" role="toolbar" aria-label="Browser toolbar">
         <NavButtons
           canGoBack={activeTab?.canGoBack ?? false}
           canGoForward={activeTab?.canGoForward ?? false}

--- a/my-app/src/renderer/shell/ZoomBadge.tsx
+++ b/my-app/src/renderer/shell/ZoomBadge.tsx
@@ -96,6 +96,7 @@ export function ZoomBadge({
             type="button"
             className="zoom-popover__reset"
             onClick={() => { onReset(); setOpen(false); }}
+            aria-label="Reset zoom to 100%"
           >
             Reset
           </button>

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -1796,3 +1796,122 @@
   pointer-events: none;
   opacity: 0.9;
 }
+
+/* ---------------------------------------------------------------------------
+ * Issue #103 — Accessibility: screen reader status region
+ * Visually hidden but exposed to the accessibility tree so VoiceOver/NVDA/JAWS
+ * can read out page titles and loading state without polluting the visual UI.
+ * --------------------------------------------------------------------------- */
+.window-chrome__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Issue #103 — Accessibility: forced-colors (Windows High Contrast) support
+ * Override transparent backgrounds/borders so interactive chrome elements
+ * remain visible in forced-colors mode. Electron inherits this media query
+ * from the OS just like a regular Chromium browser.
+ * --------------------------------------------------------------------------- */
+@media (forced-colors: active) {
+  .tab-item {
+    forced-color-adjust: none;
+    border: 1px solid ButtonText;
+  }
+
+  .tab-item--active {
+    border-color: Highlight;
+    color: HighlightText;
+    background: Highlight;
+  }
+
+  .tab-item__close,
+  .tab-strip__new-tab,
+  .nav-buttons__btn,
+  .url-bar__star,
+  .app-menu-btn,
+  .side-panel-toggle,
+  .zoom-badge,
+  .find-bar__btn,
+  .bookmark-dialog__btn,
+  .profile-menu__avatar-btn,
+  .side-panel__close-btn,
+  .side-panel__picker-btn {
+    forced-color-adjust: none;
+    border: 1px solid ButtonText;
+    color: ButtonText;
+    background: ButtonFace;
+  }
+
+  .tab-item__close:hover,
+  .tab-strip__new-tab:hover,
+  .nav-buttons__btn:hover:not(:disabled),
+  .url-bar__star:hover,
+  .app-menu-btn:hover,
+  .side-panel-toggle:hover,
+  .zoom-badge:hover,
+  .find-bar__btn:hover:not(:disabled),
+  .bookmark-dialog__btn:hover,
+  .profile-menu__avatar-btn:hover,
+  .side-panel__close-btn:hover,
+  .side-panel__picker-btn:hover {
+    border-color: Highlight;
+    color: HighlightText;
+    background: Highlight;
+  }
+
+  .url-bar {
+    forced-color-adjust: none;
+    border: 1px solid ButtonText;
+    background: Field;
+    color: FieldText;
+  }
+
+  .url-bar:focus-within {
+    border-color: Highlight;
+  }
+
+  .url-bar__input {
+    color: FieldText;
+  }
+
+  .url-bar__star--on {
+    color: Highlight;
+    border-color: Highlight;
+  }
+
+  .nav-buttons__btn:disabled {
+    color: GrayText;
+    border-color: GrayText;
+    opacity: 1;
+  }
+
+  .tab-item__spinner {
+    border-color: ButtonText;
+    border-top-color: Highlight;
+  }
+
+  .url-bar__loading {
+    background: Highlight;
+  }
+
+  .bookmarks-bar__chip {
+    forced-color-adjust: none;
+    border: 1px solid ButtonText;
+    color: ButtonText;
+    background: ButtonFace;
+  }
+
+  .bookmarks-bar__chip:hover {
+    border-color: Highlight;
+    color: HighlightText;
+    background: Highlight;
+  }
+}


### PR DESCRIPTION
Closes #103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a screen-reader status region and ARIA roles/labels for tabs, toolbar, and side panel, plus Windows High Contrast (forced-colors) support to keep controls visible. Closes #103.

- **New Features**
  - `WindowChrome`: polite live region announces page title/loading; tab bar gets role="navigation" + label; toolbar gets role="toolbar" + label.
  - `SidePanel`: role="complementary" + label; close button and panel picker labeled; picker uses aria-haspopup/expanded, listbox/option, and aria-selected; history search input labeled.
  - `ZoomBadge`: reset button labeled "Reset zoom to 100%".
  - CSS: visually hidden `.window-chrome__sr-status`; `@media (forced-colors: active)` ensures tabs, buttons, URL bar, and bookmark chips are visible in high contrast.

<sup>Written for commit 557035b622f481198d936922cb8a5c305469362e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

