### PR TITLE
feat(media): automatic Picture-in-Picture permission

### DIFF
--- a/my-app/src/main/permissions/PermissionManager.ts
+++ b/my-app/src/main/permissions/PermissionManager.ts
@@ -32,6 +32,7 @@ const ELECTRON_PERMISSION_MAP: Record<string, PermissionType> = {
   'payment-handler': 'payment-handler',
   'background-sync': 'background-sync',
   'protocol-handler': 'protocol-handler',
+  'autopictureInPicture': 'auto-picture-in-picture',
 };
 
 // Permissions that are auto-granted without prompting.
@@ -260,6 +261,14 @@ export class PermissionManager {
         wcId,
         isMainFrame,
       });
+
+      // Auto Picture-in-Picture is disabled in incognito/guest sessions by default
+      // (Chrome parity: automatic-picture-in-picture blocked in incognito)
+      if (permissionType === 'auto-picture-in-picture' && !webContents.session.isPersistent()) {
+        mainLogger.info('PermissionManager.autoPiP.incognitoDenied', { origin });
+        callback(false);
+        return;
+      }
 
       if (AUTO_GRANT.has(permissionType)) {
         mainLogger.debug('PermissionManager.autoGrant', { origin, permissionType });

--- a/my-app/src/main/permissions/PermissionStore.ts
+++ b/my-app/src/main/permissions/PermissionStore.ts
@@ -34,6 +34,7 @@ export type PermissionType =
   | 'payment-handler'
   | 'background-sync'
   | 'protocol-handler'
+  | 'auto-picture-in-picture'
   | 'unknown';
 
 export interface PermissionRecord {
@@ -68,6 +69,7 @@ const DEFAULT_PERMISSION_STATES: Record<PermissionType, PermissionState> = {
   'payment-handler': 'allow',
   'background-sync': 'allow',
   'protocol-handler': 'ask',
+  'auto-picture-in-picture': 'ask',
   unknown: 'ask',
 };
 

--- a/my-app/src/renderer/shell/PermissionBar.tsx
+++ b/my-app/src/renderer/shell/PermissionBar.tsx
@@ -29,6 +29,7 @@ const PERMISSION_LABELS: Record<string, string> = {
   'payment-handler': 'handle payment requests',
   'background-sync': 'sync data in the background',
   'protocol-handler': 'handle links for a protocol',
+  'auto-picture-in-picture': 'automatically enter Picture-in-Picture',
   unknown: 'use a feature',
 };
 
@@ -48,6 +49,7 @@ const PERMISSION_ICONS: Record<string, string> = {
   'background-sync': 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
   'protocol-handler': 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
   'idle-detection': 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  'auto-picture-in-picture': 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z',
 };
 
 interface PermissionPromptData {


### PR DESCRIPTION
Closes #101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the Automatic Picture-in-Picture permission (closes #101). Sites requesting `autopictureInPicture` now get the standard prompt; requests are auto-denied in incognito/guest sessions to match Chrome.

- **New Features**
  - New permission type `'auto-picture-in-picture'` with default state `'ask'`.
  - Maps Electron `'autopictureInPicture'` to the permission store and policy.
  - Adds PermissionBar label and icon for automatic Picture-in-Picture.

<sup>Written for commit 08af0babb87dd4185666086c76e6ad3c0368d19f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

