### PR TITLE
feat(security): HSTS store and cert error handling

### DIFF
--- a/my-app/src/main/https/CertErrorController.ts
+++ b/my-app/src/main/https/CertErrorController.ts
@@ -1,0 +1,352 @@
+/**
+ * CertErrorController — certificate error interstitial.
+ *
+ * When Chromium raises a certificate error for a page load:
+ *   - Non-HSTS hosts: show a red interstitial with a "thisisunsafe" bypass
+ *     mechanism (same as Chrome — the user types the phrase into the page and
+ *     it is intercepted via console.log prefix).
+ *   - HSTS hosts: show the same interstitial but WITHOUT the bypass option,
+ *     because RFC 6797 §12.1 requires hard-failing HSTS violations.
+ *
+ * The bypass is session-level only — bypassed origins are forgotten when the
+ * app quits.
+ */
+
+import { mainLogger } from '../logger';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const CERT_BYPASS_PREFIX = '__CERT_ERROR_BYPASS__';
+export const CERT_BACK_PREFIX   = '__CERT_ERROR_BACK__';
+
+// The magic phrase Chrome uses — kept identical for muscle-memory compatibility.
+const BYPASS_PHRASE = 'thisisunsafe';
+
+// ---------------------------------------------------------------------------
+// Session-level bypass set
+// ---------------------------------------------------------------------------
+
+const bypassedOrigins = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function allowCertBypassForOrigin(origin: string): void {
+  mainLogger.info('CertErrorController.allowBypass', { origin });
+  bypassedOrigins.add(origin);
+}
+
+export function isCertBypassed(origin: string): boolean {
+  return bypassedOrigins.has(origin);
+}
+
+export function clearCertBypasses(): void {
+  mainLogger.info('CertErrorController.clearBypasses', { count: bypassedOrigins.size });
+  bypassedOrigins.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Interstitial HTML
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the cert-error full-page interstitial.
+ *
+ * @param url       The URL that failed certificate validation.
+ * @param hostname  Extracted hostname for display.
+ * @param isHSTS    When true, the "proceed anyway" bypass is hidden (HSTS hard-fail).
+ * @param errorCode Chromium net error code (e.g. -202 for ERR_CERT_AUTHORITY_INVALID).
+ */
+export function buildCertErrorInterstitial(
+  url: string,
+  hostname: string,
+  isHSTS: boolean,
+  errorCode: number,
+): string {
+  const escapedUrl = url
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  const escapedHostname = hostname
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  const errorLabel = certErrorLabel(errorCode);
+
+  // The bypass section is hidden entirely for HSTS hosts.
+  const bypassSection = isHSTS
+    ? `<p class="hsts-note">
+        This site has security policy that prevents bypassing certificate errors.
+        You cannot visit <strong>${escapedHostname}</strong> right now because
+        the website uses HSTS which ensures your browser only connects securely.
+      </p>`
+    : `<div class="bypass-section">
+        <p>
+          If you understand the risks to your security, you may proceed.
+          To bypass this warning, type <code class="bypass-phrase">thisisunsafe</code> anywhere on this page.
+        </p>
+      </div>`;
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Your connection is not private</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body {
+      height: 100%;
+      background: #0a0a0d;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .container {
+      max-width: 560px;
+      width: 100%;
+      padding: 48px 40px;
+    }
+    .shield-icon {
+      width: 56px;
+      height: 56px;
+      color: #ef4444;
+      margin-bottom: 24px;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 600;
+      color: #ffffff;
+      margin-bottom: 12px;
+      line-height: 1.3;
+    }
+    .desc {
+      font-size: 14px;
+      line-height: 1.7;
+      color: #a0a0a0;
+      margin-bottom: 16px;
+    }
+    .error-code {
+      display: inline-block;
+      font-family: ui-monospace, "SF Mono", Monaco, monospace;
+      font-size: 12px;
+      color: #666;
+      background: #111;
+      border: 1px solid #222;
+      border-radius: 4px;
+      padding: 2px 8px;
+      margin-bottom: 24px;
+    }
+    .actions {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 24px;
+    }
+    button {
+      padding: 10px 24px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: opacity 0.15s;
+    }
+    button:hover { opacity: 0.85; }
+    .btn-back {
+      background: #6366f1;
+      color: #fff;
+    }
+    .details-toggle {
+      background: transparent;
+      color: #666;
+      border: 1px solid #333;
+      padding: 8px 20px;
+      font-size: 13px;
+    }
+    .details-toggle:hover { color: #a0a0a0; border-color: #555; }
+    .details-panel {
+      display: none;
+      margin-top: 8px;
+      padding: 20px;
+      background: #111;
+      border: 1px solid #222;
+      border-radius: 8px;
+    }
+    .details-panel.open { display: block; }
+    .url-display {
+      font-family: ui-monospace, "SF Mono", Monaco, monospace;
+      font-size: 12px;
+      color: #888;
+      word-break: break-all;
+      margin-bottom: 16px;
+    }
+    .bypass-section {
+      margin-top: 16px;
+      padding: 16px;
+      background: rgba(239, 68, 68, 0.06);
+      border: 1px solid rgba(239, 68, 68, 0.15);
+      border-radius: 6px;
+      font-size: 13px;
+      color: #888;
+      line-height: 1.6;
+    }
+    .bypass-phrase {
+      font-family: ui-monospace, "SF Mono", Monaco, monospace;
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 3px;
+      padding: 1px 6px;
+      color: #ef4444;
+      font-size: 12px;
+    }
+    .hsts-note {
+      margin-top: 16px;
+      padding: 14px 16px;
+      background: rgba(99, 102, 241, 0.06);
+      border: 1px solid rgba(99, 102, 241, 0.2);
+      border-radius: 6px;
+      font-size: 13px;
+      color: #888;
+      line-height: 1.6;
+    }
+    .hsts-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(99, 102, 241, 0.12);
+      color: #818cf8;
+      border: 1px solid rgba(99, 102, 241, 0.25);
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-size: 12px;
+      font-weight: 500;
+      margin-bottom: 16px;
+    }
+    #bypass-input-trap {
+      position: fixed;
+      left: -9999px;
+      opacity: 0;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <svg class="shield-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+      <line x1="12" y1="8" x2="12" y2="12"/>
+      <line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+
+    ${isHSTS ? `<div class="hsts-badge">
+      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+        <path d="M5 1l3.5 1.5v3C8.5 7.5 5 9 5 9S1.5 7.5 1.5 5.5v-3L5 1z" fill="currentColor" opacity="0.7"/>
+      </svg>
+      HSTS Protected
+    </div>` : ''}
+
+    <h1>Your connection is not private</h1>
+    <p class="desc">
+      Attackers might be trying to steal your information from
+      <strong>${escapedHostname}</strong> (for example, passwords, messages, or credit cards).
+    </p>
+    <div class="error-code">${errorLabel}</div>
+
+    <div class="actions">
+      <button class="btn-back" onclick="goBack()">Go back</button>
+      <button class="details-toggle" onclick="toggleDetails()" id="detailsBtn">Details</button>
+    </div>
+
+    <div class="details-panel" id="detailsPanel">
+      <div class="url-display">${escapedUrl}</div>
+      ${bypassSection}
+    </div>
+  </div>
+
+  <!-- Invisible input to capture keystrokes for the bypass phrase -->
+  <input id="bypass-input-trap" type="text" aria-hidden="true" tabindex="-1" />
+
+  <script>
+    var bypassBuffer = '';
+    var bypassPhrase = ${JSON.stringify(BYPASS_PHRASE)};
+    var isHSTS = ${JSON.stringify(isHSTS)};
+
+    document.addEventListener('keydown', function(e) {
+      if (isHSTS) return;
+      // Accumulate printable characters into a rolling buffer
+      if (e.key && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+        bypassBuffer += e.key;
+        if (bypassBuffer.length > bypassPhrase.length) {
+          bypassBuffer = bypassBuffer.slice(-bypassPhrase.length);
+        }
+        if (bypassBuffer === bypassPhrase) {
+          console.log(${JSON.stringify(CERT_BYPASS_PREFIX)} + ${JSON.stringify(url).replace(/</g, '\\u003c')});
+        }
+      }
+    });
+
+    function goBack() {
+      console.log(${JSON.stringify(CERT_BACK_PREFIX)});
+      if (history.length > 1) {
+        history.back();
+      }
+    }
+
+    function toggleDetails() {
+      var panel = document.getElementById('detailsPanel');
+      var btn = document.getElementById('detailsBtn');
+      var isOpen = panel.classList.contains('open');
+      if (isOpen) {
+        panel.classList.remove('open');
+        btn.textContent = 'Details';
+      } else {
+        panel.classList.add('open');
+        btn.textContent = 'Hide details';
+      }
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a Chromium net error code to a human-readable label.
+ * Full list: https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
+ */
+function certErrorLabel(errorCode: number): string {
+  const labels: Record<number, string> = {
+    [-200]: 'ERR_CERT_COMMON_NAME_INVALID',
+    [-201]: 'ERR_CERT_DATE_INVALID',
+    [-202]: 'ERR_CERT_AUTHORITY_INVALID',
+    [-203]: 'ERR_CERT_CONTAINS_ERRORS',
+    [-204]: 'ERR_CERT_NO_REVOCATION_MECHANISM',
+    [-205]: 'ERR_CERT_UNABLE_TO_CHECK_REVOCATION',
+    [-206]: 'ERR_CERT_REVOKED',
+    [-207]: 'ERR_CERT_INVALID',
+    [-210]: 'ERR_CERT_WEAK_SIGNATURE_ALGORITHM',
+    [-212]: 'ERR_CERT_NON_UNIQUE_NAME',
+    [-213]: 'ERR_CERT_WEAK_KEY',
+    [-214]: 'ERR_CERT_NAME_CONSTRAINT_VIOLATION',
+    [-215]: 'ERR_CERT_VALIDITY_TOO_LONG',
+    [-216]: 'ERR_CERTIFICATE_TRANSPARENCY_REQUIRED',
+    [-217]: 'ERR_CERT_SYMANTEC_LEGACY',
+    [-218]: 'ERR_CERT_KNOWN_INTERCEPTION_BLOCKED',
+  };
+  return labels[errorCode] ?? `NET_ERROR(${errorCode})`;
+}

--- a/my-app/src/main/https/HSTSStore.ts
+++ b/my-app/src/main/https/HSTSStore.ts
@@ -1,0 +1,141 @@
+/**
+ * HSTSStore — in-memory HSTS (HTTP Strict Transport Security) store.
+ *
+ * Captures Strict-Transport-Security response headers and persists them
+ * for the duration of the session. HTTP navigations to known HSTS hosts
+ * are upgraded to HTTPS before the request is made (RFC 6797).
+ *
+ * Session-only: entries are cleared on app quit (no disk persistence).
+ */
+
+import { mainLogger } from '../logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HSTSEntry {
+  host: string;
+  maxAge: number;
+  includeSubdomains: boolean;
+  capturedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const hstsStore = new Map<string, HSTSEntry>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and store a Strict-Transport-Security header value for the given URL.
+ * Ignores HTTP URLs per RFC 6797 §8.1.
+ */
+export function processHSTSHeader(url: string, headerValue: string): void {
+  if (!url.startsWith('https://')) return;
+
+  let host = '';
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return;
+  }
+
+  const maxAgeMatch = /max-age\s*=\s*(\d+)/i.exec(headerValue);
+  if (!maxAgeMatch) return;
+
+  const maxAge = parseInt(maxAgeMatch[1], 10);
+
+  // max-age=0 means delete the entry (RFC 6797 §6.1.1)
+  if (maxAge === 0) {
+    hstsStore.delete(host);
+    mainLogger.info('HSTSStore.processHeader.deleted', { host });
+    return;
+  }
+
+  const includeSubdomains = /includeSubDomains/i.test(headerValue);
+  const entry: HSTSEntry = {
+    host,
+    maxAge,
+    includeSubdomains,
+    capturedAt: Date.now(),
+  };
+
+  hstsStore.set(host, entry);
+  mainLogger.info('HSTSStore.processHeader', { host, maxAge, includeSubdomains });
+}
+
+/**
+ * Returns true if the given URL's host (or a parent domain with includeSubdomains)
+ * has a known HSTS entry that hasn't expired.
+ */
+export function isHSTSHost(url: string): boolean {
+  let host = '';
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    host = parsed.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  // Direct match
+  if (checkEntry(host)) return true;
+
+  // Parent domain with includeSubdomains
+  const parts = host.split('.');
+  for (let i = 1; i < parts.length - 1; i++) {
+    const parent = parts.slice(i).join('.');
+    const entry = hstsStore.get(parent);
+    if (entry && entry.includeSubdomains && !isExpired(entry)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns the HSTS entry for the given URL's host, or null if not known/expired.
+ */
+export function getHSTSEntry(url: string): HSTSEntry | null {
+  let host = '';
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+
+  const entry = hstsStore.get(host);
+  if (!entry || isExpired(entry)) return null;
+  return entry;
+}
+
+/**
+ * Remove all HSTS entries (e.g. on app quit or when clearing browsing data).
+ */
+export function clearHSTSEntries(): void {
+  mainLogger.info('HSTSStore.clearAll', { count: hstsStore.size });
+  hstsStore.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function checkEntry(host: string): boolean {
+  const entry = hstsStore.get(host);
+  if (!entry) return false;
+  if (isExpired(entry)) {
+    hstsStore.delete(host);
+    return false;
+  }
+  return true;
+}
+
+function isExpired(entry: HSTSEntry): boolean {
+  const ageSeconds = (Date.now() - entry.capturedAt) / 1000;
+  return ageSeconds > entry.maxAge;
+}

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -43,6 +43,18 @@ import {
   SAFE_BROWSING_BACK_PREFIX,
   type ThreatType,
 } from '../safebrowsing/SafeBrowsingController';
+import {
+  processHSTSHeader,
+  isHSTSHost,
+  getHSTSEntry,
+} from '../https/HSTSStore';
+import {
+  allowCertBypassForOrigin,
+  isCertBypassed,
+  buildCertErrorInterstitial,
+  CERT_BYPASS_PREFIX,
+  CERT_BACK_PREFIX,
+} from '../https/CertErrorController';
 
 // Forge VitePlugin globals for the new-tab page (injected at build time)
 declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
@@ -687,7 +699,20 @@ export class TabManager {
       return;
     }
 
-    const upgrade = maybeUpgradeUrl(url);
+    // HSTS: upgrade http:// to https:// pre-request for known HSTS hosts
+    let hstsUrl = url;
+    if (isHSTSHost(url)) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol === 'http:') {
+          parsed.protocol = 'https:';
+          hstsUrl = parsed.toString();
+          mainLogger.info('TabManager.navigate.hstsUpgrade', { tabId, originalUrl: url, upgradedUrl: hstsUrl });
+        }
+      } catch { /* ignore parse errors */ }
+    }
+
+    const upgrade = maybeUpgradeUrl(hstsUrl);
     if (upgrade.upgraded) {
       mainLogger.info('TabManager.navigate.httpsUpgrade', {
         tabId,
@@ -1575,6 +1600,27 @@ export class TabManager {
         mainLogger.info('TabManager.tab.safeBrowsingBack', { tabId });
         return;
       }
+      // Cert error: bypass (thisisunsafe typed on interstitial)
+      if (message.startsWith(CERT_BYPASS_PREFIX) && currentUrl.startsWith('data:text/html')) {
+        const certUrl = message.slice(CERT_BYPASS_PREFIX.length);
+        mainLogger.info('TabManager.tab.certBypass', { tabId, certUrl });
+        try {
+          const origin = new URL(certUrl).origin;
+          allowCertBypassForOrigin(origin);
+        } catch { /* ignore parse errors */ }
+        wc.loadURL(certUrl);
+        return;
+      }
+      // Cert error: back button pressed
+      if (message === CERT_BACK_PREFIX && currentUrl.startsWith('data:text/html')) {
+        mainLogger.info('TabManager.tab.certBack', { tabId });
+        if (wc.canGoBack()) {
+          wc.goBack();
+        } else {
+          wc.loadURL('about:blank');
+        }
+        return;
+      }
       if (!message.startsWith(FORM_DETECTOR_PREFIX)) return;
       try {
         const json = message.slice(FORM_DETECTOR_PREFIX.length);
@@ -1638,6 +1684,51 @@ export class TabManager {
       if (!this.win.isDestroyed() && !this.win.webContents.isDestroyed()) {
         this.win.webContents.send('target-lost', { tabId });
       }
+    });
+
+    // HSTS header capture: register a one-time onHeadersReceived listener per
+    // navigation to capture Strict-Transport-Security response headers.
+    wc.on('did-start-navigation', (_e, navUrl) => {
+      if (!navUrl.startsWith('https://')) return;
+      const wcSession = wc.session;
+      // Electron allows only one onHeadersReceived listener per session.
+      // We use a filter to narrow to this URL, and unregister after one hit.
+      let captured = false;
+      const filter = { urls: [navUrl.replace(/#.*$/, '') + '*'] };
+      wcSession.webRequest.onHeadersReceived(filter, (details, callback) => {
+        if (!captured && details.responseHeaders) {
+          const hsts = details.responseHeaders['strict-transport-security']?.[0]
+            ?? details.responseHeaders['Strict-Transport-Security']?.[0];
+          if (hsts) {
+            try { processHSTSHeader(navUrl, hsts); } catch { /* ignore */ }
+          }
+          captured = true;
+        }
+        callback({ responseHeaders: details.responseHeaders });
+      });
+    });
+
+    // Certificate errors: show interstitial or allow bypass for session-bypassed origins
+    wc.on('certificate-error', (_e, certUrl, _error, _cert, callback) => {
+      let origin = '';
+      try { origin = new URL(certUrl).origin; } catch { origin = certUrl; }
+
+      if (isCertBypassed(origin)) {
+        mainLogger.info('TabManager.tab.certError.bypassed', { tabId, certUrl, origin });
+        callback(true);
+        return;
+      }
+
+      mainLogger.warn('TabManager.tab.certError', { tabId, certUrl, origin });
+      callback(false);
+
+      let hostname = '';
+      try { hostname = new URL(certUrl).hostname; } catch { hostname = certUrl; }
+      const hstsEntry = getHSTSEntry(certUrl);
+      const isHSTS = !!hstsEntry;
+      const interstitialHtml = buildCertErrorInterstitial(certUrl, hostname, isHSTS, -202);
+      const dataUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(interstitialHtml);
+      wc.loadURL(dataUrl);
     });
 
     // Route Cmd+K from tab webContents to the pill toggle. On macOS Chromium
@@ -2054,6 +2145,18 @@ export class TabManager {
     ipcMain.handle('find:get-last-query', () => {
       return this.getActiveTabLastFindQuery();
     });
+
+    ipcMain.handle('security:get-page-info', () => {
+      const url = this.getActiveTabUrl() ?? '';
+      const hstsEntry = getHSTSEntry(url);
+      return {
+        url,
+        isHSTS: !!hstsEntry,
+        hstsMaxAge: hstsEntry?.maxAge ?? null,
+        hstsIncludeSubdomains: hstsEntry?.includeSubdomains ?? false,
+        isSecure: url.startsWith('https://'),
+      };
+    });
   }
 
   destroy(): void {
@@ -2090,5 +2193,6 @@ export class TabManager {
     ipcMain.removeHandler('find:prev');
     ipcMain.removeHandler('find:stop');
     ipcMain.removeHandler('find:get-last-query');
+    ipcMain.removeHandler('security:get-page-info');
   }
 }

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -335,6 +335,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('pip:get-status'),
   },
 
+  // Security — HSTS and cert error page info
+  security: {
+    getPageInfo: (): Promise<{
+      url: string;
+      isHSTS: boolean;
+      hstsMaxAge: number | null;
+      hstsIncludeSubdomains: boolean;
+      isSecure: boolean;
+    }> => ipcRenderer.invoke('security:get-page-info'),
+  },
+
   // Issue #81 — Three-dot app menu (non-macOS)
   menu: {
     showAppMenu: (bounds: { x: number; y: number }): Promise<void> =>

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -28,6 +28,14 @@ const DEFAULT_PORTS: Record<string, number> = {
   'https:': 443,
 };
 
+interface PageInfo {
+  url: string;
+  isHSTS: boolean;
+  hstsMaxAge: number | null;
+  hstsIncludeSubdomains: boolean;
+  isSecure: boolean;
+}
+
 interface URLBarProps {
   url: string;
   isLoading: boolean;
@@ -161,34 +169,89 @@ export function URLBar({
   // Hide the star on blank/new-tab URLs — nothing meaningful to bookmark.
   const starVisible = !!url && !BLANK_RE.test(url);
 
+  const [pageInfoOpen, setPageInfoOpen] = useState(false);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const securityRef = useRef<HTMLButtonElement>(null);
+
+  const handleSecurityClick = useCallback(async () => {
+    if (!pageInfoOpen) {
+      try {
+        const info = await (window as any).electronAPI?.security?.getPageInfo?.();
+        setPageInfo(info ?? null);
+      } catch {
+        setPageInfo(null);
+      }
+    }
+    setPageInfoOpen((v) => !v);
+  }, [pageInfoOpen]);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    if (!pageInfoOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (securityRef.current && !securityRef.current.closest('.url-bar__security-wrap')?.contains(e.target as Node)) {
+        setPageInfoOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [pageInfoOpen]);
+
   return (
     <div className={`url-bar url-bar--${security}`}>
       {/* Security icon */}
-      <span className="url-bar__security" aria-label={security}>
-        {security === 'secure' && (
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-            <rect x="2" y="5" width="8" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
-            <path
-              d="M4 5V3.5a2 2 0 0 1 4 0V5"
-              stroke="currentColor"
-              strokeWidth="1.2"
-              fill="none"
-            />
-          </svg>
+      <div className="url-bar__security-wrap">
+        <button
+          ref={securityRef}
+          type="button"
+          className="url-bar__security"
+          aria-label={security === 'secure' ? 'Connection is secure' : security === 'insecure' ? 'Connection is not secure' : 'Page info'}
+          onClick={handleSecurityClick}
+          tabIndex={-1}
+        >
+          {security === 'secure' && (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <rect x="2" y="5" width="8" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
+              <path
+                d="M4 5V3.5a2 2 0 0 1 4 0V5"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                fill="none"
+              />
+            </svg>
+          )}
+          {security === 'insecure' && (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M6 2L10.5 10H1.5L6 2Z"
+                stroke="#e5534b"
+                strokeWidth="1.2"
+                fill="none"
+              />
+              <line x1="6" y1="5.5" x2="6" y2="7.5" stroke="#e5534b" strokeWidth="1.2" />
+              <circle cx="6" cy="9" r="0.5" fill="#e5534b" />
+            </svg>
+          )}
+        </button>
+        {pageInfoOpen && (
+          <div className="url-bar__page-info-popover" role="dialog" aria-label="Page info">
+            <div className="url-bar__page-info-row">
+              <span className={`url-bar__page-info-status url-bar__page-info-status--${security}`}>
+                {security === 'secure' ? 'Connection is secure' : security === 'insecure' ? 'Connection is not secure' : 'No connection info'}
+              </span>
+            </div>
+            {pageInfo?.isHSTS && (
+              <div className="url-bar__page-info-row url-bar__page-info-hsts">
+                <span className="url-bar__page-info-badge">HSTS</span>
+                <span className="url-bar__page-info-hsts-detail">
+                  {pageInfo.hstsIncludeSubdomains ? 'Includes subdomains' : 'This domain only'}
+                  {pageInfo.hstsMaxAge != null ? ` · ${Math.round(pageInfo.hstsMaxAge / 86400)}d` : ''}
+                </span>
+              </div>
+            )}
+          </div>
         )}
-        {security === 'insecure' && (
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-            <path
-              d="M6 2L10.5 10H1.5L6 2Z"
-              stroke="#e5534b"
-              strokeWidth="1.2"
-              fill="none"
-            />
-            <line x1="6" y1="5.5" x2="6" y2="7.5" stroke="#e5534b" strokeWidth="1.2" />
-            <circle cx="6" cy="9" r="0.5" fill="#e5534b" />
-          </svg>
-        )}
-      </span>
+      </div>
 
       {/* URL input */}
       <input

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -362,10 +362,86 @@
   color: var(--color-fg-tertiary);
 }
 
+.url-bar__security-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 .url-bar__security {
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.url-bar__security:hover {
+  background: var(--color-bg-hover);
+}
+
+.url-bar__page-info-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 220px;
+  background: var(--color-bg-overlay);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 12px 14px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.url-bar__page-info-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.url-bar__page-info-status {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.url-bar__page-info-status--secure {
+  color: var(--color-status-success, #3fb950);
+}
+
+.url-bar__page-info-status--insecure {
+  color: var(--color-status-danger);
+}
+
+.url-bar__page-info-status--none {
+  color: var(--color-fg-tertiary);
+}
+
+.url-bar__page-info-hsts {
+  padding-top: 4px;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.url-bar__page-info-badge {
+  font-size: 10px;
+  font-weight: 600;
+  background: rgba(99, 102, 241, 0.12);
+  color: #818cf8;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 3px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+}
+
+.url-bar__page-info-hsts-detail {
+  font-size: 11px;
+  color: var(--color-fg-tertiary);
 }
 
 .url-bar__input {


### PR DESCRIPTION
## Summary

- Implements HSTS (HTTP Strict Transport Security) per RFC 6797: captures `Strict-Transport-Security` response headers per host, upgrades `http://` navigations to `https://` pre-request for known HSTS hosts (session-scoped, expiry-aware)
- Adds certificate error interstitial with `thisisunsafe` bypass phrase (Chrome parity); HSTS-protected hosts hard-fail without bypass option
- Session-level cert bypass set: once bypassed, reloads proceed without re-showing the interstitial
- URLBar security icon is now clickable and shows a popover with connection status and HSTS details (max-age, includeSubdomains)

## Test plan

- [ ] Navigate to an `http://` site whose domain has a known HSTS policy — verify it auto-upgrades to `https://`
- [ ] Visit a site with a self-signed cert — verify the interstitial appears with error code
- [ ] Type `thisisunsafe` on the interstitial — verify the cert bypass works and the page loads
- [ ] For an HSTS site with cert error — verify the bypass phrase is not shown and cannot bypass
- [ ] Click the lock icon in the URL bar for an HTTPS site — verify the popover shows "Connection is secure"
- [ ] Click the lock icon for an HSTS site — verify the HSTS badge with max-age and subdomain info appears
- [ ] Click "Go back" on the cert error interstitial — verify navigation goes back or clears to about:blank

Closes #61

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session‑scoped HSTS and a Chrome‑style certificate error interstitial to tighten transport security and improve UX. Closes #61.

- **New Features**
  - HSTS per RFC 6797: captures `Strict-Transport-Security` on HTTPS and upgrades `http://` to `https://` pre‑request for known hosts (expiry‑aware, respects `includeSubDomains`, session‑only).
  - Certificate error interstitial: shows error details; type “thisisunsafe” to bypass on non‑HSTS; HSTS violations hard‑fail; per‑origin bypass lasts for the session; “Go back” returns or clears to `about:blank`.
  - URL bar: security icon opens a popover with connection status and HSTS details (max‑age, include subdomains).

<sup>Written for commit 6183020631bdfc740c0f2761c014266f34392776. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

