### PR TITLE
feat(tabs): audio indicator and mute-tab

### DIFF
--- a/my-app/src/main/tabs/MutedSitesStore.ts
+++ b/my-app/src/main/tabs/MutedSitesStore.ts
@@ -1,0 +1,136 @@
+/**
+ * MutedSitesStore — persists per-origin mute state to userData/muted-sites.json.
+ *
+ * Follows the ZoomStore pattern: debounced atomic writes (300ms).
+ * Keys are origins (e.g. "https://example.com"); presence means muted.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { mainLogger } from '../logger';
+
+const MUTED_SITES_FILE_NAME = 'muted-sites.json';
+const DEBOUNCE_MS = 300;
+
+interface PersistedMutedSites {
+  version: 1;
+  origins: string[];
+}
+
+function getMutedSitesPath(): string {
+  return path.join(app.getPath('userData'), MUTED_SITES_FILE_NAME);
+}
+
+function makeEmpty(): PersistedMutedSites {
+  return { version: 1, origins: [] };
+}
+
+export class MutedSitesStore {
+  private mutedOrigins: Set<string>;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor() {
+    this.mutedOrigins = this.load();
+    mainLogger.info('MutedSitesStore.init', { mutedCount: this.mutedOrigins.size });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private load(): Set<string> {
+    try {
+      const raw = fs.readFileSync(getMutedSitesPath(), 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedMutedSites;
+      if (parsed.version !== 1 || !Array.isArray(parsed.origins)) {
+        mainLogger.warn('MutedSitesStore.load.invalid', { msg: 'Resetting muted sites data' });
+        return new Set();
+      }
+      mainLogger.info('MutedSitesStore.load.ok', { mutedCount: parsed.origins.length });
+      return new Set(parsed.origins);
+    } catch {
+      mainLogger.info('MutedSitesStore.load.fresh', { msg: 'No muted-sites.json — starting fresh' });
+      return new Set();
+    }
+  }
+
+  private schedulePersist(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    try {
+      const data: PersistedMutedSites = {
+        version: 1,
+        origins: Array.from(this.mutedOrigins),
+      };
+      fs.writeFileSync(getMutedSitesPath(), JSON.stringify(data, null, 2), 'utf-8');
+      mainLogger.info('MutedSitesStore.flushSync.ok', {
+        path: getMutedSitesPath(),
+        mutedCount: this.mutedOrigins.size,
+      });
+    } catch (err) {
+      mainLogger.error('MutedSitesStore.flushSync.failed', { error: (err as Error).message });
+    }
+    this.dirty = false;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  isMutedOrigin(origin: string): boolean {
+    return this.mutedOrigins.has(origin);
+  }
+
+  isMutedUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === 'data:' || parsed.protocol === 'about:') return false;
+      return this.isMutedOrigin(parsed.origin);
+    } catch {
+      return false;
+    }
+  }
+
+  listMutedOrigins(): string[] {
+    return Array.from(this.mutedOrigins);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  muteOrigin(origin: string): void {
+    if (this.mutedOrigins.has(origin)) return;
+    this.mutedOrigins.add(origin);
+    mainLogger.info('MutedSitesStore.muteOrigin', { origin });
+    this.schedulePersist();
+  }
+
+  unmuteOrigin(origin: string): void {
+    if (!this.mutedOrigins.has(origin)) return;
+    this.mutedOrigins.delete(origin);
+    mainLogger.info('MutedSitesStore.unmuteOrigin', { origin });
+    this.schedulePersist();
+  }
+
+  toggleOrigin(origin: string): boolean {
+    if (this.mutedOrigins.has(origin)) {
+      this.unmuteOrigin(origin);
+      return false;
+    } else {
+      this.muteOrigin(origin);
+      return true;
+    }
+  }
+}

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -18,6 +18,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { NavigationController } from './NavigationController';
 import { SessionStore, PersistedSession, PersistedTab } from './SessionStore';
 import { ZoomStore, extractOrigin, zoomLevelToPercent, type ZoomEntry } from './ZoomStore';
+import { MutedSitesStore } from './MutedSitesStore';
 import { parseNavigationInput, UrlMatchFn } from '../navigation';
 import path from 'node:path';
 import { mainLogger } from '../logger';
@@ -88,6 +89,7 @@ export interface TabState {
   zoomLevel: number;
   pinned: boolean;
   audible: boolean;
+  muted: boolean;
 }
 
 export interface TabManagerState {
@@ -164,6 +166,7 @@ export class TabManager {
   private caretBrowsingToggle: (() => void) | null = null;
   private sendingF7 = false;
   private zoomStore: ZoomStore;
+  private mutedSitesStore: MutedSitesStore;
   private urlMatchFn: UrlMatchFn | null = null;
   private historyStore: HistoryStore | null = null;
   private passwordStore: PasswordStore | null = null;
@@ -179,6 +182,7 @@ export class TabManager {
     // `opts.dataDir` plumbing is a no-op for it today. Tracked as a
     // follow-up with the rest of the profile-scoped stores.
     this.zoomStore = new ZoomStore();
+    this.mutedSitesStore = new MutedSitesStore();
     this.registerIpcHandlers();
     mainLogger.info('TabManager.init', {
       isGuest: this.isGuest,
@@ -1428,6 +1432,7 @@ export class TabManager {
         zoomLevel: view.webContents.getZoomLevel(),
         pinned: this.pinnedTabs.has(id),
         audible: view.webContents.isCurrentlyAudible(),
+        muted: view.webContents.isAudioMuted(),
       };
     });
     return { tabs, activeTabId: this.activeTabId, cdpPort: this.cdpPort };
@@ -1519,6 +1524,7 @@ export class TabManager {
         clearPendingUpgrade(tabId);
       }
       this.applyPersistedZoom(wc);
+      this.applyPersistedMute(wc);
       this.sendTabUpdate(tabId);
       this.saveSession();
       if (tabId === this.activeTabId) this.broadcastZoom();
@@ -1735,6 +1741,14 @@ export class TabManager {
     // swallows the keystroke in the renderer before the NSMenu accelerator
     // fires, so a webpage-focused Cmd+K would otherwise never reach togglePill.
     this.attachGlobalKeyHandlers(wc);
+
+    // Issue #7 — audio playback state changes: update tab state so the
+    // renderer can show/hide the speaker icon without waiting for a full reload.
+    wc.on('audio-output-device-changed' as any, () => {
+      mainLogger.debug('TabManager.tab.audioOutputChanged', { tabId });
+      this.sendTabUpdate(tabId);
+      this.broadcastState();
+    });
   }
 
   /**
@@ -1804,6 +1818,7 @@ export class TabManager {
       zoomLevel: view.webContents.getZoomLevel(),
       pinned: this.pinnedTabs.has(tabId),
       audible: view.webContents.isCurrentlyAudible(),
+      muted: view.webContents.isAudioMuted(),
     };
     this.safeSend('tab-updated', state);
   }
@@ -1953,8 +1968,24 @@ export class TabManager {
     menu.append(new MenuItem({
       label: isMuted ? 'Unmute Tab' : 'Mute Tab',
       click: () => {
-        view.webContents.setAudioMuted(!isMuted);
-        mainLogger.info('TabManager.tabContextMenu.toggleMute', { tabId, muted: !isMuted });
+        this.toggleMuteTab(tabId);
+      },
+    }));
+
+    let isSiteMuted = false;
+    try {
+      const origin = new URL(url).origin;
+      isSiteMuted = this.mutedSitesStore.isMutedOrigin(origin);
+    } catch { /* non-standard URL, skip */ }
+    menu.append(new MenuItem({
+      label: isSiteMuted ? 'Unmute Site' : 'Mute Site',
+      enabled: !!url && !url.startsWith('about:') && !url.startsWith('chrome:'),
+      click: () => {
+        if (isSiteMuted) {
+          this.unmuteSite(tabId);
+        } else {
+          this.muteSite(tabId);
+        }
       },
     }));
 
@@ -1994,6 +2025,101 @@ export class TabManager {
     }));
 
     menu.popup({ window: this.win });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab mute (Issue #7)
+  // ---------------------------------------------------------------------------
+
+  muteTab(tabId: string): void {
+    const view = this.tabs.get(tabId);
+    if (!view) {
+      mainLogger.warn('TabManager.muteTab.unknown', { tabId });
+      return;
+    }
+    view.webContents.setAudioMuted(true);
+    mainLogger.info('TabManager.muteTab', { tabId });
+    this.sendTabUpdate(tabId);
+    this.broadcastState();
+  }
+
+  unmuteTab(tabId: string): void {
+    const view = this.tabs.get(tabId);
+    if (!view) {
+      mainLogger.warn('TabManager.unmuteTab.unknown', { tabId });
+      return;
+    }
+    view.webContents.setAudioMuted(false);
+    mainLogger.info('TabManager.unmuteTab', { tabId });
+    this.sendTabUpdate(tabId);
+    this.broadcastState();
+  }
+
+  toggleMuteTab(tabId: string): void {
+    const view = this.tabs.get(tabId);
+    if (!view) return;
+    const isMuted = view.webContents.isAudioMuted();
+    if (isMuted) {
+      this.unmuteTab(tabId);
+    } else {
+      this.muteTab(tabId);
+    }
+  }
+
+  muteSite(tabId: string): void {
+    const view = this.tabs.get(tabId);
+    if (!view) return;
+    const url = view.webContents.getURL();
+    try {
+      const origin = new URL(url).origin;
+      this.mutedSitesStore.muteOrigin(origin);
+      // Apply to all tabs on this origin
+      for (const [id, v] of this.tabs) {
+        try {
+          const tabOrigin = new URL(v.webContents.getURL()).origin;
+          if (tabOrigin === origin) {
+            v.webContents.setAudioMuted(true);
+            this.sendTabUpdate(id);
+          }
+        } catch { /* ignore */ }
+      }
+      this.broadcastState();
+      mainLogger.info('TabManager.muteSite', { tabId, origin });
+    } catch (err) {
+      mainLogger.warn('TabManager.muteSite.parseError', { tabId, url, error: (err as Error).message });
+    }
+  }
+
+  unmuteSite(tabId: string): void {
+    const view = this.tabs.get(tabId);
+    if (!view) return;
+    const url = view.webContents.getURL();
+    try {
+      const origin = new URL(url).origin;
+      this.mutedSitesStore.unmuteOrigin(origin);
+      // Remove mute from all tabs on this origin (unless tab was individually muted)
+      for (const [id, v] of this.tabs) {
+        try {
+          const tabOrigin = new URL(v.webContents.getURL()).origin;
+          if (tabOrigin === origin) {
+            v.webContents.setAudioMuted(false);
+            this.sendTabUpdate(id);
+          }
+        } catch { /* ignore */ }
+      }
+      this.broadcastState();
+      mainLogger.info('TabManager.unmuteSite', { tabId, origin });
+    } catch (err) {
+      mainLogger.warn('TabManager.unmuteSite.parseError', { tabId, url, error: (err as Error).message });
+    }
+  }
+
+  private applyPersistedMute(wc: Electron.WebContents): void {
+    const url = wc.getURL();
+    if (this.mutedSitesStore.isMutedUrl(url)) {
+      wc.setAudioMuted(true);
+      mainLogger.debug('TabManager.applyPersistedMute', { url });
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -2072,6 +2198,10 @@ export class TabManager {
       return this.getClosedTabs();
     });
 
+
+    ipcMain.handle('tabs:mute-tab', (_e, tabId: string) => {
+      this.toggleMuteTab(tabId);
+    });
 
     ipcMain.handle('tabs:show-context-menu', (_e, tabId: string) => {
       this.showTabContextMenu(tabId);
@@ -2176,6 +2306,7 @@ export class TabManager {
     ipcMain.removeHandler('tabs:reopen-last-closed');
     ipcMain.removeHandler('tabs:reopen-closed-at');
     ipcMain.removeHandler('tabs:get-closed-tabs');
+    ipcMain.removeHandler('tabs:mute-tab');
     ipcMain.removeHandler('tabs:show-context-menu');
     ipcMain.removeHandler('tabs:pin');
     ipcMain.removeHandler('tabs:unpin');

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -98,6 +98,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     unpin: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:unpin', tabId),
 
+    muteTab: (tabId: string): Promise<void> =>
+      ipcRenderer.invoke('tabs:mute-tab', tabId),
+
     showBackHistory: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:show-back-history', tabId),
 

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -17,6 +17,7 @@ import type { TabState } from '../../main/tabs/TabManager';
 declare const electronAPI: {
   tabs: {
     showContextMenu: (tabId: string) => Promise<void>;
+    muteTab: (tabId: string) => Promise<void>;
   };
 };
 
@@ -50,6 +51,7 @@ interface TabStripProps {
   onClose: (tabId: string) => void;
   onNewTab: () => void;
   onMove: (tabId: string, toIndex: number) => void;
+  onMuteToggle: (tabId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +71,7 @@ interface TabItemProps {
   onContextMenu: (e: React.MouseEvent) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   tabRef: (el: HTMLDivElement | null) => void;
+  onMuteToggle: (e: React.MouseEvent) => void;
 }
 
 function TabItem({
@@ -85,6 +88,7 @@ function TabItem({
   onContextMenu,
   onKeyDown,
   tabRef,
+  onMuteToggle,
 }: TabItemProps): React.ReactElement {
   const isPinned = tab.pinned;
   const favicon = faviconSrc(tab);
@@ -113,10 +117,20 @@ function TabItem({
       title={isPinned || isIconOnly ? tab.title : undefined}
     >
       {/* Favicon / loading spinner / audio indicator */}
-      <span className="tab-item__favicon" aria-hidden="true">
+      <span
+        className={"tab-item__favicon" + ((tab.audible || tab.muted) && !tab.isLoading ? ' tab-item__favicon--audio' : '')}
+        aria-hidden="true"
+        onClick={(tab.audible || tab.muted) && !tab.isLoading ? onMuteToggle : undefined}
+        title={(tab.audible || tab.muted) && !tab.isLoading ? (tab.muted ? 'Unmute tab' : 'Mute tab') : undefined}
+      >
         {tab.isLoading ? (
           <span className="tab-item__spinner" />
-        ) : isPinned && tab.audible ? (
+        ) : tab.muted ? (
+          <svg className="tab-item__audio-icon tab-item__audio-icon--muted" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <path d="M8 2L4.5 5H2v6h2.5L8 14V2z" fill="currentColor" />
+            <path d="M11 3.5L14.5 7M14.5 3.5L11 7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+        ) : tab.audible ? (
           <svg className="tab-item__audio-icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
             <path d="M8 2L4.5 5H2v6h2.5L8 14V2z" fill="currentColor" />
             <path d="M11 5.5c.8.8 1.2 1.8 1.2 2.5s-.4 1.7-1.2 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
@@ -275,6 +289,7 @@ export function TabStrip({
   onClose,
   onNewTab,
   onMove,
+  onMuteToggle,
 }: TabStripProps): React.ReactElement {
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [iconOnlySet, setIconOnlySet] = useState<Set<string>>(new Set());
@@ -459,6 +474,10 @@ export function TabStrip({
             }}
             onKeyDown={(e) => handleTabKeyDown(e, tab, index)}
             tabRef={setTabRef(index)}
+            onMuteToggle={(e) => {
+              e.stopPropagation();
+              onMuteToggle(tab.id);
+            }}
           />
         ))}
         {/* + button sits right after the last tab (Chrome-style), not pinned right */}

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -65,6 +65,7 @@ declare const electronAPI: {
     showContextMenu: (tabId: string) => Promise<void>;
     showBackHistory: (tabId: string) => Promise<void>;
     showForwardHistory: (tabId: string) => Promise<void>;
+    muteTab: (tabId: string) => Promise<void>;
   };
   cdp: {
     getActiveTabCdpUrl: () => Promise<string | null>;
@@ -408,6 +409,16 @@ export function WindowChrome(): React.ReactElement {
     electronAPI.tabs.create();
   }, []);
 
+  const handleMuteToggle = useCallback(
+    (tabId: string) => {
+      console.log('[WindowChrome] muteTab', tabId);
+      electronAPI.tabs.muteTab(tabId).catch((err: Error) =>
+        console.error('[WindowChrome] muteTab failed', err),
+      );
+    },
+    [],
+  );
+
   const handleMove = useCallback((tabId: string, toIndex: number) => {
     electronAPI.tabs.move(tabId, toIndex);
   }, []);
@@ -547,6 +558,7 @@ export function WindowChrome(): React.ReactElement {
           onClose={handleClose}
           onNewTab={handleNewTab}
           onMove={handleMove}
+          onMuteToggle={handleMuteToggle}
         />
       </div>
 

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -306,6 +306,21 @@
 
 .tab-item__audio-icon {
   color: var(--color-accent-default);
+  display: block;
+}
+
+.tab-item__audio-icon--muted {
+  color: var(--color-fg-tertiary);
+}
+
+/* When the favicon slot is acting as an audio/mute toggle button */
+.tab-item__favicon--audio {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.tab-item__favicon--audio:hover {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .tab-item__favicon {


### PR DESCRIPTION
## Summary

- Speaker icon overlays the favicon slot when a tab is playing audio (all tabs, not just pinned)
- Muted tab shows a crossed-out speaker icon
- Clicking the speaker icon toggles mute for that tab
- Right-click tab context menu → Mute Tab / Unmute Tab (existing, now triggers state broadcast)
- Right-click tab context menu → Mute Site / Unmute Site — persists across sessions via `userData/muted-sites.json`
- Muted origins are re-applied on navigation (`applyPersistedMute` in `did-navigate`)
- `TabState` now includes `muted: boolean` so the renderer always has accurate mute state

## Files changed

- `my-app/src/main/tabs/MutedSitesStore.ts` — new per-origin mute persistence store (debounced writes, ZoomStore pattern)
- `my-app/src/main/tabs/TabManager.ts` — `muted` field, mute methods, `tabs:mute-tab` IPC, "Mute Site" context menu item, `applyPersistedMute`
- `my-app/src/preload/shell.ts` — expose `tabs.muteTab`
- `my-app/src/renderer/shell/TabStrip.tsx` — audio/muted icons for all tabs, clickable favicon slot
- `my-app/src/renderer/shell/WindowChrome.tsx` — wire `onMuteToggle` handler
- `my-app/src/renderer/shell/components.css` — `.tab-item__favicon--audio` and `.tab-item__audio-icon--muted` styles

Closes #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds audio indicators and per-tab/site mute controls with session persistence. Icons show on any audible or muted tab with click-to-toggle; site mutes auto-apply on navigation. Closes #7.

- **New Features**
  - `TabState` adds `muted`; tab updates fire on audio/mute changes for live UI.
  - Favicon slot shows a speaker (crossed-out when muted) on all audible/muted tabs; click toggles; tab context menu adds Mute/Unmute Tab and Mute/Unmute Site.
  - `MutedSitesStore` persists per-origin mutes in `userData/muted-sites.json` (debounced); site mutes apply to all tabs for that origin and persist across reloads and navigations.
  - IPC `tabs:mute-tab` exposed via preload `electronAPI.tabs.muteTab`; wired through `TabStrip` and `WindowChrome` with light CSS for the clickable favicon/audio icon.

<sup>Written for commit 194c0d16666aa0c261afae58bcd729abe824863e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

