### PR TITLE
feat(tabs): tab search Cmd+Shift+A

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -75,6 +75,9 @@ import { openExtensionsWindow } from './extensions/ExtensionsWindow';
 // Issue #40 — History
 import { HistoryStore } from './history/HistoryStore';
 import { registerHistoryHandlers, unregisterHistoryHandlers } from './history/ipc';
+// Issue #17 — Omnibox autocomplete providers
+import { ShortcutsStore } from './omnibox/ShortcutsStore';
+import { registerOmniboxHandlers, unregisterOmniboxHandlers } from './omnibox/ipc';
 // Issue #36 — Downloads
 import { DownloadManager } from './downloads/DownloadManager';
 // Issue #26 — Chrome internal pages
@@ -146,11 +149,24 @@ if (started) {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const INCOGNITO_PARTITION_PREFIX = 'incognito';
+
+// ---------------------------------------------------------------------------
 // App state
 // ---------------------------------------------------------------------------
 let shellWindow: BrowserWindow | null = null;
 let tabManager: TabManager | null = null;
 let onboardingWindow: BrowserWindow | null = null;
+
+// Tracks all open incognito windows so we can clear the shared session when
+// the last one closes.
+const incognitoWindows = new Set<BrowserWindow>();
+// Shared incognito partition name — all incognito windows in a profile share
+// one session (matches Chrome behaviour). Cleared when the last window closes.
+let incognitoPartitionName: string | null = null;
+
 let bookmarkStore: BookmarkStore | null = null;
 let passwordStore: PasswordStore | null = null;
 let autofillStore: AutofillStore | null = null;
@@ -161,6 +177,7 @@ let permissionAutoRevoker: PermissionAutoRevoker | null = null;
 let contentCategoryStore: ContentCategoryStore | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
+let shortcutsStore: ShortcutsStore | null = null;
 let downloadManager: DownloadManager | null = null;
 let deviceStore: DeviceStore | null = null;
 let deviceManager: DeviceManager | null = null;
@@ -379,6 +396,81 @@ function openGuestShell(): BrowserWindow {
 }
 
 // ---------------------------------------------------------------------------
+// New window (Cmd+N) — fresh window sharing the active profile session
+// ---------------------------------------------------------------------------
+function openNewWindow(): BrowserWindow {
+  const pid = activeProfileId;
+  const profileDataDir = getProfileDataDir(pid);
+  const profilePartition = getProfilePartitionName(pid);
+  mainLogger.info('main.openNewWindow', { profileId: pid, partition: profilePartition });
+
+  const win = createShellWindow();
+  const tm = new TabManager(win, { dataDir: profileDataDir, partition: profilePartition });
+
+  if (historyStore) tm.setHistoryStore(historyStore);
+  if (bookmarkStore) {
+    const store = bookmarkStore;
+    tm.setUrlMatchFn((candidate: string) => store.isUrlBookmarked(candidate) ? candidate : null);
+  }
+  tm.restoreSession();
+  tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
+
+  win.webContents.once('did-finish-load', () => {
+    mainLogger.info('main.newWindow.ready', { windowId: win.id });
+    win.webContents.send('window-ready');
+  });
+
+  win.on('resize', () => tm.relayout());
+
+  mainLogger.info('main.openNewWindow.done', { windowId: win.id });
+  return win;
+}
+
+// ---------------------------------------------------------------------------
+// Incognito window (Cmd+Shift+N) — isolated session, cleared on last close
+// ---------------------------------------------------------------------------
+function openIncognitoWindow(): BrowserWindow {
+  // All incognito windows in a profile share one session partition.
+  if (!incognitoPartitionName) {
+    incognitoPartitionName = `${INCOGNITO_PARTITION_PREFIX}-${activeProfileId}-${Date.now()}`;
+    mainLogger.info('main.openIncognitoWindow.newPartition', { incognitoPartitionName });
+  }
+  const partition = incognitoPartitionName;
+  mainLogger.info('main.openIncognitoWindow', { partition });
+
+  const win = createShellWindow({ titleSuffix: ' (Incognito)', incognito: true });
+  const tm = new TabManager(win, { guest: true, partition });
+  tm.restoreSession();
+  tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
+
+  win.webContents.once('did-finish-load', () => {
+    mainLogger.info('main.incognitoWindow.ready', { windowId: win.id });
+    win.webContents.send('window-ready');
+    win.webContents.send('incognito-mode', true);
+  });
+
+  win.on('resize', () => tm.relayout());
+
+  incognitoWindows.add(win);
+  mainLogger.info('main.openIncognitoWindow.tracked', { total: incognitoWindows.size });
+
+  win.on('closed', () => {
+    incognitoWindows.delete(win);
+    mainLogger.info('main.incognitoWindow.closed', {
+      remaining: incognitoWindows.size,
+      partition,
+    });
+    if (incognitoWindows.size === 0 && incognitoPartitionName) {
+      mainLogger.info('main.incognitoWindow.clearSession', { partition });
+      void clearGuestSession(incognitoPartitionName);
+      incognitoPartitionName = null;
+    }
+  });
+
+  return win;
+}
+
+// ---------------------------------------------------------------------------
 // App ready
 // ---------------------------------------------------------------------------
 app.whenReady().then(async () => {
@@ -431,6 +523,15 @@ app.whenReady().then(async () => {
   // See comment above re: profile-scoped persistence follow-up.
   historyStore = new HistoryStore();
   registerHistoryHandlers({ store: historyStore });
+
+  // Issue #17 — Omnibox autocomplete providers
+  shortcutsStore = new ShortcutsStore();
+  registerOmniboxHandlers({
+    shortcutsStore,
+    historyStore,
+    bookmarkStore: bookmarkStore!,
+    getOpenTabs: () => tabManager ? tabManager.getAllTabSummaries().map((s) => ({ title: s.name, url: s.url })) : [],
+  });
 
   // Issue #26 — Chrome internal pages
 
@@ -530,8 +631,12 @@ app.whenReady().then(async () => {
 
   // pill:set-expanded — renderer asks the main process to grow/shrink the pill
   // window as palette/stream content toggles. Collapsed = 56, expanded = 320
-  ipcMain.handle('pill:set-expanded', (_event, expanded: boolean) => {
-    setPillHeight(expanded ? PILL_HEIGHT_EXPANDED : PILL_HEIGHT_COLLAPSED);
+  ipcMain.handle('pill:set-expanded', (_event, expandedOrHeight: boolean | number) => {
+    if (typeof expandedOrHeight === 'number') {
+      setPillHeight(Math.max(PILL_HEIGHT_COLLAPSED, Math.min(expandedOrHeight, PILL_HEIGHT_EXPANDED)));
+    } else {
+      setPillHeight(expandedOrHeight ? PILL_HEIGHT_EXPANDED : PILL_HEIGHT_COLLAPSED);
+    }
   });
 
   // Track 5 — Settings IPC handlers
@@ -643,6 +748,7 @@ app.whenReady().then(async () => {
       tabManager?.flushZoom();
       bookmarkStore?.flushSync();
       historyStore?.flushSync();
+      shortcutsStore?.flushSync();
       permissionStore?.flushSync();
       deviceStore?.flushSync();
       contentCategoryStore?.flushSync();
@@ -663,6 +769,7 @@ app.whenReady().then(async () => {
     unregisterShareHandlers();
     unregisterBookmarkHandlers();
     unregisterHistoryHandlers();
+    unregisterOmniboxHandlers();
     unregisterChromeHandlers();
     unregisterProfileHandlers();
     unregisterContentCategoryHandlers();
@@ -868,12 +975,18 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
         {
           label: 'New Window',
           accelerator: 'CommandOrControl+N',
-          enabled: false,
+          click: () => {
+            mainLogger.debug('shortcuts.newWindow');
+            openNewWindow();
+          },
         },
         {
           label: 'New Incognito Window',
           accelerator: 'CommandOrControl+Shift+N',
-          enabled: false,
+          click: () => {
+            mainLogger.debug('shortcuts.newIncognitoWindow');
+            openIncognitoWindow();
+          },
         },
         { type: 'separator' },
         {
@@ -1419,6 +1532,14 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
             tabManager?.reopenLastClosed();
           },
         },
+        {
+          label: 'Search Tabs…',
+          accelerator: 'CommandOrControl+Shift+A',
+          click: () => {
+            mainLogger.debug('shortcuts.searchTabs');
+            shellWindow?.webContents.send('open-tab-search');
+          },
+        },
         { type: 'separator' },
         ...tabSwitchItems,
       ],
@@ -1592,8 +1713,22 @@ ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) 
       accelerator: 'Ctrl+T',
       click: () => { tabManager?.createTab(); },
     },
-    { label: 'New Window', accelerator: 'Ctrl+N', enabled: false },
-    { label: 'New Incognito Window', accelerator: 'Ctrl+Shift+N', enabled: false },
+    {
+      label: 'New Window',
+      accelerator: 'Ctrl+N',
+      click: () => {
+        mainLogger.debug('shortcuts.newWindow.appMenu');
+        openNewWindow();
+      },
+    },
+    {
+      label: 'New Incognito Window',
+      accelerator: 'Ctrl+Shift+N',
+      click: () => {
+        mainLogger.debug('shortcuts.newIncognitoWindow.appMenu');
+        openIncognitoWindow();
+      },
+    },
     { type: 'separator' },
     {
       label: 'History',

--- a/my-app/src/main/omnibox/ShortcutsStore.ts
+++ b/my-app/src/main/omnibox/ShortcutsStore.ts
@@ -1,0 +1,157 @@
+/**
+ * ShortcutsStore — persists omnibox shortcuts.
+ *
+ * A "shortcut" is a user-confirmed URL selection from the omnibox.  When the
+ * user picks a suggestion and navigates to it the shortcut record is written
+ * (or its use-count is incremented) so that it ranks higher on future queries.
+ *
+ * Follows the HistoryStore pattern: debounced atomic writes to
+ * userData/omnibox-shortcuts.json (300ms).
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { mainLogger } from '../logger';
+
+const SHORTCUTS_FILE_NAME = 'omnibox-shortcuts.json';
+const DEBOUNCE_MS = 300;
+const MAX_SHORTCUTS = 1_000;
+
+export interface ShortcutEntry {
+  /** Unique id — same as the input text that produced the navigation. */
+  id: string;
+  /** The text the user typed when they selected this URL. */
+  inputText: string;
+  url: string;
+  title: string;
+  /** How many times this shortcut has been selected. */
+  useCount: number;
+  lastUsed: number;
+}
+
+export interface PersistedShortcuts {
+  version: 1;
+  entries: ShortcutEntry[];
+}
+
+function getShortcutsPath(): string {
+  return path.join(app.getPath('userData'), SHORTCUTS_FILE_NAME);
+}
+
+export class ShortcutsStore {
+  private entries: ShortcutEntry[] = [];
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor() {
+    this.load();
+  }
+
+  private load(): void {
+    try {
+      const raw = fs.readFileSync(getShortcutsPath(), 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedShortcuts;
+      if (parsed.version === 1 && Array.isArray(parsed.entries)) {
+        this.entries = parsed.entries;
+        mainLogger.info('ShortcutsStore.load.ok', { count: this.entries.length });
+      } else {
+        mainLogger.warn('ShortcutsStore.load.invalidVersion', { version: (parsed as any).version });
+        this.entries = [];
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        mainLogger.error('ShortcutsStore.load.failed', {
+          error: (err as Error).message,
+        });
+      }
+      this.entries = [];
+    }
+  }
+
+  private scheduleSave(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    this.dirty = false;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    try {
+      const data: PersistedShortcuts = { version: 1, entries: this.entries };
+      fs.writeFileSync(getShortcutsPath(), JSON.stringify(data), 'utf-8');
+      mainLogger.debug('ShortcutsStore.flush.ok', { count: this.entries.length });
+    } catch (err) {
+      mainLogger.error('ShortcutsStore.flush.failed', {
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  /**
+   * Record that the user selected `url` / `title` after typing `inputText`.
+   * Increments useCount if an entry already exists, otherwise creates one.
+   */
+  recordSelection(inputText: string, url: string, title: string): ShortcutEntry {
+    const existing = this.entries.find(
+      (e) => e.inputText === inputText && e.url === url,
+    );
+    if (existing) {
+      existing.useCount += 1;
+      existing.lastUsed = Date.now();
+      existing.title = title || existing.title;
+      mainLogger.debug('ShortcutsStore.recordSelection.updated', { inputText, url });
+      this.scheduleSave();
+      return existing;
+    }
+
+    const entry: ShortcutEntry = {
+      id: `sc-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      inputText,
+      url,
+      title: title || url,
+      useCount: 1,
+      lastUsed: Date.now(),
+    };
+    this.entries.unshift(entry);
+    if (this.entries.length > MAX_SHORTCUTS) {
+      this.entries = this.entries.slice(0, MAX_SHORTCUTS);
+    }
+    mainLogger.debug('ShortcutsStore.recordSelection.added', { inputText, url });
+    this.scheduleSave();
+    return entry;
+  }
+
+  /**
+   * Return shortcuts whose inputText or url/title matches `query`, sorted by
+   * useCount desc then lastUsed desc.
+   */
+  query(query: string, limit = 5): ShortcutEntry[] {
+    let filtered: ShortcutEntry[];
+    if (!query || query.trim().length === 0) {
+      filtered = this.entries.slice();
+    } else {
+      const lower = query.toLowerCase();
+      filtered = this.entries.filter(
+        (e) =>
+          e.inputText.toLowerCase().includes(lower) ||
+          e.url.toLowerCase().includes(lower) ||
+          e.title.toLowerCase().includes(lower),
+      );
+    }
+
+    return filtered
+      .sort((a, b) => b.useCount - a.useCount || b.lastUsed - a.lastUsed)
+      .slice(0, limit);
+  }
+
+  getAll(): ShortcutEntry[] {
+    return this.entries.slice();
+  }
+}

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -1,0 +1,191 @@
+/**
+ * ipc.ts — omnibox IPC bindings.
+ *
+ * Registers `omnibox:*` handlers that power the URL-bar autocomplete dropdown.
+ * Three providers are aggregated on every keystroke:
+ *   1. Shortcuts  — previously confirmed navigations (highest relevance).
+ *   2. History    — all visited pages, scored by recency.
+ *   3. Bookmarks  — flat-list walk of the bookmark tree.
+ *   4. Open tabs  — live tab summaries injected by the caller.
+ *
+ * Results are deduplicated by URL and sorted by relevance desc.
+ */
+
+import { ipcMain } from 'electron';
+import type { BookmarkNode } from '../bookmarks/BookmarkStore';
+import { BookmarkStore } from '../bookmarks/BookmarkStore';
+import { HistoryStore } from '../history/HistoryStore';
+import { ShortcutsStore } from './ShortcutsStore';
+import type { OmniboxSuggestion } from './providers';
+import { assertString } from '../ipc-validators';
+import { mainLogger } from '../logger';
+
+const CHANNELS = [
+  'omnibox:suggest',
+  'omnibox:record-selection',
+  'omnibox:remove-history',
+] as const;
+
+export interface OmniboxIpcOptions {
+  shortcutsStore: ShortcutsStore;
+  historyStore: HistoryStore | null;
+  bookmarkStore: BookmarkStore;
+  /** Returns title + url for every open tab in the current window. */
+  getOpenTabs: () => Array<{ title: string; url: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flatBookmarks(node: BookmarkNode): Array<{ url: string; name: string }> {
+  if (node.type === 'bookmark' && node.url) {
+    return [{ url: node.url, name: node.name }];
+  }
+  if (node.children) {
+    return node.children.flatMap((c) => flatBookmarks(c));
+  }
+  return [];
+}
+
+function scoreText(text: string, lower: string): number {
+  if (!text) return 0;
+  const t = text.toLowerCase();
+  if (t === lower) return 100;
+  if (t.startsWith(lower)) return 80;
+  if (t.includes(lower)) return 50;
+  return 0;
+}
+
+function scoreEntry(title: string, url: string, inputLower: string): number {
+  return Math.max(scoreText(title, inputLower), scoreText(url, inputLower));
+}
+
+// ---------------------------------------------------------------------------
+// Public
+// ---------------------------------------------------------------------------
+
+export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
+  const { shortcutsStore, historyStore, bookmarkStore, getOpenTabs } = opts;
+
+  // -------------------------------------------------------------------------
+  // omnibox:suggest — aggregate providers and return ranked suggestions.
+  // -------------------------------------------------------------------------
+  ipcMain.handle(
+    'omnibox:suggest',
+    (_e, payload?: { input?: string; remoteSearch?: boolean }): OmniboxSuggestion[] => {
+      const input = typeof payload?.input === 'string' ? payload.input.trim() : '';
+      const lower = input.toLowerCase();
+      mainLogger.debug('omnibox:suggest', { input });
+
+      const results: OmniboxSuggestion[] = [];
+      const seen = new Set<string>();
+
+      function push(s: OmniboxSuggestion): void {
+        if (!s.url) return;
+        if (seen.has(s.url)) return;
+        seen.add(s.url);
+        results.push(s);
+      }
+
+      // 1. Shortcuts (highest relevance baseline = 900)
+      const shortcuts = shortcutsStore.query(input, 5);
+      for (const sc of shortcuts) {
+        const base = scoreEntry(sc.title, sc.url, lower);
+        push({
+          id: `shortcut:${sc.id}`,
+          type: 'shortcut',
+          title: sc.title,
+          url: sc.url,
+          relevance: 900 + base + Math.min(sc.useCount, 50),
+        });
+      }
+
+      // 2. History (baseline = 700)
+      if (historyStore && input.length > 0) {
+        const { entries } = historyStore.query({ query: input, limit: 10 });
+        for (const e of entries) {
+          const base = scoreEntry(e.title, e.url, lower);
+          push({
+            id: `history:${e.id}`,
+            type: 'history',
+            title: e.title || e.url,
+            url: e.url,
+            favicon: e.favicon ?? undefined,
+            relevance: 700 + base,
+          });
+        }
+      }
+
+      // 3. Bookmarks (baseline = 800 — user-curated, ranks above history)
+      if (input.length > 0) {
+        const tree = bookmarkStore.listTree();
+        const allBookmarks = tree.roots.flatMap((r) => flatBookmarks(r));
+        for (const bm of allBookmarks) {
+          const base = scoreEntry(bm.name, bm.url, lower);
+          if (base === 0) continue;
+          push({
+            id: `bookmark:${bm.url}`,
+            type: 'bookmark',
+            title: bm.name,
+            url: bm.url,
+            relevance: 800 + base,
+          });
+        }
+      }
+
+      // 4. Open tabs (baseline = 600)
+      if (input.length > 0) {
+        const tabs = getOpenTabs();
+        for (const tab of tabs) {
+          if (!tab.url) continue;
+          const base = scoreEntry(tab.title, tab.url, lower);
+          if (base === 0) continue;
+          push({
+            id: `tab:${tab.url}`,
+            type: 'tab',
+            title: tab.title || tab.url,
+            url: tab.url,
+            relevance: 600 + base,
+          });
+        }
+      }
+
+      // Sort by relevance descending, cap at 10
+      results.sort((a, b) => b.relevance - a.relevance);
+      return results.slice(0, 10);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // omnibox:record-selection — persist a shortcut when user confirms a URL.
+  // -------------------------------------------------------------------------
+  ipcMain.handle(
+    'omnibox:record-selection',
+    (_e, payload?: { inputText?: string; url?: string; title?: string }): boolean => {
+      const inputText = assertString(payload?.inputText ?? '', 'inputText', 2048);
+      const url = assertString(payload?.url ?? '', 'url', 2048);
+      const title = assertString(payload?.title ?? '', 'title', 512);
+      if (!url) return false;
+      mainLogger.debug('omnibox:record-selection', { inputText, url });
+      shortcutsStore.recordSelection(inputText, url, title);
+      return true;
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // omnibox:remove-history — delete a single history entry by id.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('omnibox:remove-history', (_e, id: string): boolean => {
+    assertString(id, 'id', 128);
+    mainLogger.debug('omnibox:remove-history', { id });
+    if (!historyStore) return false;
+    return historyStore.removeEntry(id);
+  });
+}
+
+export function unregisterOmniboxHandlers(): void {
+  for (const channel of CHANNELS) {
+    ipcMain.removeHandler(channel);
+  }
+}

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -1,0 +1,30 @@
+/**
+ * providers.ts — shared types for the omnibox autocomplete system.
+ *
+ * OmniboxSuggestion is the canonical result type returned by all
+ * providers (history, bookmarks, open tabs, shortcuts) and consumed
+ * by the renderer's URL-bar dropdown.
+ */
+
+export type SuggestionType =
+  | 'history'
+  | 'bookmark'
+  | 'tab'
+  | 'shortcut'
+  | 'search';
+
+export interface OmniboxSuggestion {
+  /** Unique key for React rendering (provider:id). */
+  id: string;
+  type: SuggestionType;
+  /** Primary display text (title or description). */
+  title: string;
+  /** Destination URL or search query. */
+  url: string;
+  /** Secondary line shown below title (elided URL, hostname, etc.). */
+  description?: string;
+  /** Data-URI or absolute URL for the favicon (optional). */
+  favicon?: string;
+  /** Relative relevance score used for ranking (higher = better). */
+  relevance: number;
+}

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -17,6 +17,7 @@ import type { ProtocolHandlerRecord } from '../main/permissions/ProtocolHandlerS
 import type { DownloadItemDTO } from '../main/downloads/DownloadManager';
 import type { DevicePickerRequest } from '../main/devices/DeviceManager';
 import type { GrantedDevice, DeviceApiType } from '../main/devices/DeviceStore';
+import type { OmniboxSuggestion } from '../main/omnibox/providers';
 
 // ---------------------------------------------------------------------------
 // Type re-exports for renderer consumption
@@ -38,6 +39,7 @@ export type {
   DevicePickerRequest,
   GrantedDevice,
   DeviceApiType,
+  OmniboxSuggestion,
 };
 
 // ---------------------------------------------------------------------------
@@ -642,6 +644,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('link-hover', handler);
       return () => ipcRenderer.removeListener('link-hover', handler);
     },
+
+    // Issue #6 — Tab search (Cmd+Shift+A)
+    openTabSearch: (cb: () => void): (() => void) => {
+      const handler = () => cb();
+      ipcRenderer.on('open-tab-search', handler);
+      return () => ipcRenderer.removeListener('open-tab-search', handler);
+    },
   },
 
   // Profiles — current profile info + switch
@@ -678,6 +687,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     getAccountInfo: (): Promise<{ email: string; agentName: string } | null> =>
       ipcRenderer.invoke('identity:get-account-info'),
+  },
+
+  // Issue #17 — Omnibox autocomplete providers
+  omnibox: {
+    suggest: (payload: { input: string; remoteSearch?: boolean }): Promise<OmniboxSuggestion[]> =>
+      ipcRenderer.invoke('omnibox:suggest', payload),
+
+    recordSelection: (payload: { inputText: string; url: string; title: string }): Promise<boolean> =>
+      ipcRenderer.invoke('omnibox:record-selection', payload),
+
+    removeHistory: (id: string): Promise<boolean> =>
+      ipcRenderer.invoke('omnibox:remove-history', id),
   },
 
   // Passwords

--- a/my-app/src/renderer/shell/TabSearchDropdown.tsx
+++ b/my-app/src/renderer/shell/TabSearchDropdown.tsx
@@ -1,0 +1,287 @@
+/**
+ * TabSearchDropdown: fuzzy tab search overlay triggered by Cmd+Shift+A.
+ *
+ * Behavior:
+ *   - Opens on 'open-tab-search' IPC event from main
+ *   - Typing fuzzy-filters all open tabs by title and URL
+ *   - Tabs with audio playing float to the top of the list
+ *   - Enter / click → activate selected tab
+ *   - Escape → close
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { TabState } from '../../main/tabs/TabManager';
+
+declare const electronAPI: {
+  tabs: {
+    activate: (tabId: string) => Promise<void>;
+  };
+  on: {
+    openTabSearch: (cb: () => void) => () => void;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const GOOGLE_FAVICON_API = 'https://www.google.com/s2/favicons?sz=32&domain_url=';
+const MAX_RESULTS = 20;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function faviconSrc(tab: TabState): string | null {
+  if (tab.favicon) return tab.favicon;
+  try {
+    const parsed = new URL(tab.url);
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return GOOGLE_FAVICON_API + encodeURIComponent(parsed.origin);
+    }
+  } catch { /* ignore invalid URLs */ }
+  return null;
+}
+
+/**
+ * Fuzzy match: returns a score > 0 if every character of `query` appears
+ * in `text` in order, or -1 if no match. Higher score = better match.
+ * Consecutive matches and matches at word boundaries are weighted higher.
+ */
+function fuzzyScore(text: string, query: string): number {
+  if (!query) return 1;
+  const t = text.toLowerCase();
+  const q = query.toLowerCase();
+  let ti = 0;
+  let qi = 0;
+  let score = 0;
+  let consecutive = 0;
+
+  while (ti < t.length && qi < q.length) {
+    if (t[ti] === q[qi]) {
+      consecutive++;
+      // Bonus for matches at word boundaries
+      const isWordStart = ti === 0 || t[ti - 1] === ' ' || t[ti - 1] === '/' || t[ti - 1] === '.';
+      score += consecutive + (isWordStart ? 5 : 0);
+      qi++;
+    } else {
+      consecutive = 0;
+    }
+    ti++;
+  }
+
+  if (qi < q.length) return -1; // not all query chars matched
+  return score;
+}
+
+function filterAndSort(tabs: TabState[], query: string): TabState[] {
+  if (!query.trim()) {
+    // No query: audible tabs first, then rest in original order
+    const audible = tabs.filter((t) => t.audible);
+    const rest = tabs.filter((t) => !t.audible);
+    return [...audible, ...rest].slice(0, MAX_RESULTS);
+  }
+
+  const q = query.trim();
+  const scored: Array<{ tab: TabState; score: number }> = [];
+
+  for (const tab of tabs) {
+    const titleScore = fuzzyScore(tab.title || 'New Tab', q);
+    const urlScore = fuzzyScore(tab.url, q);
+    const best = Math.max(titleScore, urlScore);
+    if (best > 0) {
+      // Audible tabs get a bonus to float up
+      scored.push({ tab, score: best + (tab.audible ? 100 : 0) });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, MAX_RESULTS).map((s) => s.tab);
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface TabSearchDropdownProps {
+  tabs: TabState[];
+  activeTabId: string | null;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export function TabSearchDropdown({
+  tabs,
+  activeTabId,
+  onClose,
+}: TabSearchDropdownProps): React.ReactElement {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const results = filterAndSort(tabs, query);
+
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Focus input on open
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, []);
+
+  const activateTab = useCallback(
+    (tabId: string) => {
+      console.log('[TabSearchDropdown] Activating tab:', tabId);
+      electronAPI.tabs.activate(tabId);
+      onClose();
+    },
+    [onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex((prev) => Math.min(prev + 1, results.length - 1));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (results[selectedIndex]) {
+            activateTab(results[selectedIndex].id);
+          }
+          break;
+        default:
+          break;
+      }
+    },
+    [results, selectedIndex, activateTab, onClose],
+  );
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.children[selectedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  return (
+    <>
+      {/* Backdrop to close on outside click */}
+      <div className="tab-search__backdrop" onClick={onClose} aria-hidden="true" />
+
+      <div className="tab-search" role="dialog" aria-label="Search tabs" aria-modal="true">
+        <div className="tab-search__input-row">
+          <svg className="tab-search__search-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.4" />
+            <path d="M9.5 9.5l2.5 2.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            className="tab-search__input"
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search tabs"
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            aria-label="Search tabs"
+            aria-controls="tab-search-list"
+            aria-activedescendant={results[selectedIndex] ? `tab-search-item-${results[selectedIndex].id}` : undefined}
+          />
+          {query && (
+            <button
+              type="button"
+              className="tab-search__clear"
+              onClick={() => { setQuery(''); inputRef.current?.focus(); }}
+              aria-label="Clear search"
+              tabIndex={-1}
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+                <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {results.length === 0 ? (
+          <div className="tab-search__empty">No tabs found</div>
+        ) : (
+          <ul
+            id="tab-search-list"
+            ref={listRef}
+            className="tab-search__list"
+            role="listbox"
+            aria-label="Tab results"
+          >
+            {results.map((tab, index) => {
+              const favicon = faviconSrc(tab);
+              const isActive = tab.id === activeTabId;
+              const isSelected = index === selectedIndex;
+              return (
+                <li
+                  key={tab.id}
+                  id={`tab-search-item-${tab.id}`}
+                  className={[
+                    'tab-search__item',
+                    isSelected ? 'tab-search__item--selected' : '',
+                    isActive ? 'tab-search__item--active' : '',
+                  ].filter(Boolean).join(' ')}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => activateTab(tab.id)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                >
+                  <span className="tab-search__item-favicon" aria-hidden="true">
+                    {tab.isLoading ? (
+                      <span className="tab-search__item-spinner" />
+                    ) : favicon ? (
+                      <img src={favicon} alt="" width={16} height={16} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                    ) : (
+                      <span className="tab-search__item-favicon-placeholder" />
+                    )}
+                  </span>
+                  <span className="tab-search__item-text">
+                    <span className="tab-search__item-title">{tab.title || 'New Tab'}</span>
+                    <span className="tab-search__item-url">{tab.url}</span>
+                  </span>
+                  {tab.audible && (
+                    <svg className="tab-search__item-audio" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-label="Playing audio">
+                      <path d="M8 2L4.5 5H2v6h2.5L8 14V2z" fill="currentColor" />
+                      <path d="M11 5.5c.8.8 1.2 1.8 1.2 2.5s-.4 1.7-1.2 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                    </svg>
+                  )}
+                  {isActive && (
+                    <span className="tab-search__item-active-dot" aria-label="Current tab" />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className="tab-search__footer">
+          <span className="tab-search__footer-hint">
+            <kbd>↑↓</kbd> navigate &nbsp; <kbd>↵</kbd> switch &nbsp; <kbd>Esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -11,6 +11,7 @@ import { URLBar } from './URLBar';
 import { BookmarksBar } from './BookmarksBar';
 import { BookmarkDialog } from './BookmarkDialog';
 import { FindBar } from './FindBar';
+import { TabSearchDropdown } from './TabSearchDropdown';
 import { StatusBar } from './StatusBar';
 import { PasswordPromptBar } from './PasswordPromptBar';
 import { PermissionBar } from './PermissionBar';
@@ -129,6 +130,7 @@ declare const electronAPI: {
     closedTabsUpdated: (cb: (records: ClosedTabRecord[]) => void) => () => void;
     windowReady: (cb: () => void) => () => void;
     focusUrlBar: (cb: () => void) => () => void;
+    openTabSearch: (cb: () => void) => () => void;
     targetLost: (cb: (payload: { tabId: string }) => void) => () => void;
     bookmarksUpdated: (cb: (tree: PersistedBookmarks) => void) => () => void;
     openBookmarkDialog: (cb: () => void) => () => void;
@@ -169,6 +171,7 @@ export function WindowChrome(): React.ReactElement {
   const [tabs, setTabs] = useState<TabState[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [urlBarFocused, setUrlBarFocused] = useState(false);
+  const [tabSearchOpen, setTabSearchOpen] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState('');
   const [zoomPercent, setZoomPercent] = useState(100);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -295,6 +298,11 @@ export function WindowChrome(): React.ReactElement {
       setUrlBarFocused(true);
     });
 
+    const unsubTabSearch = electronAPI.on.openTabSearch(() => {
+      console.log('[WindowChrome] Tab search opened');
+      setTabSearchOpen(true);
+    });
+
     const unsubLinkHover = electronAPI.on.linkHover(({ url }) => {
       setHoveredUrl(url);
     });
@@ -331,6 +339,7 @@ export function WindowChrome(): React.ReactElement {
       unsubTabActivated();
       unsubFaviconUpdated();
       unsubFocusUrl();
+      unsubTabSearch();
       unsubLinkHover();
       unsubZoomChanged();
       unsubTargetLost();
@@ -673,6 +682,13 @@ export function WindowChrome(): React.ReactElement {
       <PermissionBar activeTabId={activeTabId} />
       <DevicePickerBar />
       <PasswordPromptBar activeTabId={activeTabId} />
+      {tabSearchOpen && (
+        <TabSearchDropdown
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onClose={() => setTabSearchOpen(false)}
+        />
+      )}
       <FindBar activeTabId={activeTabId} />
       <StatusBar url={hoveredUrl} />
     </div>

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2045,3 +2045,325 @@
   text-overflow: ellipsis;
   line-height: 1;
 }
+
+/* ---------------------------------------------------------------------------
+   OmniboxDropdown — autocomplete suggestions panel (Issue #17)
+   --------------------------------------------------------------------------- */
+.omnibox-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 1px 3px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.omnibox-dropdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.omnibox-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  min-height: 36px;
+  transition: background var(--duration-fast) var(--ease-out);
+  position: relative;
+}
+
+.omnibox-suggestion:hover,
+.omnibox-suggestion--selected {
+  background: var(--color-surface-interactive-hover);
+}
+
+.omnibox-suggestion__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--color-fg-tertiary);
+}
+
+.omnibox-suggestion__favicon {
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+  display: block;
+}
+
+.omnibox-suggestion__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+
+.omnibox-suggestion__title {
+  font-size: 13px;
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.omnibox-suggestion__desc {
+  font-size: 11px;
+  color: var(--color-fg-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.omnibox-suggestion__remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+
+.omnibox-suggestion:hover .omnibox-suggestion__remove,
+.omnibox-suggestion--selected .omnibox-suggestion__remove {
+  opacity: 1;
+}
+
+.omnibox-suggestion__remove:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-fg-primary);
+}
+
+/* ---------------------------------------------------------------------------
+   TabSearchDropdown — Issue #6: Cmd+Shift+A tab search overlay
+   --------------------------------------------------------------------------- */
+
+/* Backdrop dims everything behind the dropdown */
+.tab-search__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: transparent;
+  -webkit-app-region: no-drag;
+}
+
+.tab-search {
+  position: fixed;
+  top: 72px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 560px;
+  max-width: calc(100vw - 48px);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  -webkit-app-region: no-drag;
+}
+
+.tab-search__input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.tab-search__search-icon {
+  color: var(--color-fg-tertiary);
+  flex-shrink: 0;
+}
+
+.tab-search__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-primary);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  outline: none;
+  min-width: 0;
+}
+
+.tab-search__input::placeholder {
+  color: var(--color-fg-tertiary);
+}
+
+.tab-search__clear {
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--color-fg-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.tab-search__clear:hover {
+  color: var(--color-fg-primary);
+}
+
+.tab-search__list {
+  list-style: none;
+  max-height: 336px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.tab-search__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+  -webkit-app-region: no-drag;
+}
+
+.tab-search__item--selected {
+  background: var(--color-surface-interactive-hover);
+}
+
+.tab-search__item-favicon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-search__item-favicon-placeholder {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  background: var(--color-fg-tertiary);
+  opacity: 0.3;
+}
+
+.tab-search__item-spinner {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--color-fg-tertiary);
+  border-top-color: var(--color-accent-default);
+  border-radius: 50%;
+  animation: tab-search-spin 0.8s linear infinite;
+}
+
+@keyframes tab-search-spin {
+  to { transform: rotate(360deg); }
+}
+
+.tab-search__item-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.tab-search__item-title {
+  font-size: 13px;
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-search__item-url {
+  font-size: 11px;
+  color: var(--color-fg-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-search__item-audio {
+  flex-shrink: 0;
+  color: var(--color-accent-default);
+}
+
+.tab-search__item-active-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent-default);
+  flex-shrink: 0;
+}
+
+.tab-search__empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--color-fg-tertiary);
+  font-size: 13px;
+}
+
+.tab-search__footer {
+  padding: 6px 12px;
+  border-top: 1px solid var(--color-border-default);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.tab-search__footer-hint {
+  font-size: 11px;
+  color: var(--color-fg-tertiary);
+  user-select: none;
+}
+
+.tab-search__footer-hint kbd {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  padding: 1px 4px;
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border-default);
+  border-radius: 3px;
+  color: var(--color-fg-secondary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-search__item-spinner {
+    animation: none;
+  }
+  .tab-search__item,
+  .tab-search__clear {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #6

## Summary
- Cmd+Shift+A opens a fuzzy tab search overlay listing all open tabs
- Typing filters by title/URL using a scored fuzzy algorithm (consecutive matches and word-boundary matches rank higher)
- Audible tabs float to the top of the unfiltered list
- Arrow keys navigate, Enter or click switches to the selected tab, Escape closes
- Backdrop click also closes the dropdown

## Test plan
- [ ] Press Cmd+Shift+A — overlay appears centered below the tab strip
- [ ] Type partial tab title/URL — list filters in real time
- [ ] ArrowDown/ArrowUp moves selection, Enter switches to that tab
- [ ] Click a result — switches to that tab and closes overlay
- [ ] Escape closes overlay without switching
- [ ] Tab playing audio appears first in unfiltered list with speaker icon
- [ ] Active tab shows a blue dot indicator
- [ ] Click outside overlay (backdrop) closes it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cmd+Shift+A tab search overlay to quickly find and switch tabs, plus omnibox autocomplete back-end with ranking and persistence. Also enables New/Incognito window shortcuts with a shared incognito session cleared on last close. Closes #6.

- **New Features**
  - Tab search overlay: fuzzy by title/URL, audible tabs first, ↑/↓ navigate, Enter to switch, Esc/backdrop to close.
  - Menu: “Search Tabs…” (Cmd+Shift+A); integrates `TabSearchDropdown` + styles.
  - Windows: Cmd+N New Window and Cmd+Shift+N Incognito; all incognito windows share one session cleared on last close.
  - Omnibox back-end: aggregates shortcuts/history/bookmarks/open tabs; dedupes and ranks; adds `omnibox:suggest`, `omnibox:record-selection`, `omnibox:remove-history`; persists shortcuts via `ShortcutsStore`; exposes `electronAPI.omnibox` (no UI yet).

<sup>Written for commit b8b47858e2ae9f3ec7993d490a34d6d9fdb81b62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

