### PR TITLE
fix(build): revert @vitejs/plugin-react to 4.x (ESM incompatibility with electron-forge 7.x)

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -44,7 +44,7 @@
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
-        "@vitejs/plugin-react": "^5.2.0",
+        "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.1.4",
         "electron": "41.2.1",
         "electron-playwright-helpers": "^1.8.2",
@@ -55,7 +55,7 @@
         "jsdom": "^29.0.2",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
-        "typescript": "~5.6.0",
+        "typescript": "~5.4.5",
         "vite": "^5.4.21",
         "vitest": "^4.1.4"
       }
@@ -1035,20 +1035,6 @@
       },
       "engines": {
         "node": ">= 16.4.0"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack-typescript/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@electron-forge/tracer": {
@@ -3104,9 +3090,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4420,24 +4406,24 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.29.0",
+        "@babel/core": "^7.28.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
+        "react-refresh": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -11828,9 +11814,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13737,9 +13723,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -58,7 +58,7 @@
     "globals": "^17.5.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
-    "@vitejs/plugin-react": "^5.2.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.1.4",
     "electron": "41.2.1",
     "electron-playwright-helpers": "^1.8.2",
@@ -68,7 +68,7 @@
     "jsdom": "^29.0.2",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
-    "typescript": "~5.6.0",
+    "typescript": "~5.4.5",
     "vite": "^5.4.21",
     "vitest": "^4.1.4"
   },

--- a/my-app/tsconfig.json
+++ b/my-app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "preserve",
+    "module": "commonjs",
     "jsx": "react-jsx",
     "allowJs": true,
     "skipLibCheck": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary

- Reverts `@vitejs/plugin-react` from `^5.2.0` back to `^4.7.0` — v5+ ships as ESM-only and cannot be loaded via require() by `@electron-forge/plugin-vite@7.x`
- Reverts `typescript` from `~5.6.0` back to `~5.4.5` (5.6 was only needed for v5's .d.ts syntax)
- Reverts tsconfig.json module from preserve to commonjs and moduleResolution from bundler to node (PR #161 changes)
- Regenerates package-lock.json with downgraded dependencies

## Root Cause

`@electron-forge/plugin-vite@7.x` loads vite config files via esbuild/require (CommonJS), but `@vitejs/plugin-react@5.x` is ESM-only. This causes:

ERROR: [plugin: externalize-deps] @vitejs/plugin-react resolved to an ESM file. ESM file cannot be loaded by require.

The fix is to stay on v4.x until the project upgrades to `@electron-forge/plugin-vite@8.x`, which supports ESM config loading.

## Test plan

- [ ] Run npm install in my-app/ — should complete without errors
- [ ] Run electron-forge start — should start without the ESM require error
- [ ] Run npm run typecheck — should pass with CommonJS module settings
- [ ] Run npm run test — unit tests should pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted `@vitejs/plugin-react` to `^4.7.0` and aligned TypeScript/tsconfig back to CommonJS (TS `~5.4.5`, `module: "commonjs"`, `moduleResolution: "node"`), fixing the ESM/require error with `@electron-forge/plugin-vite@7.x`. This restores `electron-forge start` and keeps us on v4.x until we can move to `@electron-forge/plugin-vite@8.x`.

<sup>Written for commit 804f4527e9338cb204c798364cb36c5c525ed93f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

