### PR TITLE
feat(settings): add Downloads settings tab (closes #39)

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -3,10 +3,11 @@
  * and emits IPC events to the shell renderer for the download bubble UI.
  */
 
-import { BrowserWindow, ipcMain, session, shell, app } from 'electron';
+import { BrowserWindow, dialog, ipcMain, session, shell, app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
 import { mainLogger } from '../logger';
+import { readPrefs } from '../settings/ipc';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -97,6 +98,24 @@ export class DownloadManager {
       const url = item.getURL();
       const totalBytes = item.getTotalBytes();
 
+      // Apply download folder / ask-before-save preferences
+      const prefs = readPrefs();
+      const customFolder = typeof prefs.defaultDownloadFolder === 'string' ? prefs.defaultDownloadFolder : '';
+      if (prefs.askBeforeSave === true) {
+        item.pause();
+        const defaultPath = path.join(customFolder || app.getPath('downloads'), filename);
+        void dialog.showSaveDialog(this.win, { defaultPath }).then((result) => {
+          if (result.canceled || !result.filePath) {
+            item.cancel();
+          } else {
+            item.setSavePath(result.filePath);
+            item.resume();
+          }
+        });
+      } else if (customFolder) {
+        item.setSavePath(path.join(customFolder, filename));
+      }
+
       mainLogger.info('DownloadManager.willDownload', {
         id,
         filename,
@@ -185,11 +204,18 @@ export class DownloadManager {
 
           if (dlItem.openWhenDone && dlItem.savePath) {
             shell.openPath(dlItem.savePath).catch((err) => {
-              mainLogger.warn('DownloadManager.openWhenDone.failed', {
-                id,
-                error: err,
-              });
+              mainLogger.warn('DownloadManager.openWhenDone.failed', { id, error: err });
             });
+          } else if (!dlItem.openWhenDone && dlItem.savePath) {
+            // Auto-open by file type association
+            const ext = path.extname(filename).toLowerCase().slice(1);
+            const fileTypeAssociations = (readPrefs().fileTypeAssociations as Record<string, boolean>) ?? {};
+            if (ext && fileTypeAssociations[ext] === true) {
+              mainLogger.info('DownloadManager.autoOpen', { id, ext });
+              shell.openPath(dlItem.savePath).catch((err) => {
+                mainLogger.warn('DownloadManager.autoOpen.failed', { id, ext, error: err });
+              });
+            }
           }
         } else {
           dlItem.status = 'cancelled';

--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -111,7 +111,7 @@ export class DownloadManager {
             item.setSavePath(result.filePath);
             item.resume();
           }
-        });
+        }).catch(() => { item.cancel(); });
       } else if (customFolder) {
         item.setSavePath(path.join(customFolder, filename));
       }
@@ -207,8 +207,8 @@ export class DownloadManager {
               mainLogger.warn('DownloadManager.openWhenDone.failed', { id, error: err });
             });
           } else if (!dlItem.openWhenDone && dlItem.savePath) {
-            // Auto-open by file type association
-            const ext = path.extname(filename).toLowerCase().slice(1);
+            // Auto-open by file type association — use final saved path, not initial filename
+            const ext = path.extname(dlItem.savePath).toLowerCase().slice(1);
             const fileTypeAssociations = (readPrefs().fileTypeAssociations as Record<string, boolean>) ?? {};
             if (ext && fileTypeAssociations[ext] === true) {
               mainLogger.info('DownloadManager.autoOpen', { id, ext });

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -12,7 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app, ipcMain, session } from 'electron';
+import { app, dialog, ipcMain, session } from 'electron';
 import { mainLogger } from '../logger';
 import type { AccountStore } from '../identity/AccountStore';
 import type { KeychainStore } from '../identity/KeychainStore';
@@ -91,8 +91,15 @@ const CH_GET_HTTPS_FIRST     = 'settings:get-https-first';
 const CH_SET_HTTPS_FIRST     = 'settings:set-https-first';
 const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
-const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
-const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_GPC_ENABLED          = 'settings:get-gpc-enabled';
+const CH_SET_GPC_ENABLED          = 'settings:set-gpc-enabled';
+const CH_GET_DOWNLOAD_FOLDER      = 'settings:get-download-folder';
+const CH_SET_DOWNLOAD_FOLDER      = 'settings:set-download-folder';
+const CH_GET_ASK_BEFORE_SAVE      = 'settings:get-ask-before-save';
+const CH_SET_ASK_BEFORE_SAVE      = 'settings:set-ask-before-save';
+const CH_GET_FILE_TYPE_ASSOC      = 'settings:get-file-type-associations';
+const CH_SET_FILE_TYPE_ASSOC      = 'settings:set-file-type-association';
+const CH_REMOVE_FILE_TYPE_ASSOC   = 'settings:remove-file-type-association';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -671,6 +678,80 @@ export function refreshPrivacyHeaders(): void {
   mainLogger.info('privacy.refreshHeaders.installed');
 }
 
+// ---------------------------------------------------------------------------
+// Downloads settings handlers
+// ---------------------------------------------------------------------------
+
+function handleGetDownloadFolder(): string {
+  mainLogger.info(CH_GET_DOWNLOAD_FOLDER);
+  const prefs = readPrefs();
+  const folder = typeof prefs.defaultDownloadFolder === 'string' ? prefs.defaultDownloadFolder : '';
+  mainLogger.info(`${CH_GET_DOWNLOAD_FOLDER}.ok`, { folder: folder || '(default)' });
+  return folder;
+}
+
+async function handleSetDownloadFolder(): Promise<string> {
+  mainLogger.info(CH_SET_DOWNLOAD_FOLDER);
+  const result = await dialog.showOpenDialog({
+    title: 'Select download folder',
+    defaultPath: app.getPath('downloads'),
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (result.canceled || result.filePaths.length === 0) {
+    mainLogger.info(`${CH_SET_DOWNLOAD_FOLDER}.canceled`);
+    return handleGetDownloadFolder();
+  }
+  const folder = result.filePaths[0];
+  mergePrefs({ defaultDownloadFolder: folder });
+  mainLogger.info(`${CH_SET_DOWNLOAD_FOLDER}.ok`, { folder });
+  return folder;
+}
+
+function handleGetAskBeforeSave(): boolean {
+  mainLogger.info(CH_GET_ASK_BEFORE_SAVE);
+  const prefs = readPrefs();
+  const enabled = prefs.askBeforeSave === true;
+  mainLogger.info(`${CH_GET_ASK_BEFORE_SAVE}.ok`, { enabled });
+  return enabled;
+}
+
+function handleSetAskBeforeSave(_event: Electron.IpcMainInvokeEvent, enabled: boolean): void {
+  if (typeof enabled !== 'boolean') throw new Error('askBeforeSave must be a boolean');
+  mainLogger.info(CH_SET_ASK_BEFORE_SAVE, { enabled });
+  mergePrefs({ askBeforeSave: enabled });
+  mainLogger.info(`${CH_SET_ASK_BEFORE_SAVE}.ok`, { enabled });
+}
+
+function handleGetFileTypeAssociations(): Record<string, boolean> {
+  mainLogger.info(CH_GET_FILE_TYPE_ASSOC);
+  const prefs = readPrefs();
+  const assoc = (prefs.fileTypeAssociations as Record<string, boolean>) ?? {};
+  mainLogger.info(`${CH_GET_FILE_TYPE_ASSOC}.ok`, { count: Object.keys(assoc).length });
+  return assoc;
+}
+
+function handleSetFileTypeAssociation(_event: Electron.IpcMainInvokeEvent, ext: string, enabled: boolean): void {
+  if (typeof ext !== 'string' || !ext) throw new Error('ext must be a non-empty string');
+  if (typeof enabled !== 'boolean') throw new Error('enabled must be a boolean');
+  const normalized = ext.toLowerCase().replace(/^\./, '');
+  mainLogger.info(CH_SET_FILE_TYPE_ASSOC, { ext: normalized, enabled });
+  const prefs = readPrefs();
+  const existing = (prefs.fileTypeAssociations as Record<string, boolean>) ?? {};
+  mergePrefs({ fileTypeAssociations: { ...existing, [normalized]: enabled } });
+  mainLogger.info(`${CH_SET_FILE_TYPE_ASSOC}.ok`, { ext: normalized });
+}
+
+function handleRemoveFileTypeAssociation(_event: Electron.IpcMainInvokeEvent, ext: string): void {
+  if (typeof ext !== 'string' || !ext) throw new Error('ext must be a non-empty string');
+  const normalized = ext.toLowerCase().replace(/^\./, '');
+  mainLogger.info(CH_REMOVE_FILE_TYPE_ASSOC, { ext: normalized });
+  const prefs = readPrefs();
+  const existing = { ...((prefs.fileTypeAssociations as Record<string, boolean>) ?? {}) };
+  delete existing[normalized];
+  mergePrefs({ fileTypeAssociations: existing });
+  mainLogger.info(`${CH_REMOVE_FILE_TYPE_ASSOC}.ok`, { ext: normalized });
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -717,12 +798,19 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_HTTPS_FIRST,    handleSetHttpsFirst);
   ipcMain.handle(CH_GET_DNT_ENABLED,    handleGetDntEnabled);
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
-  ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
-  ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_GPC_ENABLED,         handleGetGpcEnabled);
+  ipcMain.handle(CH_SET_GPC_ENABLED,         handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_DOWNLOAD_FOLDER,     handleGetDownloadFolder);
+  ipcMain.handle(CH_SET_DOWNLOAD_FOLDER,     handleSetDownloadFolder);
+  ipcMain.handle(CH_GET_ASK_BEFORE_SAVE,     handleGetAskBeforeSave);
+  ipcMain.handle(CH_SET_ASK_BEFORE_SAVE,     handleSetAskBeforeSave);
+  ipcMain.handle(CH_GET_FILE_TYPE_ASSOC,     handleGetFileTypeAssociations);
+  ipcMain.handle(CH_SET_FILE_TYPE_ASSOC,     handleSetFileTypeAssociation);
+  ipcMain.handle(CH_REMOVE_FILE_TYPE_ASSOC,  handleRemoveFileTypeAssociation);
 
   refreshPrivacyHeaders();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 34 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -753,6 +841,13 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_DOWNLOAD_FOLDER);
+  ipcMain.removeHandler(CH_SET_DOWNLOAD_FOLDER);
+  ipcMain.removeHandler(CH_GET_ASK_BEFORE_SAVE);
+  ipcMain.removeHandler(CH_SET_ASK_BEFORE_SAVE);
+  ipcMain.removeHandler(CH_GET_FILE_TYPE_ASSOC);
+  ipcMain.removeHandler(CH_SET_FILE_TYPE_ASSOC);
+  ipcMain.removeHandler(CH_REMOVE_FILE_TYPE_ASSOC);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -690,7 +690,7 @@ function handleGetDownloadFolder(): string {
   return folder;
 }
 
-async function handleSetDownloadFolder(): Promise<string> {
+async function handleSetDownloadFolder(): Promise<string | null> {
   mainLogger.info(CH_SET_DOWNLOAD_FOLDER);
   const result = await dialog.showOpenDialog({
     title: 'Select download folder',
@@ -699,7 +699,7 @@ async function handleSetDownloadFolder(): Promise<string> {
   });
   if (result.canceled || result.filePaths.length === 0) {
     mainLogger.info(`${CH_SET_DOWNLOAD_FOLDER}.canceled`);
-    return handleGetDownloadFolder();
+    return null;
   }
   const folder = result.filePaths[0];
   mergePrefs({ defaultDownloadFolder: folder });

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -256,6 +256,15 @@ export interface SettingsAPI {
   /** Reset all per-site overrides */
   resetAllContentCategoryOverrides: () => Promise<void>;
 
+  // Downloads settings
+  getDownloadFolder: () => Promise<string>;
+  setDownloadFolder: () => Promise<string>;
+  getAskBeforeSave: () => Promise<boolean>;
+  setAskBeforeSave: (enabled: boolean) => Promise<void>;
+  getFileTypeAssociations: () => Promise<Record<string, boolean>>;
+  setFileTypeAssociation: (ext: string, enabled: boolean) => Promise<void>;
+  removeFileTypeAssociation: (ext: string) => Promise<void>;
+
   // Autofill — addresses
   saveAddress: (fields: Omit<SavedAddress, 'id' | 'createdAt' | 'updatedAt'>) => Promise<SavedAddress>;
   listAddresses: () => Promise<SavedAddress[]>;
@@ -519,6 +528,42 @@ const api: SettingsAPI = {
   resetAllContentCategoryOverrides: async (): Promise<void> => {
     console.debug('[settings-preload] resetAllContentCategoryOverrides');
     await ipcRenderer.invoke('content-categories:reset-all');
+  },
+
+  // Downloads settings
+  getDownloadFolder: async (): Promise<string> => {
+    console.debug('[settings-preload] getDownloadFolder');
+    return ipcRenderer.invoke('settings:get-download-folder') as Promise<string>;
+  },
+
+  setDownloadFolder: async (): Promise<string> => {
+    console.debug('[settings-preload] setDownloadFolder');
+    return ipcRenderer.invoke('settings:set-download-folder') as Promise<string>;
+  },
+
+  getAskBeforeSave: async (): Promise<boolean> => {
+    console.debug('[settings-preload] getAskBeforeSave');
+    return ipcRenderer.invoke('settings:get-ask-before-save') as Promise<boolean>;
+  },
+
+  setAskBeforeSave: async (enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setAskBeforeSave', { enabled });
+    await ipcRenderer.invoke('settings:set-ask-before-save', enabled);
+  },
+
+  getFileTypeAssociations: async (): Promise<Record<string, boolean>> => {
+    console.debug('[settings-preload] getFileTypeAssociations');
+    return ipcRenderer.invoke('settings:get-file-type-associations') as Promise<Record<string, boolean>>;
+  },
+
+  setFileTypeAssociation: async (ext: string, enabled: boolean): Promise<void> => {
+    console.debug('[settings-preload] setFileTypeAssociation', { ext, enabled });
+    await ipcRenderer.invoke('settings:set-file-type-association', ext, enabled);
+  },
+
+  removeFileTypeAssociation: async (ext: string): Promise<void> => {
+    console.debug('[settings-preload] removeFileTypeAssociation', { ext });
+    await ipcRenderer.invoke('settings:remove-file-type-association', ext);
   },
 
   // Autofill — addresses

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -258,7 +258,7 @@ export interface SettingsAPI {
 
   // Downloads settings
   getDownloadFolder: () => Promise<string>;
-  setDownloadFolder: () => Promise<string>;
+  setDownloadFolder: () => Promise<string | null>;
   getAskBeforeSave: () => Promise<boolean>;
   setAskBeforeSave: (enabled: boolean) => Promise<void>;
   getFileTypeAssociations: () => Promise<Record<string, boolean>>;
@@ -536,9 +536,9 @@ const api: SettingsAPI = {
     return ipcRenderer.invoke('settings:get-download-folder') as Promise<string>;
   },
 
-  setDownloadFolder: async (): Promise<string> => {
+  setDownloadFolder: async (): Promise<string | null> => {
     console.debug('[settings-preload] setDownloadFolder');
-    return ipcRenderer.invoke('settings:set-download-folder') as Promise<string>;
+    return ipcRenderer.invoke('settings:set-download-folder') as Promise<string | null>;
   },
 
   getAskBeforeSave: async (): Promise<boolean> => {

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -37,6 +37,7 @@ const TAB_CONTENT      = 'content'          as const;
 const TAB_PERMISSIONS  = 'permissions'     as const;
 const TAB_ADDRESSES    = 'addresses'        as const;
 const TAB_PAYMENTS     = 'payments'         as const;
+const TAB_DOWNLOADS    = 'downloads'        as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -51,6 +52,7 @@ type TabId =
   | typeof TAB_PERMISSIONS
   | typeof TAB_ADDRESSES
   | typeof TAB_PAYMENTS
+  | typeof TAB_DOWNLOADS
   | typeof TAB_DANGER;
 
 const TABS: Array<{ id: TabId; label: string }> = [
@@ -66,6 +68,7 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_PERMISSIONS, label: 'Permissions' },
   { id: TAB_ADDRESSES,   label: 'Addresses' },
   { id: TAB_PAYMENTS,    label: 'Payments' },
+  { id: TAB_DOWNLOADS,   label: 'Downloads' },
   { id: TAB_DANGER,     label: 'Danger Zone' },
 ];
 
@@ -194,6 +197,13 @@ declare global {
       }>;
       applyAutoRevokePermissions: (revocations: Array<{ origin: string; permissionType: string }>) => Promise<number>;
       optOutAutoRevoke: (origin: string, permissionType: string) => Promise<void>;
+      getDownloadFolder: () => Promise<string>;
+      setDownloadFolder: () => Promise<string>;
+      getAskBeforeSave: () => Promise<boolean>;
+      setAskBeforeSave: (enabled: boolean) => Promise<void>;
+      getFileTypeAssociations: () => Promise<Record<string, boolean>>;
+      setFileTypeAssociation: (ext: string, enabled: boolean) => Promise<void>;
+      removeFileTypeAssociation: (ext: string) => Promise<void>;
     };
   }
 }
@@ -2581,6 +2591,150 @@ function PaymentsTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Downloads tab
+// ---------------------------------------------------------------------------
+
+const COMMON_FILE_TYPES: Array<{ ext: string; label: string }> = [
+  { ext: 'pdf',  label: 'PDF documents (.pdf)' },
+  { ext: 'zip',  label: 'ZIP archives (.zip)' },
+  { ext: 'dmg',  label: 'Disk images (.dmg)' },
+  { ext: 'pkg',  label: 'Installer packages (.pkg)' },
+  { ext: 'mp4',  label: 'Video files (.mp4)' },
+  { ext: 'mp3',  label: 'Audio files (.mp3)' },
+  { ext: 'csv',  label: 'CSV spreadsheets (.csv)' },
+  { ext: 'txt',  label: 'Text files (.txt)' },
+];
+
+function DownloadsTab(): React.ReactElement {
+  const toast = useToast();
+  const [downloadFolder, setDownloadFolder] = useState('');
+  const [askBeforeSave, setAskBeforeSave] = useState(false);
+  const [fileTypeAssoc, setFileTypeAssoc] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void Promise.all([
+      window.settingsAPI.getDownloadFolder(),
+      window.settingsAPI.getAskBeforeSave(),
+      window.settingsAPI.getFileTypeAssociations(),
+    ]).then(([folder, ask, assoc]) => {
+      setDownloadFolder(folder);
+      setAskBeforeSave(ask);
+      setFileTypeAssoc(assoc);
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, []);
+
+  async function handleChangeFolderClick(): Promise<void> {
+    try {
+      const newFolder = await window.settingsAPI.setDownloadFolder();
+      setDownloadFolder(newFolder);
+      toast.show({ variant: 'success', title: 'Download folder updated' });
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to change folder', message: (err as Error).message });
+    }
+  }
+
+  async function handleAskBeforeSaveToggle(checked: boolean): Promise<void> {
+    setAskBeforeSave(checked);
+    try {
+      await window.settingsAPI.setAskBeforeSave(checked);
+      toast.show({
+        variant: 'success',
+        title: checked ? 'Will prompt for save location' : 'Saving to download folder automatically',
+      });
+    } catch (err) {
+      setAskBeforeSave(!checked);
+      toast.show({ variant: 'error', title: 'Failed to update setting', message: (err as Error).message });
+    }
+  }
+
+  async function handleFileTypeToggle(ext: string, checked: boolean): Promise<void> {
+    setFileTypeAssoc((prev) => ({ ...prev, [ext]: checked }));
+    try {
+      await window.settingsAPI.setFileTypeAssociation(ext, checked);
+    } catch (err) {
+      setFileTypeAssoc((prev) => ({ ...prev, [ext]: !checked }));
+      toast.show({ variant: 'error', title: 'Failed to update setting', message: (err as Error).message });
+    }
+  }
+
+  const displayFolder = downloadFolder || '(System default downloads folder)';
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Downloads</h2>
+      <p className="settings-section-desc">
+        Choose where downloads are saved and when to be prompted.
+      </p>
+
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          <Card variant="default" padding="md" className="settings-card">
+            <div className="settings-toggle-row">
+              <div className="settings-toggle-info">
+                <span className="settings-toggle-label">Download location</span>
+                <span className="settings-toggle-desc" style={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                  {displayFolder}
+                </span>
+              </div>
+              <Button variant="secondary" size="sm" onClick={() => void handleChangeFolderClick()}>
+                Change…
+              </Button>
+            </div>
+          </Card>
+
+          <Card variant="default" padding="md" className="settings-card">
+            <div className="settings-toggle-row">
+              <div className="settings-toggle-info">
+                <span className="settings-toggle-label">Ask where to save each file before downloading</span>
+                <span className="settings-toggle-desc">
+                  When enabled, a save dialog appears for every download. When disabled,
+                  files are saved directly to the download folder.
+                </span>
+              </div>
+              <label className="settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={askBeforeSave}
+                  onChange={(e) => void handleAskBeforeSaveToggle(e.target.checked)}
+                />
+                <span className="settings-toggle-track" />
+              </label>
+            </div>
+          </Card>
+
+          <Card variant="default" padding="md" className="settings-card">
+            <div style={{ marginBottom: 12 }}>
+              <span className="settings-toggle-label">Open files of these types automatically</span>
+              <p className="settings-toggle-desc" style={{ marginTop: 4 }}>
+                Files of the selected types will be opened after downloading completes.
+              </p>
+            </div>
+            {COMMON_FILE_TYPES.map(({ ext, label }) => (
+              <div key={ext} className="settings-toggle-row" style={{ paddingTop: 8, paddingBottom: 8 }}>
+                <div className="settings-toggle-info">
+                  <span className="settings-toggle-label" style={{ fontWeight: 400 }}>{label}</span>
+                </div>
+                <label className="settings-toggle">
+                  <input
+                    type="checkbox"
+                    checked={fileTypeAssoc[ext] === true}
+                    onChange={(e) => void handleFileTypeToggle(ext, e.target.checked)}
+                  />
+                  <span className="settings-toggle-track" />
+                </label>
+              </div>
+            ))}
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Inner app (uses useToast — must be inside ToastProvider)
 // ---------------------------------------------------------------------------
 
@@ -2644,6 +2798,7 @@ function SettingsInner(): React.ReactElement {
     [TAB_PERMISSIONS]: <PermissionsTab />,
     [TAB_ADDRESSES]:   <AddressesTab />,
     [TAB_PAYMENTS]:    <PaymentsTab />,
+    [TAB_DOWNLOADS]:   <DownloadsTab />,
     [TAB_CONTENT]:    <ContentCategoriesTab />,
     [TAB_DANGER]:     <DangerZoneTab />,
   };

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2627,8 +2627,10 @@ function DownloadsTab(): React.ReactElement {
   async function handleChangeFolderClick(): Promise<void> {
     try {
       const newFolder = await window.settingsAPI.setDownloadFolder();
-      setDownloadFolder(newFolder);
-      toast.show({ variant: 'success', title: 'Download folder updated' });
+      if (newFolder !== null) {
+        setDownloadFolder(newFolder);
+        toast.show({ variant: 'success', title: 'Download folder updated' });
+      }
     } catch (err) {
       toast.show({ variant: 'error', title: 'Failed to change folder', message: (err as Error).message });
     }


### PR DESCRIPTION
## Summary
- Adds a **Downloads** tab to the Settings page with three controls:
  - **Download folder** — shows current path with a picker button to change it
  - **Ask before saving** — toggle to prompt user with a Save dialog on each download
  - **Auto-open by file type** — checkboxes for common types (pdf, zip, dmg, pkg, mp4, mp3, csv, txt)
- Wires preferences into `DownloadManager` so `will-download` respects the stored settings at runtime
- Stores all preferences in the existing `preferences.json` via `readPrefs()` / `mergePrefs()`

## Test plan
- [ ] Open Settings → Downloads tab is visible and renders correctly
- [ ] Click "Change…" — folder picker dialog opens; selecting a folder updates the displayed path
- [ ] Enable "Ask before saving" — downloading a file prompts a Save As dialog
- [ ] Enable auto-open for `pdf` — downloaded PDF opens automatically after completion
- [ ] All existing settings tabs still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Downloads tab in Settings to control where files are saved, when to ask before saving, and which file types auto-open. Implements #39 and wires these prefs into the download flow, with fixes for dialog cancellation, file-type detection, and folder-picker UX.

- **New Features**
  - Settings → Downloads tab: folder picker, ask-before-save toggle, and auto-open checkboxes (pdf, zip, dmg, pkg, mp4, mp3, csv, txt)
  - `DownloadManager` applies prefs at runtime: Save dialog when ask-before-save is on; otherwise uses the selected folder; auto-opens completed downloads for selected types
  - New settings IPC + preload APIs; values persisted in `preferences.json`

- **Bug Fixes**
  - Prevent stuck downloads by canceling when the Save dialog is dismissed or rejects
  - Use the final saved path to detect file type for auto-open instead of the initial filename
  - Suppress success toast when the download folder picker is canceled

<sup>Written for commit 663a3b04f5924cd957333bd565274935a2f3df89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

