### PR TITLE
feat(bookmarks): Cmd+click folder opens all tabs; Cmd+Shift+D bookmark all tabs (closes #34, #33)

### DIFF
--- a/my-app/src/main/bookmarks/ipc.ts
+++ b/my-app/src/main/bookmarks/ipc.ts
@@ -107,9 +107,12 @@ export function registerBookmarkHandlers(opts: BookmarksIpcOptions): void {
 
   ipcMain.handle('bookmarks:get-visibility', () => store.getVisibility());
 
-  ipcMain.handle('bookmarks:bookmark-all-tabs', (_e, payload: { folderName: string }) => {
+  ipcMain.handle('bookmarks:bookmark-all-tabs', (_e, payload: { folderName: string; parentId?: string }) => {
     const folderName = assertString(payload?.folderName, 'folderName', 512);
-    const folder = store.addFolder({ name: folderName });
+    const parentId = payload?.parentId
+      ? assertString(payload.parentId, 'parentId', 128)
+      : undefined;
+    const folder = store.addFolder({ name: folderName, parentId });
     for (const t of getAllTabs()) {
       if (!t.url || /^(data:|about:)/i.test(t.url)) continue;
       store.addBookmark({ name: t.name || t.url, url: t.url, parentId: folder.id });

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1437,7 +1437,10 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
         {
           label: 'Bookmark All Tabs…',
           accelerator: 'CommandOrControl+Shift+D',
-          enabled: false,
+          click: () => {
+            mainLogger.debug('shortcuts.bookmarkAllTabs');
+            shellWindow?.webContents.send('open-bookmark-all-tabs-dialog');
+          },
         },
         { type: 'separator' },
         {
@@ -1760,6 +1763,10 @@ ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) 
         {
           label: 'Bookmark This Tab…', accelerator: 'Ctrl+D',
           click: () => { shellWindow?.webContents.send('open-bookmark-dialog'); },
+        },
+        {
+          label: 'Bookmark All Tabs…', accelerator: 'Ctrl+Shift+D',
+          click: () => { shellWindow?.webContents.send('open-bookmark-all-tabs-dialog'); },
         },
         {
           label: 'Show Bookmarks Bar', accelerator: 'Ctrl+Shift+B',

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -151,7 +151,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getVisibility: (): Promise<Visibility> =>
       ipcRenderer.invoke('bookmarks:get-visibility'),
 
-    bookmarkAllTabs: (payload: { folderName: string }): Promise<BookmarkNode> =>
+    bookmarkAllTabs: (payload: { folderName: string; parentId?: string }): Promise<BookmarkNode> =>
       ipcRenderer.invoke('bookmarks:bookmark-all-tabs', payload),
   },
 
@@ -472,6 +472,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       const handler = () => cb();
       ipcRenderer.on('open-bookmark-dialog', handler);
       return () => ipcRenderer.removeListener('open-bookmark-dialog', handler);
+    },
+
+    openBookmarkAllTabsDialog: (cb: () => void): (() => void) => {
+      const handler = () => cb();
+      ipcRenderer.on('open-bookmark-all-tabs-dialog', handler);
+      return () => ipcRenderer.removeListener('open-bookmark-all-tabs-dialog', handler);
     },
 
     toggleBookmarksBar: (cb: () => void): (() => void) => {

--- a/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
+++ b/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
@@ -1,0 +1,164 @@
+/**
+ * BookmarkAllTabsDialog — modal for Cmd+Shift+D "Bookmark All Tabs".
+ *
+ * Lets the user set a folder name and destination before saving every
+ * open tab as a bookmark folder.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { BookmarkNode, PersistedBookmarks } from '../../main/bookmarks/BookmarkStore';
+
+declare const electronAPI: {
+  bookmarks: {
+    bookmarkAllTabs: (payload: { folderName: string; parentId?: string }) => Promise<BookmarkNode>;
+  };
+};
+
+export interface BookmarkAllTabsDialogProps {
+  tree: PersistedBookmarks;
+  onClose: () => void;
+}
+
+interface FolderOption {
+  id: string;
+  label: string;
+  depth: number;
+}
+
+function flattenFolders(tree: PersistedBookmarks): FolderOption[] {
+  const out: FolderOption[] = [];
+  const walk = (node: BookmarkNode, depth: number): void => {
+    if (node.type !== 'folder') return;
+    out.push({ id: node.id, label: node.name, depth });
+    for (const child of node.children ?? []) {
+      if (child.type === 'folder') walk(child, depth + 1);
+    }
+  };
+  for (const root of tree.roots) walk(root, 0);
+  return out;
+}
+
+export function BookmarkAllTabsDialog({
+  tree,
+  onClose,
+}: BookmarkAllTabsDialogProps): React.ReactElement {
+  const defaultName = `Tabs — ${new Date().toLocaleDateString()}`;
+  const [folderName, setFolderName] = useState(defaultName);
+  const [parentId, setParentId] = useState<string>(tree.roots[0].id);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scrimRef = useRef<HTMLDivElement>(null);
+  const folders = useMemo(() => flattenFolders(tree), [tree]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    let cleanup = (): void => {};
+    const raf = requestAnimationFrame(() => {
+      const handler = (e: MouseEvent): void => {
+        if (scrimRef.current && e.target === scrimRef.current) onClose();
+      };
+      document.addEventListener('click', handler);
+      cleanup = () => document.removeEventListener('click', handler);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      cleanup();
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleSave = useCallback(async () => {
+    const name = folderName.trim() || defaultName;
+    await electronAPI.bookmarks.bookmarkAllTabs({ folderName: name, parentId });
+    onClose();
+  }, [folderName, defaultName, parentId, onClose]);
+
+  const handleFormKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') { e.preventDefault(); void handleSave(); }
+    },
+    [handleSave],
+  );
+
+  return (
+    <div
+      ref={scrimRef}
+      className="bookmark-dialog__scrim"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Bookmark all tabs"
+    >
+      <div className="bookmark-dialog" onKeyDown={handleFormKeyDown}>
+        <div className="bookmark-dialog__header">
+          <h2 className="bookmark-dialog__title">Bookmark all tabs</h2>
+          <button
+            type="button"
+            className="bookmark-dialog__close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+              <path
+                d="M3 3l6 6M9 3l-6 6"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <label className="bookmark-dialog__field">
+          <span className="bookmark-dialog__label">Folder name</span>
+          <input
+            ref={inputRef}
+            className="bookmark-dialog__input"
+            type="text"
+            value={folderName}
+            onChange={(e) => setFolderName(e.target.value)}
+            spellCheck={false}
+          />
+        </label>
+
+        <label className="bookmark-dialog__field">
+          <span className="bookmark-dialog__label">Folder</span>
+          <select
+            className="bookmark-dialog__select"
+            value={parentId}
+            onChange={(e) => setParentId(e.target.value)}
+          >
+            {folders.map((f) => (
+              <option key={f.id} value={f.id}>
+                {`${'\u00A0\u00A0'.repeat(f.depth)}${f.label}`}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="bookmark-dialog__actions">
+          <div className="bookmark-dialog__spacer" />
+          <button type="button" className="bookmark-dialog__btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="bookmark-dialog__btn bookmark-dialog__btn--primary"
+            onClick={() => void handleSave()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
+++ b/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
@@ -79,8 +79,12 @@ export function BookmarkAllTabsDialog({
 
   const handleSave = useCallback(async () => {
     const name = folderName.trim() || defaultName;
-    await electronAPI.bookmarks.bookmarkAllTabs({ folderName: name, parentId });
-    onClose();
+    try {
+      await electronAPI.bookmarks.bookmarkAllTabs({ folderName: name, parentId });
+      onClose();
+    } catch {
+      // keep dialog open so user can retry
+    }
   }, [folderName, defaultName, parentId, onClose]);
 
   const handleFormKeyDown = useCallback(

--- a/my-app/src/renderer/shell/BookmarksBar.tsx
+++ b/my-app/src/renderer/shell/BookmarksBar.tsx
@@ -27,21 +27,29 @@ declare const electronAPI: {
     remove: (id: string) => Promise<boolean>;
     move: (payload: { id: string; newParentId: string; index: number }) => Promise<boolean>;
     addFolder: (payload: { name: string; parentId?: string }) => Promise<BookmarkNode>;
-    bookmarkAllTabs: (payload: { folderName: string }) => Promise<BookmarkNode>;
   };
 };
+
+function collectBookmarkUrls(node: BookmarkNode): string[] {
+  if (node.type === 'bookmark') return node.url ? [node.url] : [];
+  const urls: string[] = [];
+  for (const child of node.children ?? []) urls.push(...collectBookmarkUrls(child));
+  return urls;
+}
 
 interface BookmarksBarProps {
   tree: PersistedBookmarks;
   onOpen: (url: string) => void;
   onOpenInNewTab: (url: string) => void;
   focusTick: number;
+  onBookmarkAllTabs: () => void;
 }
 
 interface ChipProps {
   node: BookmarkNode;
   onOpen: (url: string) => void;
   onOpenInNewTab: (url: string) => void;
+  onOpenAllInFolder: (node: BookmarkNode) => void;
   onDragStart: (e: React.DragEvent, id: string) => void;
   onDragOver: (e: React.DragEvent, id: string) => void;
   onDrop: (e: React.DragEvent, id: string) => void;
@@ -53,6 +61,7 @@ function Chip({
   node,
   onOpen,
   onOpenInNewTab,
+  onOpenAllInFolder,
   onDragStart,
   onDragOver,
   onDrop,
@@ -71,17 +80,25 @@ function Chip({
       onDrop={(e) => onDrop(e, node.id)}
       onContextMenu={(e) => onContextMenu(e, node)}
       onClick={(e) => {
+        if (node.type === 'folder') {
+          if (e.metaKey || e.ctrlKey) onOpenAllInFolder(node);
+          return;
+        }
         if (!node.url) return;
-        if (e.metaKey || e.ctrlKey || e.button === 1) {
+        if (e.metaKey || e.ctrlKey) {
           onOpenInNewTab(node.url);
         } else {
           onOpen(node.url);
         }
       }}
       onAuxClick={(e) => {
-        if (e.button === 1 && node.url) onOpenInNewTab(node.url);
+        if (e.button !== 1) return;
+        if (node.type === 'folder') { onOpenAllInFolder(node); return; }
+        if (node.url) onOpenInNewTab(node.url);
       }}
-      title={`${node.name}${node.url ? `\n${node.url}` : ''}`}
+      title={node.type === 'folder'
+        ? `${node.name}\nCmd+click to open all`
+        : `${node.name}${node.url ? `\n${node.url}` : ''}`}
     >
       <span className="bookmarks-bar__chip-icon" aria-hidden="true">
         {node.type === 'folder' ? (
@@ -120,6 +137,7 @@ export function BookmarksBar({
   onOpen,
   onOpenInNewTab,
   focusTick,
+  onBookmarkAllTabs,
 }: BookmarksBarProps): React.ReactElement {
   const barRef = useRef<HTMLDivElement>(null);
   const chipRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -259,12 +277,17 @@ export function BookmarksBar({
   }, [tree.roots]);
 
   const handleBookmarkAllTabs = useCallback(() => {
-    const stamp = new Date().toLocaleDateString();
-    void electronAPI.bookmarks.bookmarkAllTabs({
-      folderName: `Tabs — ${stamp}`,
-    });
     setContextMenu(null);
-  }, []);
+    onBookmarkAllTabs();
+  }, [onBookmarkAllTabs]);
+
+  const handleOpenAllInFolder = useCallback(
+    (node: BookmarkNode) => {
+      const urls = collectBookmarkUrls(node);
+      for (const url of urls) onOpenInNewTab(url);
+    },
+    [onOpenInNewTab],
+  );
 
   const handleDelete = useCallback((id: string) => {
     void electronAPI.bookmarks.remove(id);
@@ -301,6 +324,7 @@ export function BookmarksBar({
               node={node}
               onOpen={onOpen}
               onOpenInNewTab={onOpenInNewTab}
+              onOpenAllInFolder={handleOpenAllInFolder}
               onDragStart={handleDragStart}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
@@ -325,6 +349,7 @@ export function BookmarksBar({
               node={node}
               onOpen={() => undefined}
               onOpenInNewTab={() => undefined}
+              onOpenAllInFolder={() => undefined}
               onDragStart={() => undefined}
               onDragOver={() => undefined}
               onDrop={() => undefined}
@@ -395,16 +420,29 @@ export function BookmarksBar({
         >
           {contextMenu.target ? (
             <>
-              <button
-                type="button"
-                className="bookmarks-bar__menu-item"
-                onClick={() => {
-                  if (contextMenu.target?.url) onOpen(contextMenu.target.url);
-                  setContextMenu(null);
-                }}
-              >
-                Open
-              </button>
+              {contextMenu.target.type === 'folder' ? (
+                <button
+                  type="button"
+                  className="bookmarks-bar__menu-item"
+                  onClick={() => {
+                    handleOpenAllInFolder(contextMenu.target!);
+                    setContextMenu(null);
+                  }}
+                >
+                  Open all ({collectBookmarkUrls(contextMenu.target).length})
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="bookmarks-bar__menu-item"
+                  onClick={() => {
+                    if (contextMenu.target?.url) onOpen(contextMenu.target.url);
+                    setContextMenu(null);
+                  }}
+                >
+                  Open
+                </button>
+              )}
               <button
                 type="button"
                 className="bookmarks-bar__menu-item bookmarks-bar__menu-item--danger"

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -10,6 +10,7 @@ import { NavButtons } from './NavButtons';
 import { URLBar } from './URLBar';
 import { BookmarksBar } from './BookmarksBar';
 import { BookmarkDialog } from './BookmarkDialog';
+import { BookmarkAllTabsDialog } from './BookmarkAllTabsDialog';
 import { FindBar } from './FindBar';
 import { TabSearchDropdown } from './TabSearchDropdown';
 import { StatusBar } from './StatusBar';
@@ -134,6 +135,7 @@ declare const electronAPI: {
     targetLost: (cb: (payload: { tabId: string }) => void) => () => void;
     bookmarksUpdated: (cb: (tree: PersistedBookmarks) => void) => () => void;
     openBookmarkDialog: (cb: () => void) => () => void;
+    openBookmarkAllTabsDialog: (cb: () => void) => () => void;
     toggleBookmarksBar: (cb: () => void) => () => void;
     focusBookmarksBar: (cb: () => void) => () => void;
     zoomChanged: (cb: (payload: { percent: number }) => void) => () => void;
@@ -179,6 +181,7 @@ export function WindowChrome(): React.ReactElement {
   // Bookmarks state
   const [bookmarksTree, setBookmarksTree] = useState<PersistedBookmarks | null>(null);
   const [bookmarkDialogOpen, setBookmarkDialogOpen] = useState(false);
+  const [bookmarkAllTabsDialogOpen, setBookmarkAllTabsDialogOpen] = useState(false);
   const [focusBookmarksBarTick, setFocusBookmarksBarTick] = useState(0);
 
   // Downloads state
@@ -323,6 +326,10 @@ export function WindowChrome(): React.ReactElement {
       setBookmarkDialogOpen(true);
     });
 
+    const unsubOpenAllTabsDialog = electronAPI.on.openBookmarkAllTabsDialog(() => {
+      setBookmarkAllTabsDialogOpen(true);
+    });
+
     const unsubToggleBar = electronAPI.on.toggleBookmarksBar(() => {
       const current = bookmarksTree?.visibility ?? 'always';
       const next: Visibility = current === 'always' ? 'never' : 'always';
@@ -345,6 +352,7 @@ export function WindowChrome(): React.ReactElement {
       unsubTargetLost();
       unsubBookmarksUpdated();
       unsubOpenDialog();
+      unsubOpenAllTabsDialog();
       unsubToggleBar();
       unsubFocusBar();
     };
@@ -666,6 +674,14 @@ export function WindowChrome(): React.ReactElement {
             electronAPI.tabs.create(url);
           }}
           focusTick={focusBookmarksBarTick}
+          onBookmarkAllTabs={() => setBookmarkAllTabsDialogOpen(true)}
+        />
+      )}
+
+      {bookmarkAllTabsDialogOpen && bookmarksTree && (
+        <BookmarkAllTabsDialog
+          tree={bookmarksTree}
+          onClose={() => setBookmarkAllTabsDialogOpen(false)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- **Issue #34**: Cmd+click (or middle-click) a bookmark folder chip opens all its bookmarks as new tabs; right-click shows "Open all (N)" in the context menu
- **Issue #33**: Cmd+Shift+D (also available in the Bookmarks menu and bookmarks-bar empty-area context menu) opens a dialog to set the folder name and destination before saving all open tabs as bookmarks
- `bookmarks:bookmark-all-tabs` IPC now accepts an optional `parentId` so the dialog can choose the destination folder
- The "Bookmark all tabs…" context menu item on the bookmarks bar now opens the full dialog instead of silently using a default name

## Test plan
- [ ] Right-click a folder on the bookmarks bar → "Open all (N)" is shown and opens N tabs
- [ ] Cmd+click a folder chip → all bookmarks in the folder open as new tabs
- [ ] Middle-click a folder chip → all bookmarks in the folder open as new tabs
- [ ] Cmd+Shift+D opens the "Bookmark all tabs" dialog with a folder name input and destination selector
- [ ] Saving from the dialog creates a folder with all current tabs as bookmarks
- [ ] Right-clicking empty bar area → "Bookmark all tabs…" opens the same dialog
- [ ] Regular click on a folder chip does nothing (no navigation)
- [ ] Existing bookmark chips still open normally on click / Cmd+click / middle-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “open all in folder” and a “Bookmark all tabs” dialog to make working with many tabs faster. Addresses #34 and #33.

- New Features
  - Cmd/Ctrl+click or middle-click a bookmark folder chip opens all its bookmarks in new tabs; right-click shows “Open all (N)”.
  - Cmd/Ctrl+Shift+D (also in the Bookmarks menu and bookmarks-bar empty-area menu) opens a dialog to name the folder and choose its destination before saving all open tabs.
  - Bookmarks bar “Bookmark all tabs…” now opens the same dialog.
  - `bookmarks:bookmark-all-tabs` IPC accepts optional `parentId` to place the new folder under a chosen parent.

- Bug Fixes
  - Dialog stays open if saving fails (wraps `bookmarkAllTabs` in try/catch) so users can retry.

<sup>Written for commit 287c81dc9e5959a3772c667a04a87ac691583249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

