### PR TITLE
feat(tabs): tab hover card with thumbnail screenshot (closes #8)

### DIFF
--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2296,6 +2296,19 @@ export class TabManager {
       this.unpinTab(tabId);
     });
 
+    // Issue #8 — Tab hover card thumbnail
+    ipcMain.handle('tabs:capture-thumbnail', async (_e, tabId: string) => {
+      const view = this.tabs.get(tabId);
+      if (!view || view.webContents.isDestroyed()) return null;
+      try {
+        const image = await view.webContents.capturePage({ x: 0, y: 0, width: 560, height: 350 });
+        const resized = image.resize({ width: 280, height: 175 });
+        return resized.toDataURL();
+      } catch {
+        return null;
+      }
+    });
+
     // Issue #19 — back/forward long-press history menu
     ipcMain.handle('tabs:show-back-history', (_e, tabId: string) => {
       this.showBackHistoryMenu(tabId);

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -103,6 +103,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     muteTab: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:mute-tab', tabId),
 
+    captureThumbnail: (tabId: string): Promise<string | null> =>
+      ipcRenderer.invoke('tabs:capture-thumbnail', tabId),
+
     showBackHistory: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:show-back-history', tabId),
 

--- a/my-app/src/renderer/shell/TabHoverCard.tsx
+++ b/my-app/src/renderer/shell/TabHoverCard.tsx
@@ -29,6 +29,7 @@ export function TabHoverCard({
   const [thumbnail, setThumbnail] = useState<string | null>(null);
 
   useEffect(() => {
+    setThumbnail(null);
     let cancelled = false;
     void electronAPI.tabs.captureThumbnail(tabId).then((dataUrl) => {
       if (!cancelled) setThumbnail(dataUrl);
@@ -37,11 +38,15 @@ export function TabHoverCard({
   }, [tabId]);
 
   const CARD_WIDTH = 280;
+  const CARD_HEIGHT = 175 + 56; // thumbnail + body estimate
   const left = Math.max(4, Math.min(
     anchorRect.left + anchorRect.width / 2 - CARD_WIDTH / 2,
     window.innerWidth - CARD_WIDTH - 4,
   ));
-  const top = anchorRect.bottom + 6;
+  const topBelow = anchorRect.bottom + 6;
+  const top = topBelow + CARD_HEIGHT > window.innerHeight
+    ? Math.max(4, anchorRect.top - CARD_HEIGHT - 6)
+    : topBelow;
 
   const displayUrl = (() => {
     try { return new URL(url).hostname || url; } catch { return url; }

--- a/my-app/src/renderer/shell/TabHoverCard.tsx
+++ b/my-app/src/renderer/shell/TabHoverCard.tsx
@@ -1,0 +1,73 @@
+/**
+ * TabHoverCard — tooltip-style card shown when hovering a tab chip.
+ *
+ * Shows the tab's title, URL, and a thumbnail screenshot.
+ * Positioned absolutely below the hovered tab.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+declare const electronAPI: {
+  tabs: {
+    captureThumbnail: (tabId: string) => Promise<string | null>;
+  };
+};
+
+interface TabHoverCardProps {
+  tabId: string;
+  title: string;
+  url: string;
+  anchorRect: DOMRect;
+}
+
+export function TabHoverCard({
+  tabId,
+  title,
+  url,
+  anchorRect,
+}: TabHoverCardProps): React.ReactElement {
+  const [thumbnail, setThumbnail] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void electronAPI.tabs.captureThumbnail(tabId).then((dataUrl) => {
+      if (!cancelled) setThumbnail(dataUrl);
+    });
+    return () => { cancelled = true; };
+  }, [tabId]);
+
+  const CARD_WIDTH = 280;
+  const left = Math.max(4, Math.min(
+    anchorRect.left + anchorRect.width / 2 - CARD_WIDTH / 2,
+    window.innerWidth - CARD_WIDTH - 4,
+  ));
+  const top = anchorRect.bottom + 6;
+
+  const displayUrl = (() => {
+    try { return new URL(url).hostname || url; } catch { return url; }
+  })();
+
+  return (
+    <div
+      className="tab-hover-card"
+      style={{ left, top, width: CARD_WIDTH }}
+      role="tooltip"
+    >
+      {thumbnail ? (
+        <img
+          className="tab-hover-card__thumbnail"
+          src={thumbnail}
+          alt=""
+          width={CARD_WIDTH}
+          height={175}
+        />
+      ) : (
+        <div className="tab-hover-card__thumbnail-placeholder" />
+      )}
+      <div className="tab-hover-card__body">
+        <p className="tab-hover-card__title">{title || 'New Tab'}</p>
+        {displayUrl && <p className="tab-hover-card__url">{displayUrl}</p>}
+      </div>
+    </div>
+  );
+}

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -13,11 +13,13 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { TabState } from '../../main/tabs/TabManager';
+import { TabHoverCard } from './TabHoverCard';
 
 declare const electronAPI: {
   tabs: {
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
+    captureThumbnail: (tabId: string) => Promise<string | null>;
   };
 };
 
@@ -57,6 +59,8 @@ interface TabStripProps {
 // ---------------------------------------------------------------------------
 // Individual tab
 // ---------------------------------------------------------------------------
+const HOVER_DELAY_MS = 500;
+
 interface TabItemProps {
   tab: TabState;
   index: number;
@@ -72,6 +76,8 @@ interface TabItemProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
   tabRef: (el: HTMLDivElement | null) => void;
   onMuteToggle: (e: React.MouseEvent) => void;
+  onHoverStart: (tab: TabState, rect: DOMRect) => void;
+  onHoverEnd: () => void;
 }
 
 function TabItem({
@@ -89,12 +95,29 @@ function TabItem({
   onKeyDown,
   tabRef,
   onMuteToggle,
+  onHoverStart,
+  onHoverEnd,
 }: TabItemProps): React.ReactElement {
   const isPinned = tab.pinned;
   const favicon = faviconSrc(tab);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const elemRef = useRef<HTMLDivElement | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    hoverTimer.current = setTimeout(() => {
+      const rect = elemRef.current?.getBoundingClientRect();
+      if (rect) onHoverStart(tab, rect);
+    }, HOVER_DELAY_MS);
+  }, [tab, onHoverStart]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimer.current) { clearTimeout(hoverTimer.current); hoverTimer.current = null; }
+    onHoverEnd();
+  }, [onHoverEnd]);
+
   return (
     <div
-      ref={tabRef}
+      ref={(el) => { elemRef.current = el; tabRef(el); }}
       className={[
         'tab-item',
         isActive ? 'tab-item--active' : '',
@@ -114,6 +137,8 @@ function TabItem({
       onDragOver={(e) => onDragOver(e, index)}
       onDrop={(e) => onDrop(e, index)}
       onContextMenu={onContextMenu}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       title={isPinned || isIconOnly ? tab.title : undefined}
     >
       {/* Favicon / loading spinner / audio indicator */}
@@ -282,6 +307,11 @@ function TabSearchDropdown({
 // ---------------------------------------------------------------------------
 // TabStrip
 // ---------------------------------------------------------------------------
+interface HoverState {
+  tab: TabState;
+  rect: DOMRect;
+}
+
 export function TabStrip({
   tabs,
   activeTabId,
@@ -294,6 +324,7 @@ export function TabStrip({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [iconOnlySet, setIconOnlySet] = useState<Set<string>>(new Set());
   const [searchOpen, setSearchOpen] = useState(false);
+  const [hoverState, setHoverState] = useState<HoverState | null>(null);
   const dragTabId = useRef<string | null>(null);
   const tabRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const tabsContainerRef = useRef<HTMLDivElement>(null);
@@ -478,6 +509,8 @@ export function TabStrip({
               e.stopPropagation();
               onMuteToggle(tab.id);
             }}
+            onHoverStart={(t, rect) => setHoverState({ tab: t, rect })}
+            onHoverEnd={() => setHoverState(null)}
           />
         ))}
         {/* + button sits right after the last tab (Chrome-style), not pinned right */}
@@ -523,6 +556,15 @@ export function TabStrip({
           activeTabId={activeTabId}
           onActivate={onActivate}
           onClose={() => setSearchOpen(false)}
+        />
+      )}
+
+      {hoverState && (
+        <TabHoverCard
+          tabId={hoverState.tab.id}
+          title={hoverState.tab.title}
+          url={hoverState.tab.url}
+          anchorRect={hoverState.rect}
         />
       )}
     </div>

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -103,6 +103,12 @@ function TabItem({
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const elemRef = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (hoverTimer.current) clearTimeout(hoverTimer.current);
+    };
+  }, []);
+
   const handleMouseEnter = useCallback(() => {
     hoverTimer.current = setTimeout(() => {
       const rect = elemRef.current?.getBoundingClientRect();

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2367,3 +2367,60 @@
     transition: none;
   }
 }
+
+/* Tab hover card (issue #8) */
+.tab-hover-card {
+  position: fixed;
+  z-index: 600;
+  background: var(--color-bg-overlay);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  pointer-events: none;
+  -webkit-app-region: no-drag;
+  animation: tab-hover-card-in 0.1s var(--ease-out) forwards;
+}
+
+@keyframes tab-hover-card-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.tab-hover-card__thumbnail {
+  display: block;
+  width: 100%;
+  height: 175px;
+  object-fit: cover;
+  background: var(--color-bg-base);
+}
+
+.tab-hover-card__thumbnail-placeholder {
+  display: block;
+  width: 100%;
+  height: 175px;
+  background: var(--color-bg-base);
+}
+
+.tab-hover-card__body {
+  padding: 8px 10px;
+}
+
+.tab-hover-card__title {
+  margin: 0 0 2px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-hover-card__url {
+  margin: 0;
+  font-size: 11px;
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Summary
- Hovering a tab chip for 500ms shows a card with title, URL, and live thumbnail
- Card dismisses immediately on mouse-out; falls back to placeholder while loading
- Thumbnail captured via Electron webContents.capturePage() at 280x175px
- Card positioned to stay within viewport bounds

## Test plan
- [ ] Hover a tab for ~500ms, hover card appears below the tab
- [ ] Mouse away dismisses immediately
- [ ] Loaded page shows thumbnail; loading page shows placeholder
- [ ] Card stays in viewport near edges

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tab hover card that shows the page title, hostname, and a live thumbnail after 500ms hover to help preview tabs without switching. Closes #8.

- New Features
  - Shows after 500ms; clears hover timer on unmount; hides immediately on mouse-out.
  - Live thumbnail via Electron `webContents.capturePage`, resized to 280×175; placeholder shown while loading or on failure; resets on tab change.
  - Card anchors under the tab and stays within the viewport.
  - Adds `tabs:capture-thumbnail` IPC and `electronAPI.tabs.captureThumbnail`; introduces `TabHoverCard` and wires it into `TabStrip`.

<sup>Written for commit 5c4240aeb827699606650dbcb5f7d5e2701e1763. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

