### PR TITLE
feat(omnibox): expand Page Info bubble with permissions, cookies, site settings (closes #24)

### DIFF
--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2373,8 +2373,11 @@ export class TabManager {
       const url = this.getActiveTabUrl() ?? '';
       if (!url) return 0;
       try {
-        const u = new URL(url);
-        const cookies = await this.win.webContents.session.cookies.get({ url });
+        const activeView = this.activeTabId ? this.tabs.get(this.activeTabId) : null;
+        const session = activeView
+          ? activeView.webContents.session
+          : this.win.webContents.session;
+        const cookies = await session.cookies.get({ url });
         return cookies.length;
       } catch {
         return 0;

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2368,6 +2368,18 @@ export class TabManager {
         isSecure: url.startsWith('https://'),
       };
     });
+
+    ipcMain.handle('security:get-cookie-count', async () => {
+      const url = this.getActiveTabUrl() ?? '';
+      if (!url) return 0;
+      try {
+        const u = new URL(url);
+        const cookies = await this.win.webContents.session.cookies.get({ url });
+        return cookies.length;
+      } catch {
+        return 0;
+      }
+    });
   }
 
   destroy(): void {
@@ -2406,5 +2418,6 @@ export class TabManager {
     ipcMain.removeHandler('find:stop');
     ipcMain.removeHandler('find:get-last-query');
     ipcMain.removeHandler('security:get-page-info');
+    ipcMain.removeHandler('security:get-cookie-count');
   }
 }

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -349,6 +349,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       hstsIncludeSubdomains: boolean;
       isSecure: boolean;
     }> => ipcRenderer.invoke('security:get-page-info'),
+    getCookieCount: (): Promise<number> =>
+      ipcRenderer.invoke('security:get-cookie-count'),
   },
 
   // Issue #81 — Three-dot app menu (non-macOS)

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -154,7 +154,7 @@ function PageInfoPopover({
   );
 
   const handleSiteSettings = useCallback(() => {
-    void (window as any).electronAPI?.chrome?.openPage?.('settings');
+    electronAPI.tabs.navigateActive('chrome://settings').catch(() => {});
     onClose();
   }, [onClose]);
 

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -327,6 +327,11 @@ export function URLBar({
     setPageInfoOpen((v) => !v);
   }, [pageInfoOpen]);
 
+  // Close popover on navigation (URL change)
+  useEffect(() => {
+    setPageInfoOpen(false);
+  }, [url]);
+
   // Close popover when clicking outside
   useEffect(() => {
     if (!pageInfoOpen) return;

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -28,13 +28,31 @@ const DEFAULT_PORTS: Record<string, number> = {
   'https:': 443,
 };
 
+interface PermissionEntry {
+  permissionType: string;
+  state: 'allow' | 'deny' | 'ask';
+}
+
 interface PageInfo {
   url: string;
   isHSTS: boolean;
   hstsMaxAge: number | null;
   hstsIncludeSubdomains: boolean;
   isSecure: boolean;
+  permissions: PermissionEntry[];
+  cookieCount: number;
 }
+
+declare const electronAPI: {
+  security: {
+    getPageInfo: () => Promise<Omit<PageInfo, 'permissions' | 'cookieCount'>>;
+    getCookieCount: () => Promise<number>;
+  };
+  permissions: {
+    getSite: (origin: string) => Promise<PermissionEntry[]>;
+    setSite: (origin: string, permissionType: string, state: string) => Promise<void>;
+  };
+};
 
 interface URLBarProps {
   url: string;
@@ -95,6 +113,119 @@ function displayUrl(url: string): string {
   // Build final display string.
   // https scheme is elided entirely; http scheme remains implicit via chip.
   return host + path + parsed.search + parsed.hash;
+}
+
+const PERMISSION_LABELS: Record<string, string> = {
+  camera: 'Camera',
+  microphone: 'Microphone',
+  geolocation: 'Location',
+  notifications: 'Notifications',
+  clipboard: 'Clipboard',
+  midi: 'MIDI',
+};
+
+function PageInfoPopover({
+  security,
+  pageInfo,
+  onClose,
+}: {
+  security: 'secure' | 'insecure' | 'none';
+  pageInfo: PageInfo | null;
+  onClose: () => void;
+}): React.ReactElement {
+  const [permissions, setPermissions] = React.useState<PermissionEntry[]>(
+    pageInfo?.permissions ?? [],
+  );
+
+  const handlePermissionChange = useCallback(
+    async (permType: string, newState: string) => {
+      if (!pageInfo?.url) return;
+      try {
+        const origin = new URL(pageInfo.url).origin;
+        await electronAPI.permissions.setSite(origin, permType, newState);
+        setPermissions((prev) =>
+          prev.map((p) =>
+            p.permissionType === permType ? { ...p, state: newState as PermissionEntry['state'] } : p,
+          ),
+        );
+      } catch { /* ignore */ }
+    },
+    [pageInfo?.url],
+  );
+
+  const handleSiteSettings = useCallback(() => {
+    void (window as any).electronAPI?.chrome?.openPage?.('settings');
+    onClose();
+  }, [onClose]);
+
+  const namedPerms = permissions.filter((p) => PERMISSION_LABELS[p.permissionType]);
+
+  return (
+    <div className="url-bar__page-info-popover" role="dialog" aria-label="Page info">
+      {/* Connection */}
+      <div className="url-bar__page-info-row">
+        <span className={`url-bar__page-info-status url-bar__page-info-status--${security}`}>
+          {security === 'secure'
+            ? 'Connection is secure'
+            : security === 'insecure'
+              ? 'Connection is not secure'
+              : 'No connection info'}
+        </span>
+      </div>
+      {pageInfo?.isHSTS && (
+        <div className="url-bar__page-info-row url-bar__page-info-hsts">
+          <span className="url-bar__page-info-badge">HSTS</span>
+          <span className="url-bar__page-info-hsts-detail">
+            {pageInfo.hstsIncludeSubdomains ? 'Includes subdomains' : 'This domain only'}
+            {pageInfo.hstsMaxAge != null ? ` · ${Math.round(pageInfo.hstsMaxAge / 86400)}d` : ''}
+          </span>
+        </div>
+      )}
+
+      {/* Permissions */}
+      {namedPerms.length > 0 && (
+        <>
+          <div className="url-bar__page-info-divider" />
+          <div className="url-bar__page-info-section-label">Permissions</div>
+          {namedPerms.map((p) => (
+            <div key={p.permissionType} className="url-bar__page-info-perm-row">
+              <span className="url-bar__page-info-perm-label">
+                {PERMISSION_LABELS[p.permissionType]}
+              </span>
+              <select
+                className="url-bar__page-info-perm-select"
+                value={p.state}
+                onChange={(e) => void handlePermissionChange(p.permissionType, e.target.value)}
+              >
+                <option value="allow">Allow</option>
+                <option value="deny">Block</option>
+                <option value="ask">Ask</option>
+              </select>
+            </div>
+          ))}
+        </>
+      )}
+
+      {/* Cookies & site settings */}
+      <div className="url-bar__page-info-divider" />
+      <div className="url-bar__page-info-footer">
+        {pageInfo != null && (
+          <span className="url-bar__page-info-cookies">
+            {pageInfo.cookieCount === 0
+              ? 'No cookies'
+              : `${pageInfo.cookieCount} cookie${pageInfo.cookieCount === 1 ? '' : 's'}`}
+          </span>
+        )}
+        <button
+          type="button"
+          className="url-bar__page-info-site-settings"
+          onClick={handleSiteSettings}
+        >
+          Site settings
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export function URLBar({
@@ -176,8 +307,16 @@ export function URLBar({
   const handleSecurityClick = useCallback(async () => {
     if (!pageInfoOpen) {
       try {
-        const info = await (window as any).electronAPI?.security?.getPageInfo?.();
-        setPageInfo(info ?? null);
+        const [base, cookieCount] = await Promise.all([
+          electronAPI.security.getPageInfo(),
+          electronAPI.security.getCookieCount(),
+        ]);
+        let permissions: PermissionEntry[] = [];
+        try {
+          const origin = new URL(base.url).origin;
+          permissions = await electronAPI.permissions.getSite(origin);
+        } catch { /* non-URL pages have no permissions */ }
+        setPageInfo({ ...base, permissions, cookieCount });
       } catch {
         setPageInfo(null);
       }
@@ -234,22 +373,11 @@ export function URLBar({
           )}
         </button>
         {pageInfoOpen && (
-          <div className="url-bar__page-info-popover" role="dialog" aria-label="Page info">
-            <div className="url-bar__page-info-row">
-              <span className={`url-bar__page-info-status url-bar__page-info-status--${security}`}>
-                {security === 'secure' ? 'Connection is secure' : security === 'insecure' ? 'Connection is not secure' : 'No connection info'}
-              </span>
-            </div>
-            {pageInfo?.isHSTS && (
-              <div className="url-bar__page-info-row url-bar__page-info-hsts">
-                <span className="url-bar__page-info-badge">HSTS</span>
-                <span className="url-bar__page-info-hsts-detail">
-                  {pageInfo.hstsIncludeSubdomains ? 'Includes subdomains' : 'This domain only'}
-                  {pageInfo.hstsMaxAge != null ? ` · ${Math.round(pageInfo.hstsMaxAge / 86400)}d` : ''}
-                </span>
-              </div>
-            )}
-          </div>
+          <PageInfoPopover
+            security={security}
+            pageInfo={pageInfo}
+            onClose={() => setPageInfoOpen(false)}
+          />
         )}
       </div>
 

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -52,6 +52,9 @@ declare const electronAPI: {
     getSite: (origin: string) => Promise<PermissionEntry[]>;
     setSite: (origin: string, permissionType: string, state: string) => Promise<void>;
   };
+  tabs: {
+    navigateActive: (input: string) => Promise<void>;
+  };
 };
 
 interface URLBarProps {

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -585,6 +585,71 @@
   color: var(--color-fg-tertiary);
 }
 
+.url-bar__page-info-divider {
+  height: 1px;
+  background: var(--color-border-subtle);
+  margin: 6px 0;
+}
+
+.url-bar__page-info-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-fg-tertiary);
+  margin-bottom: 4px;
+}
+
+.url-bar__page-info-perm-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.url-bar__page-info-perm-label {
+  font-size: 12px;
+  color: var(--color-fg-primary);
+}
+
+.url-bar__page-info-perm-select {
+  font-size: 11px;
+  padding: 2px 4px;
+  background: var(--color-bg-base);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  outline: none;
+}
+
+.url-bar__page-info-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.url-bar__page-info-cookies {
+  font-size: 11px;
+  color: var(--color-fg-tertiary);
+}
+
+.url-bar__page-info-site-settings {
+  font-size: 11px;
+  color: var(--color-accent-default);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.url-bar__page-info-site-settings:hover {
+  color: var(--color-accent-hover, var(--color-accent-default));
+}
+
 .url-bar__input {
   flex: 1;
   border: none;


### PR DESCRIPTION
## Summary
- Permissions quick-toggles: shows granted/denied permissions for the current origin with a select to change them instantly
- Cookie count: shows how many cookies the current site has set
- Site settings link: opens the Settings window for further configuration
- HSTS info (existing) preserved
- Connection status (existing) preserved

## Test plan
- [ ] Click lock icon on an HTTPS site, popover shows 'Connection is secure'
- [ ] If site has granted permissions (e.g. geolocation), they appear with a toggle
- [ ] Changing the permission select updates the permission immediately
- [ ] Cookie count reflects actual cookies for the site
- [ ] 'Site settings' button opens the Settings window
- [ ] Popover closes when clicking outside

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the URL bar Page Info popover with per-site permission controls, cookie count, and a quick link to Site settings. Users can manage privacy for the current origin without leaving the page.

- **New Features**
  - Inline permission toggles for camera, microphone, location, notifications, clipboard, and MIDI; updates instantly via `electronAPI.permissions.setSite(origin, ...)`.
  - Cookie count for the current URL via new IPC `security:get-cookie-count` (exposed as `electronAPI.security.getCookieCount()`).
  - HSTS badge and connection status retained; clearer popover layout.
  - “Site settings” button opens the Settings page.

- **Bug Fixes**
  - Use `electronAPI.tabs.navigateActive('chrome://settings')` for the Site settings link and add a local type to avoid TS errors.
  - Read cookie count from the active tab’s session to match the current site context.
  - Close the Page Info popover on navigation to avoid showing stale site data.

<sup>Written for commit 0192175515a6e4db75f15b702d4d5b8eb703153c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

