### PR TITLE
feat(tabs): middle-click behaviors (closes #15)

### DIFF
--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -465,6 +465,31 @@ export class TabManager {
     return tabId;
   }
 
+  createBackgroundTab(url: string): string {
+    const tabId = uuidv4();
+    const webPrefs: Electron.WebPreferences = {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    };
+    if (this.partition) webPrefs.partition = this.partition;
+    const view = new WebContentsView({ webPreferences: webPrefs });
+    this.win.contentView.addChildView(view);
+    this.tabs.set(tabId, view);
+    this.tabOrder.push(tabId);
+    this.navControllers.set(tabId, new NavigationController(view));
+    view.webContents.setVisualZoomLevelLimits(1, 3).catch(() => {});
+    this.attachViewEvents(tabId, view);
+    this.positionView(view);
+    this.onWebContentsCreated?.(view.webContents);
+    view.webContents.loadURL(url);
+    // Do NOT activate — stays in background
+    this.saveSession();
+    this.broadcastState();
+    mainLogger.info('TabManager.createBackgroundTab', { tabId, url });
+    return tabId;
+  }
+
   closeTab(tabId: string, force = false): void {
     const view = this.tabs.get(tabId);
     if (!view) {
@@ -1734,6 +1759,20 @@ export class TabManager {
     wc.on('new-window' as any, (e: Event, url: string) => {
       e.preventDefault();
       this.createTab(url);
+    });
+
+    wc.setWindowOpenHandler(({ url, disposition }) => {
+      if (url && !BLOCKED_SCHEMES.test(url)) {
+        const background =
+          disposition === 'background-tab' ||
+          disposition === 'other';
+        if (background) {
+          this.createBackgroundTab(url);
+        } else {
+          this.createTab(url);
+        }
+      }
+      return { action: 'deny' };
     });
 
     // Find-in-page results stream back here. We only broadcast the final

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -481,6 +481,7 @@ export class TabManager {
     view.webContents.setVisualZoomLevelLimits(1, 3).catch(() => {});
     this.attachViewEvents(tabId, view);
     this.positionView(view);
+    view.setVisible(false);
     this.onWebContentsCreated?.(view.webContents);
     view.webContents.loadURL(url);
     // Do NOT activate — stays in background

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -109,6 +109,7 @@ function TabItem({
       tabIndex={isActive ? 0 : -1}
       draggable
       onClick={onActivate}
+      onAuxClick={(e) => { if (e.button === 1) { e.stopPropagation(); onClose(e); } }}
       onKeyDown={onKeyDown}
       onDragStart={(e) => onDragStart(e, tab.id, index)}
       onDragOver={(e) => onDragOver(e, index)}


### PR DESCRIPTION
## Summary
- Middle-click a tab chip closes that tab
- Middle-click or Cmd+click a link opens it in a background tab (no focus steal)
- Uses Electron setWindowOpenHandler with disposition detection to differentiate background-tab from foreground-tab

## Test plan
- [ ] Middle-click a tab in the tab strip → tab closes
- [ ] Middle-click a link on a page → opens in new background tab without switching
- [ ] Cmd+click a link → opens in new background tab
- [ ] Regular click on a link that opens in new tab → still switches to new tab
- [ ] Pinned tab: middle-click should still close it (since it's a background operation)

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #15: Middle-clicking a tab closes it. Middle- or Cmd+clicking a link opens a background tab without switching; normal new-tab navigations still focus.

- **New Features**
  - Added `createBackgroundTab` and Electron `setWindowOpenHandler` using `disposition` to choose background vs foreground, and hide background tabs on create to prevent a flash.

<sup>Written for commit 3885577d0eeb1f71eda7c43288f1f92db08b85d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

