### PR TITLE
feat(tabs): fullscreen hides chrome, content fills screen

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -304,6 +304,16 @@ function openShellAndWire(profileId?: string): BrowserWindow {
 
   shellWindow.on('resize', () => tabManager?.relayout());
 
+  // Issue #13 — Fullscreen: hide chrome, edge-peek reveal
+  shellWindow.on('enter-full-screen', () => {
+    tabManager?.setFullscreen(true);
+    shellWindow?.webContents.send('fullscreen-changed', { isFullscreen: true });
+  });
+  shellWindow.on('leave-full-screen', () => {
+    tabManager?.setFullscreen(false);
+    shellWindow?.webContents.send('fullscreen-changed', { isFullscreen: false });
+  });
+
   // DEV/TEST: expose tabManager on the Node.js global object so E2E tests can
   // reach it via electronApp.evaluate() calls (which run in the same Node.js
   // process and share the global scope).  The BrowserWindow proxy returned by

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -270,6 +270,15 @@ export class TabManager {
     this.urlMatchFn = fn;
   }
 
+  private isFullscreen = false;
+
+  setFullscreen(fullscreen: boolean): void {
+    if (this.isFullscreen === fullscreen) return;
+    this.isFullscreen = fullscreen;
+    mainLogger.debug('TabManager.setFullscreen', { fullscreen });
+    this.relayout();
+  }
+
   setChromeOffset(offset: number): void {
     const next = Math.max(0, Math.min(512, Math.round(offset)));
     if (next === this.chromeOffset) return;
@@ -1463,7 +1472,7 @@ export class TabManager {
 
   private positionView(view: WebContentsView): void {
     const [winWidth, winHeight] = this.win.getContentSize();
-    const top = CHROME_HEIGHT + this.chromeOffset;
+    const top = this.isFullscreen ? 0 : CHROME_HEIGHT + this.chromeOffset;
     const contentWidth = Math.max(0, winWidth - this.sidePanelWidth);
     const x = this.sidePanelPosition === 'left' ? this.sidePanelWidth : 0;
     view.setBounds({

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -651,6 +651,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('open-tab-search', handler);
       return () => ipcRenderer.removeListener('open-tab-search', handler);
     },
+
+    // Issue #13 — Fullscreen
+    fullscreenChanged: (cb: (payload: { isFullscreen: boolean }) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, payload: { isFullscreen: boolean }) => cb(payload);
+      ipcRenderer.on('fullscreen-changed', handler);
+      return () => ipcRenderer.removeListener('fullscreen-changed', handler);
+    },
   },
 
   // Profiles — current profile info + switch

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -184,7 +184,6 @@ export function WindowChrome(): React.ReactElement {
 
   // Fullscreen state
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [chromeRevealed, setChromeRevealed] = useState(false);
 
   // Downloads state
   const [downloads, setDownloads] = useState<DownloadItemDTO[]>([]);
@@ -340,7 +339,6 @@ export function WindowChrome(): React.ReactElement {
 
     const unsubFullscreen = electronAPI.on.fullscreenChanged(({ isFullscreen: fs }) => {
       setIsFullscreen(fs);
-      setChromeRevealed(false);
     });
 
     return () => {

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -136,6 +136,7 @@ declare const electronAPI: {
     openBookmarkDialog: (cb: () => void) => () => void;
     toggleBookmarksBar: (cb: () => void) => () => void;
     focusBookmarksBar: (cb: () => void) => () => void;
+    fullscreenChanged: (cb: (payload: { isFullscreen: boolean }) => void) => () => void;
     zoomChanged: (cb: (payload: { percent: number }) => void) => () => void;
     permissionPrompt: (
       cb: (data: { id: string; tabId: string | null; origin: string; permissionType: string; isMainFrame: boolean }) => void,
@@ -180,6 +181,10 @@ export function WindowChrome(): React.ReactElement {
   const [bookmarksTree, setBookmarksTree] = useState<PersistedBookmarks | null>(null);
   const [bookmarkDialogOpen, setBookmarkDialogOpen] = useState(false);
   const [focusBookmarksBarTick, setFocusBookmarksBarTick] = useState(0);
+
+  // Fullscreen state
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [chromeRevealed, setChromeRevealed] = useState(false);
 
   // Downloads state
   const [downloads, setDownloads] = useState<DownloadItemDTO[]>([]);
@@ -333,6 +338,11 @@ export function WindowChrome(): React.ReactElement {
       setFocusBookmarksBarTick((n) => n + 1);
     });
 
+    const unsubFullscreen = electronAPI.on.fullscreenChanged(({ isFullscreen: fs }) => {
+      setIsFullscreen(fs);
+      setChromeRevealed(false);
+    });
+
     return () => {
       unsubTabsState();
       unsubTabUpdated();
@@ -347,6 +357,7 @@ export function WindowChrome(): React.ReactElement {
       unsubOpenDialog();
       unsubToggleBar();
       unsubFocusBar();
+      unsubFullscreen();
     };
   }, [bookmarksTree?.visibility]);
 
@@ -555,7 +566,7 @@ export function WindowChrome(): React.ReactElement {
   // Render
   // ---------------------------------------------------------------------------
   return (
-    <div className="window-chrome">
+    <div className={['window-chrome', isFullscreen ? 'window-chrome--fullscreen' : ''].filter(Boolean).join(' ')}>
       {/* Tab strip row */}
       <div className="window-chrome__tab-row">
         <div className="window-chrome__traffic-light-spacer" aria-hidden="true" />

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -27,6 +27,21 @@
   -webkit-app-region: no-drag;
 }
 
+.window-chrome--fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  transform: translateY(-100%);
+  transition: transform 0.2s ease;
+  min-height: var(--chrome-height);
+}
+
+.window-chrome--fullscreen:hover {
+  transform: translateY(0);
+}
+
 .window-chrome__tab-row {
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
## Summary
- Adds fullscreen support (closes #13)
- enter-full-screen/leave-full-screen events relay state to TabManager and renderer
- TabManager.setFullscreen() repositions content view to y:0, filling the window
- WindowChrome slides off-screen in fullscreen; hovering top edge reveals chrome

## Test plan
- [ ] Enter fullscreen: content fills entire screen
- [ ] Hover top edge reveals tabs/toolbar overlay
- [ ] Leave fullscreen restores normal layout
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fullscreen mode hides the window chrome and lets content fill the window, with top-edge hover reveal (closes #13).
Main wires `enter/leave-full-screen` to `TabManager.setFullscreen` and emits `fullscreen-changed`; renderer listens via `electronAPI.on.fullscreenChanged`, toggles `window-chrome--fullscreen` for CSS :hover reveal; removed unused chromeRevealed state.

<sup>Written for commit f926b12e1bedae218dc4e0e2778bb9ee00574a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

