### PR TITLE
feat(omnibox): IDN decode to Unicode with mixed-script spoof protection

### DIFF
--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { decode as punyDecode } from 'punycode';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -27,6 +28,39 @@ const DEFAULT_PORTS: Record<string, number> = {
   'http:': 80,
   'https:': 443,
 };
+
+// ---------------------------------------------------------------------------
+// IDN / Punycode display helpers (Chrome IDN policy)
+// ---------------------------------------------------------------------------
+
+// Script ranges for mixed-script spoofing detection.
+const CYRILLIC_RE = /[\u0400-\u04FF\u0500-\u052F]/;
+const GREEK_RE = /[\u0370-\u03FF\u1F00-\u1FFF]/;
+const LATIN_RE = /[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF]/;
+
+function isSafeUnicodeLabel(unicode: string): boolean {
+  const hasCyrillic = CYRILLIC_RE.test(unicode);
+  const hasGreek = GREEK_RE.test(unicode);
+  const hasLatin = LATIN_RE.test(unicode);
+  // Cyrillic or Greek mixed with Latin is a known IDN spoofing vector.
+  return !((hasCyrillic || hasGreek) && hasLatin);
+}
+
+function decodeHostnameForDisplay(hostname: string): string {
+  if (!hostname.includes('xn--')) return hostname;
+  return hostname
+    .split('.')
+    .map(label => {
+      if (!label.startsWith('xn--')) return label;
+      try {
+        const unicode = punyDecode(label.slice(4)); // strip 'xn--' prefix
+        return isSafeUnicodeLabel(unicode) ? unicode : label;
+      } catch {
+        return label;
+      }
+    })
+    .join('.');
+}
 
 interface URLBarProps {
   url: string;
@@ -68,8 +102,8 @@ function displayUrl(url: string): string {
     return url;
   }
 
-  // Build display hostname: strip trivial subdomains.
-  let host = parsed.hostname;
+  // Build display hostname: decode IDN labels, then strip trivial subdomains.
+  let host = decodeHostnameForDisplay(parsed.hostname);
   if (TRIVIAL_SUBDOMAIN_RE.test(host)) {
     host = host.replace(TRIVIAL_SUBDOMAIN_RE, '');
   }


### PR DESCRIPTION
## Summary
- Closes #23
- xn-- punycode labels are decoded to Unicode for display
- Labels mixing Cyrillic/Greek with Latin are kept as punycode (anti-spoofing)
- Uses bundled punycode package (already a transitive dep)

## Test plan
- [ ] xn-- hostname (e.g. xn--nxasmq6b.com) shows as Unicode in URL bar
- [ ] Cyrillic+Latin mixed domain stays as punycode (spoof protection)
- [ ] ASCII-only hostnames are unaffected
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode `xn--` punycode hostnames to Unicode in the URL bar with mixed-script spoof protection, aligned with Chrome’s IDN policy. Closes #23.

- **New Features**
  - Decode `xn--` labels to Unicode for display using `punycode`.
  - Keep labels mixing Cyrillic/Greek with Latin as punycode (spoof protection).
  - Decode before stripping trivial subdomains; ASCII-only hosts unchanged.

- **Refactors**
  - Synced with `main` and kept `PageInfo` and IDN helpers intact.

<sup>Written for commit e69409bfa397d1dbd74673bc917a2bd625d8d795. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

