### PR TITLE
feat(tabs): window naming via Name Window dialog

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -186,6 +186,8 @@ let isGuestSession = false;
 let guestPartitionName: string | null = null;
 // Issue #12 — Window naming: in-memory custom title; cleared on window close
 let windowCustomName: string | null = null;
+// Stores the default (pre-rename) title for each window, keyed by window.id.
+const windowDefaultTitles = new Map<number, string>();
 
 const accountStore = new AccountStore();
 const oauthClient = new OAuthClient({ clientId: process.env.GOOGLE_CLIENT_ID ?? '42357852543-62lvdghq5hatidr3ovmq1rig9q5r5mcg.apps.googleusercontent.com' });
@@ -1719,7 +1721,19 @@ ipcMain.handle('window:set-name', (e, name: string) => {
   const callerWin = BrowserWindow.fromWebContents(e.sender);
   const targetWin = callerWin ?? shellWindow;
   if (targetWin && !targetWin.isDestroyed()) {
-    targetWin.setTitle(windowCustomName ?? app.getName());
+    const winId = targetWin.id;
+    if (windowCustomName) {
+      // Save default title before first rename so we can restore it later.
+      if (!windowDefaultTitles.has(winId)) {
+        windowDefaultTitles.set(winId, targetWin.getTitle());
+      }
+      targetWin.setTitle(windowCustomName);
+    } else {
+      // Restore the original title (preserves Guest/Incognito suffix).
+      const defaultTitle = windowDefaultTitles.get(winId) ?? app.getName();
+      windowDefaultTitles.delete(winId);
+      targetWin.setTitle(defaultTitle);
+    }
   }
 });
 

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -165,6 +165,8 @@ let deviceManager: DeviceManager | null = null;
 let activeProfileId = 'default';
 let isGuestSession = false;
 let guestPartitionName: string | null = null;
+// Issue #12 — Window naming: in-memory custom title; cleared on window close
+let windowCustomName: string | null = null;
 
 const accountStore = new AccountStore();
 const oauthClient = new OAuthClient({ clientId: process.env.GOOGLE_CLIENT_ID ?? '42357852543-62lvdghq5hatidr3ovmq1rig9q5r5mcg.apps.googleusercontent.com' });
@@ -295,6 +297,12 @@ function openShellAndWire(profileId?: string): BrowserWindow {
       msg: 'global.__tabManager__ set for E2E test access',
     });
   }
+
+  // Issue #12 — reset custom window name when shell window closes
+  shellWindow.on('closed', () => {
+    mainLogger.info('main.shellWindow.closed', { msg: 'Clearing custom window name' });
+    windowCustomName = null;
+  });
 
   return shellWindow;
 }
@@ -1502,6 +1510,13 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
           },
         },
         {
+          label: 'Name Window…',
+          click: () => {
+            mainLogger.debug('shortcuts.nameWindow');
+            shellWindow?.webContents.send('name-window-dialog');
+          },
+        },
+        {
           label: 'Task Manager',
           enabled: false,
         },
@@ -1555,6 +1570,15 @@ function switchTabRelative(delta: number): void {
 // IPC: window-level handlers
 // ---------------------------------------------------------------------------
 ipcMain.handle('shell:get-platform', () => process.platform);
+
+// Issue #12 — Window naming: set a custom OS-level window title
+ipcMain.handle('window:set-name', (_e, name: string) => {
+  windowCustomName = name && name.trim() ? name.trim() : null;
+  mainLogger.info('main.window:set-name', { name: windowCustomName });
+  if (shellWindow && !shellWindow.isDestroyed()) {
+    shellWindow.setTitle(windowCustomName ?? app.getName());
+  }
+});
 
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {
@@ -1699,6 +1723,14 @@ ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) 
         { label: 'JavaScript Console', accelerator: 'Ctrl+Shift+J', click: () => { tabManager?.openDevToolsConsoleForActive(); } },
         { type: 'separator' },
         { label: 'Task Manager', enabled: false },
+        { type: 'separator' },
+        {
+          label: 'Name Window…',
+          click: () => {
+            mainLogger.debug('shortcuts.nameWindow.threedot');
+            shellWindow?.webContents.send('name-window-dialog');
+          },
+        },
       ],
     },
     { type: 'separator' },

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1713,11 +1713,13 @@ function switchTabRelative(delta: number): void {
 ipcMain.handle('shell:get-platform', () => process.platform);
 
 // Issue #12 — Window naming: set a custom OS-level window title
-ipcMain.handle('window:set-name', (_e, name: string) => {
+ipcMain.handle('window:set-name', (e, name: string) => {
   windowCustomName = name && name.trim() ? name.trim() : null;
   mainLogger.info('main.window:set-name', { name: windowCustomName });
-  if (shellWindow && !shellWindow.isDestroyed()) {
-    shellWindow.setTitle(windowCustomName ?? app.getName());
+  const callerWin = BrowserWindow.fromWebContents(e.sender);
+  const targetWin = callerWin ?? shellWindow;
+  if (targetWin && !targetWin.isDestroyed()) {
+    targetWin.setTitle(windowCustomName ?? app.getName());
   }
 });
 

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -323,9 +323,11 @@ function openShellAndWire(profileId?: string): BrowserWindow {
   }
 
   // Issue #12 — reset custom window name when shell window closes
+  const shellWinId = shellWindow.id;
   shellWindow.on('closed', () => {
     mainLogger.info('main.shellWindow.closed', { msg: 'Clearing custom window name' });
     windowCustomName = null;
+    windowDefaultTitles.delete(shellWinId);
   });
 
   return shellWindow;
@@ -431,6 +433,11 @@ function openNewWindow(): BrowserWindow {
   });
 
   win.on('resize', () => tm.relayout());
+  const newWinId = win.id;
+  win.on('closed', () => {
+    windowDefaultTitles.delete(newWinId);
+    tm.destroy();
+  });
 
   mainLogger.info('main.openNewWindow.done', { windowId: win.id });
   return win;
@@ -464,7 +471,9 @@ function openIncognitoWindow(): BrowserWindow {
   incognitoWindows.add(win);
   mainLogger.info('main.openIncognitoWindow.tracked', { total: incognitoWindows.size });
 
+  const incogWinId = win.id;
   win.on('closed', () => {
+    windowDefaultTitles.delete(incogWinId);
     incognitoWindows.delete(win);
     mainLogger.info('main.incognitoWindow.closed', {
       remaining: incognitoWindows.size,

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -309,6 +309,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
 
+  // Issue #12 — Window naming
+  windowName: {
+    set: (name: string): Promise<void> =>
+      ipcRenderer.invoke('window:set-name', name),
+  },
+
   // Issue #98 — Share menu
   share: {
     copyLink: (): Promise<boolean> =>
@@ -615,6 +621,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       const handler = (_e: Electron.IpcRendererEvent, payload: { url: string }) => cb(payload);
       ipcRenderer.on('link-hover', handler);
       return () => ipcRenderer.removeListener('link-hover', handler);
+    },
+
+    // Issue #12 — Window naming: main asks renderer to open the name dialog
+    nameWindowDialog: (cb: () => void): (() => void) => {
+      const handler = () => cb();
+      ipcRenderer.on('name-window-dialog', handler);
+      return () => ipcRenderer.removeListener('name-window-dialog', handler);
     },
   },
 

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -104,6 +104,9 @@ declare const electronAPI: {
     setSidePanelPosition: (position: 'left' | 'right') => Promise<void>;
     getPlatform: () => Promise<string>;
   };
+  windowName: {
+    set: (name: string) => Promise<void>;
+  };
   share: {
     copyLink: () => Promise<boolean>;
     emailPage: () => Promise<boolean>;
@@ -143,6 +146,7 @@ declare const electronAPI: {
     downloadDone: (cb: (dl: DownloadItemDTO) => void) => () => void;
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
+    nameWindowDialog: (cb: () => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -180,6 +184,9 @@ export function WindowChrome(): React.ReactElement {
 
   // Side panel state
   const [sidePanelOpen, setSidePanelOpen] = useState(false);
+
+  // Issue #12 — Window naming dialog state
+  const [nameWindowDialogOpen, setNameWindowDialogOpen] = useState(false);
 
   // Share menu state
   const [shareMenuOpen, setShareMenuOpen] = useState(false);
@@ -316,6 +323,11 @@ export function WindowChrome(): React.ReactElement {
       setFocusBookmarksBarTick((n) => n + 1);
     });
 
+    // Issue #12 — Window naming: main process signals renderer to open dialog
+    const unsubNameWindow = electronAPI.on.nameWindowDialog(() => {
+      setNameWindowDialogOpen(true);
+    });
+
     return () => {
       unsubTabsState();
       unsubTabUpdated();
@@ -329,6 +341,7 @@ export function WindowChrome(): React.ReactElement {
       unsubOpenDialog();
       unsubToggleBar();
       unsubFocusBar();
+      unsubNameWindow();
     };
   }, [bookmarksTree?.visibility]);
 
@@ -625,6 +638,127 @@ export function WindowChrome(): React.ReactElement {
       <PasswordPromptBar activeTabId={activeTabId} />
       <FindBar activeTabId={activeTabId} />
       <StatusBar url={hoveredUrl} />
+
+      {nameWindowDialogOpen && (
+        <NameWindowDialog
+          onClose={() => setNameWindowDialogOpen(false)}
+          onSave={(name) => {
+            void electronAPI.windowName.set(name);
+            setNameWindowDialogOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #12 — Name Window dialog
+// ---------------------------------------------------------------------------
+function NameWindowDialog({
+  onClose,
+  onSave,
+}: {
+  onClose: () => void;
+  onSave: (name: string) => void;
+}): React.ReactElement {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  };
+
+  return (
+    <div
+      className="name-window-dialog__overlay"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.4)',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="name-window-dialog"
+        style={{
+          background: 'var(--surface-primary, #fff)',
+          borderRadius: 8,
+          padding: '20px 24px',
+          minWidth: 320,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.24)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+        }}
+        onKeyDown={handleKeyDown}
+      >
+        <div style={{ fontWeight: 600, fontSize: 14 }}>Name Window</div>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <input
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Window name"
+            maxLength={200}
+            style={{
+              padding: '6px 10px',
+              borderRadius: 4,
+              border: '1px solid var(--border-primary, #ccc)',
+              fontSize: 13,
+              outline: 'none',
+              background: 'var(--surface-secondary, #f5f5f5)',
+              color: 'inherit',
+            }}
+          />
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: '5px 14px',
+                borderRadius: 4,
+                border: '1px solid var(--border-primary, #ccc)',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontSize: 13,
+                color: 'inherit',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              style={{
+                padding: '5px 14px',
+                borderRadius: 4,
+                border: 'none',
+                background: 'var(--accent-primary, #1a73e8)',
+                color: '#fff',
+                cursor: 'pointer',
+                fontSize: 13,
+                fontWeight: 500,
+              }}
+            >
+              Name
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Closes #12
- Adds 'Name Window…' menu item to the Window menu (macOS menu bar)
- Dialog with text input to set a custom OS window title
- Name shows in Alt+Tab / Mission Control
- Session-scoped: cleared when the window closes

## Test plan
- [ ] Window menu shows 'Name Window…'
- [ ] Dialog opens, accepts text input
- [ ] Window title changes in macOS title bar and Mission Control
- [ ] Window title resets on close
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Name Window…” dialog to set a custom OS window title per window. The name shows in the title bar and task switchers and resets to the window’s original title on close (Linear #12).

- **New Features**
  - Added “Name Window…” in the Window menu (macOS) and the 3‑dot app menu to open the dialog.
  - Implemented `window:set-name` IPC using `BrowserWindow.setTitle` for a session-scoped title.
  - Exposed `windowName.set` and `on.nameWindowDialog` in preload for renderer↔main messaging.
  - Trim input; empty value clears the custom name.

- **Bug Fixes**
  - `window:set-name` targets the calling window and restores the original title (preserves Guest/Incognito suffix) when a custom name is cleared.
  - Cleans up cached default titles (`windowDefaultTitles`) when windows close to avoid stale titles and leaks.

<sup>Written for commit faef7e0c5a1691d55b46ed40f2d3dbdd48408197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

