### PR TITLE
feat(omnibox): autocomplete dropdown with history/bookmark/tab suggestions

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -671,6 +671,7 @@ app.whenReady().then(async () => {
     unregisterShareHandlers();
     unregisterBookmarkHandlers();
     unregisterHistoryHandlers();
+    shortcutsStore?.flushSync();
     unregisterOmniboxHandlers();
     unregisterChromeHandlers();
     unregisterProfileHandlers();

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -75,6 +75,9 @@ import { openExtensionsWindow } from './extensions/ExtensionsWindow';
 // Issue #40 — History
 import { HistoryStore } from './history/HistoryStore';
 import { registerHistoryHandlers, unregisterHistoryHandlers } from './history/ipc';
+// Issue #17 — Omnibox autocomplete
+import { ShortcutsStore } from './omnibox/ShortcutsStore';
+import { registerOmniboxHandlers, unregisterOmniboxHandlers } from './omnibox/ipc';
 // Issue #36 — Downloads
 import { DownloadManager } from './downloads/DownloadManager';
 // Issue #26 — Chrome internal pages
@@ -159,6 +162,7 @@ let permissionAutoRevoker: PermissionAutoRevoker | null = null;
 let contentCategoryStore: ContentCategoryStore | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
+let shortcutsStore: ShortcutsStore | null = null;
 let downloadManager: DownloadManager | null = null;
 let deviceStore: DeviceStore | null = null;
 let deviceManager: DeviceManager | null = null;
@@ -427,6 +431,15 @@ app.whenReady().then(async () => {
   historyStore = new HistoryStore();
   registerHistoryHandlers({ store: historyStore });
 
+  // Issue #17 — Omnibox autocomplete
+  shortcutsStore = new ShortcutsStore();
+  registerOmniboxHandlers({
+    shortcutsStore,
+    historyStore,
+    bookmarkStore: bookmarkStore!,
+    getOpenTabs: () => tabManager?.getState().tabs.map((t) => ({ title: t.title, url: t.url })) ?? [],
+  });
+
   // Issue #26 — Chrome internal pages
 
   // Issue #98 — Share menu
@@ -658,6 +671,7 @@ app.whenReady().then(async () => {
     unregisterShareHandlers();
     unregisterBookmarkHandlers();
     unregisterHistoryHandlers();
+    unregisterOmniboxHandlers();
     unregisterChromeHandlers();
     unregisterProfileHandlers();
     unregisterContentCategoryHandlers();

--- a/my-app/src/main/omnibox/ShortcutsStore.ts
+++ b/my-app/src/main/omnibox/ShortcutsStore.ts
@@ -1,0 +1,157 @@
+/**
+ * ShortcutsStore — persists omnibox shortcuts.
+ *
+ * A "shortcut" is a user-confirmed URL selection from the omnibox.  When the
+ * user picks a suggestion and navigates to it the shortcut record is written
+ * (or its use-count is incremented) so that it ranks higher on future queries.
+ *
+ * Follows the HistoryStore pattern: debounced atomic writes to
+ * userData/omnibox-shortcuts.json (300ms).
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { mainLogger } from '../logger';
+
+const SHORTCUTS_FILE_NAME = 'omnibox-shortcuts.json';
+const DEBOUNCE_MS = 300;
+const MAX_SHORTCUTS = 1_000;
+
+export interface ShortcutEntry {
+  /** Unique id — same as the input text that produced the navigation. */
+  id: string;
+  /** The text the user typed when they selected this URL. */
+  inputText: string;
+  url: string;
+  title: string;
+  /** How many times this shortcut has been selected. */
+  useCount: number;
+  lastUsed: number;
+}
+
+export interface PersistedShortcuts {
+  version: 1;
+  entries: ShortcutEntry[];
+}
+
+function getShortcutsPath(): string {
+  return path.join(app.getPath('userData'), SHORTCUTS_FILE_NAME);
+}
+
+export class ShortcutsStore {
+  private entries: ShortcutEntry[] = [];
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor() {
+    this.load();
+  }
+
+  private load(): void {
+    try {
+      const raw = fs.readFileSync(getShortcutsPath(), 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedShortcuts;
+      if (parsed.version === 1 && Array.isArray(parsed.entries)) {
+        this.entries = parsed.entries;
+        mainLogger.info('ShortcutsStore.load.ok', { count: this.entries.length });
+      } else {
+        mainLogger.warn('ShortcutsStore.load.invalidVersion', { version: (parsed as any).version });
+        this.entries = [];
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        mainLogger.error('ShortcutsStore.load.failed', {
+          error: (err as Error).message,
+        });
+      }
+      this.entries = [];
+    }
+  }
+
+  private scheduleSave(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    this.dirty = false;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    try {
+      const data: PersistedShortcuts = { version: 1, entries: this.entries };
+      fs.writeFileSync(getShortcutsPath(), JSON.stringify(data), 'utf-8');
+      mainLogger.debug('ShortcutsStore.flush.ok', { count: this.entries.length });
+    } catch (err) {
+      mainLogger.error('ShortcutsStore.flush.failed', {
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  /**
+   * Record that the user selected `url` / `title` after typing `inputText`.
+   * Increments useCount if an entry already exists, otherwise creates one.
+   */
+  recordSelection(inputText: string, url: string, title: string): ShortcutEntry {
+    const existing = this.entries.find(
+      (e) => e.inputText === inputText && e.url === url,
+    );
+    if (existing) {
+      existing.useCount += 1;
+      existing.lastUsed = Date.now();
+      existing.title = title || existing.title;
+      mainLogger.debug('ShortcutsStore.recordSelection.updated', { inputText, url });
+      this.scheduleSave();
+      return existing;
+    }
+
+    const entry: ShortcutEntry = {
+      id: `sc-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      inputText,
+      url,
+      title: title || url,
+      useCount: 1,
+      lastUsed: Date.now(),
+    };
+    this.entries.unshift(entry);
+    if (this.entries.length > MAX_SHORTCUTS) {
+      this.entries = this.entries.slice(0, MAX_SHORTCUTS);
+    }
+    mainLogger.debug('ShortcutsStore.recordSelection.added', { inputText, url });
+    this.scheduleSave();
+    return entry;
+  }
+
+  /**
+   * Return shortcuts whose inputText or url/title matches `query`, sorted by
+   * useCount desc then lastUsed desc.
+   */
+  query(query: string, limit = 5): ShortcutEntry[] {
+    let filtered: ShortcutEntry[];
+    if (!query || query.trim().length === 0) {
+      filtered = this.entries.slice();
+    } else {
+      const lower = query.toLowerCase();
+      filtered = this.entries.filter(
+        (e) =>
+          e.inputText.toLowerCase().includes(lower) ||
+          e.url.toLowerCase().includes(lower) ||
+          e.title.toLowerCase().includes(lower),
+      );
+    }
+
+    return filtered
+      .sort((a, b) => b.useCount - a.useCount || b.lastUsed - a.lastUsed)
+      .slice(0, limit);
+  }
+
+  getAll(): ShortcutEntry[] {
+    return this.entries.slice();
+  }
+}

--- a/my-app/src/main/omnibox/ShortcutsStore.ts
+++ b/my-app/src/main/omnibox/ShortcutsStore.ts
@@ -53,7 +53,7 @@ export class ShortcutsStore {
       const raw = fs.readFileSync(getShortcutsPath(), 'utf-8');
       const parsed = JSON.parse(raw) as PersistedShortcuts;
       if (parsed.version === 1 && Array.isArray(parsed.entries)) {
-        this.entries = parsed.entries;
+        this.entries = parsed.entries.slice(0, MAX_SHORTCUTS);
         mainLogger.info('ShortcutsStore.load.ok', { count: this.entries.length });
       } else {
         mainLogger.warn('ShortcutsStore.load.invalidVersion', { version: (parsed as any).version });

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -79,12 +79,19 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
       mainLogger.debug('omnibox:suggest', { input });
 
       const results: OmniboxSuggestion[] = [];
-      const seen = new Set<string>();
+      const seenIndex = new Map<string, number>(); // url → index in results
 
       function push(s: OmniboxSuggestion): void {
         if (!s.url) return;
-        if (seen.has(s.url)) return;
-        seen.add(s.url);
+        const existing = seenIndex.get(s.url);
+        if (existing !== undefined) {
+          // Replace if this entry has higher relevance (e.g. bookmark > history).
+          if (s.relevance > results[existing].relevance) {
+            results[existing] = s;
+          }
+          return;
+        }
+        seenIndex.set(s.url, results.length);
         results.push(s);
       }
 

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -1,0 +1,191 @@
+/**
+ * ipc.ts — omnibox IPC bindings.
+ *
+ * Registers `omnibox:*` handlers that power the URL-bar autocomplete dropdown.
+ * Three providers are aggregated on every keystroke:
+ *   1. Shortcuts  — previously confirmed navigations (highest relevance).
+ *   2. History    — all visited pages, scored by recency.
+ *   3. Bookmarks  — flat-list walk of the bookmark tree.
+ *   4. Open tabs  — live tab summaries injected by the caller.
+ *
+ * Results are deduplicated by URL and sorted by relevance desc.
+ */
+
+import { ipcMain } from 'electron';
+import type { BookmarkNode } from '../bookmarks/BookmarkStore';
+import { BookmarkStore } from '../bookmarks/BookmarkStore';
+import { HistoryStore } from '../history/HistoryStore';
+import { ShortcutsStore } from './ShortcutsStore';
+import type { OmniboxSuggestion } from './providers';
+import { assertString } from '../ipc-validators';
+import { mainLogger } from '../logger';
+
+const CHANNELS = [
+  'omnibox:suggest',
+  'omnibox:record-selection',
+  'omnibox:remove-history',
+] as const;
+
+export interface OmniboxIpcOptions {
+  shortcutsStore: ShortcutsStore;
+  historyStore: HistoryStore | null;
+  bookmarkStore: BookmarkStore;
+  /** Returns title + url for every open tab in the current window. */
+  getOpenTabs: () => Array<{ title: string; url: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flatBookmarks(node: BookmarkNode): Array<{ url: string; name: string }> {
+  if (node.type === 'bookmark' && node.url) {
+    return [{ url: node.url, name: node.name }];
+  }
+  if (node.children) {
+    return node.children.flatMap((c) => flatBookmarks(c));
+  }
+  return [];
+}
+
+function scoreText(text: string, lower: string): number {
+  if (!text) return 0;
+  const t = text.toLowerCase();
+  if (t === lower) return 100;
+  if (t.startsWith(lower)) return 80;
+  if (t.includes(lower)) return 50;
+  return 0;
+}
+
+function scoreEntry(title: string, url: string, inputLower: string): number {
+  return Math.max(scoreText(title, inputLower), scoreText(url, inputLower));
+}
+
+// ---------------------------------------------------------------------------
+// Public
+// ---------------------------------------------------------------------------
+
+export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
+  const { shortcutsStore, historyStore, bookmarkStore, getOpenTabs } = opts;
+
+  // -------------------------------------------------------------------------
+  // omnibox:suggest — aggregate providers and return ranked suggestions.
+  // -------------------------------------------------------------------------
+  ipcMain.handle(
+    'omnibox:suggest',
+    (_e, payload?: { input?: string; remoteSearch?: boolean }): OmniboxSuggestion[] => {
+      const input = typeof payload?.input === 'string' ? payload.input.trim() : '';
+      const lower = input.toLowerCase();
+      mainLogger.debug('omnibox:suggest', { input });
+
+      const results: OmniboxSuggestion[] = [];
+      const seen = new Set<string>();
+
+      function push(s: OmniboxSuggestion): void {
+        if (!s.url) return;
+        if (seen.has(s.url)) return;
+        seen.add(s.url);
+        results.push(s);
+      }
+
+      // 1. Shortcuts (highest relevance baseline = 900)
+      const shortcuts = shortcutsStore.query(input, 5);
+      for (const sc of shortcuts) {
+        const base = scoreEntry(sc.title, sc.url, lower);
+        push({
+          id: `shortcut:${sc.id}`,
+          type: 'shortcut',
+          title: sc.title,
+          url: sc.url,
+          relevance: 900 + base + Math.min(sc.useCount, 50),
+        });
+      }
+
+      // 2. History (baseline = 700)
+      if (historyStore && input.length > 0) {
+        const { entries } = historyStore.query({ query: input, limit: 10 });
+        for (const e of entries) {
+          const base = scoreEntry(e.title, e.url, lower);
+          push({
+            id: `history:${e.id}`,
+            type: 'history',
+            title: e.title || e.url,
+            url: e.url,
+            favicon: e.favicon ?? undefined,
+            relevance: 700 + base,
+          });
+        }
+      }
+
+      // 3. Bookmarks (baseline = 800 — user-curated, ranks above history)
+      if (input.length > 0) {
+        const tree = bookmarkStore.listTree();
+        const allBookmarks = tree.roots.flatMap((r) => flatBookmarks(r));
+        for (const bm of allBookmarks) {
+          const base = scoreEntry(bm.name, bm.url, lower);
+          if (base === 0) continue;
+          push({
+            id: `bookmark:${bm.url}`,
+            type: 'bookmark',
+            title: bm.name,
+            url: bm.url,
+            relevance: 800 + base,
+          });
+        }
+      }
+
+      // 4. Open tabs (baseline = 600)
+      if (input.length > 0) {
+        const tabs = getOpenTabs();
+        for (const tab of tabs) {
+          if (!tab.url) continue;
+          const base = scoreEntry(tab.title, tab.url, lower);
+          if (base === 0) continue;
+          push({
+            id: `tab:${tab.url}`,
+            type: 'tab',
+            title: tab.title || tab.url,
+            url: tab.url,
+            relevance: 600 + base,
+          });
+        }
+      }
+
+      // Sort by relevance descending, cap at 10
+      results.sort((a, b) => b.relevance - a.relevance);
+      return results.slice(0, 10);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // omnibox:record-selection — persist a shortcut when user confirms a URL.
+  // -------------------------------------------------------------------------
+  ipcMain.handle(
+    'omnibox:record-selection',
+    (_e, payload?: { inputText?: string; url?: string; title?: string }): boolean => {
+      const inputText = assertString(payload?.inputText ?? '', 'inputText', 2048);
+      const url = assertString(payload?.url ?? '', 'url', 2048);
+      const title = assertString(payload?.title ?? '', 'title', 512);
+      if (!url) return false;
+      mainLogger.debug('omnibox:record-selection', { inputText, url });
+      shortcutsStore.recordSelection(inputText, url, title);
+      return true;
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // omnibox:remove-history — delete a single history entry by id.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('omnibox:remove-history', (_e, id: string): boolean => {
+    assertString(id, 'id', 128);
+    mainLogger.debug('omnibox:remove-history', { id });
+    if (!historyStore) return false;
+    return historyStore.removeEntry(id);
+  });
+}
+
+export function unregisterOmniboxHandlers(): void {
+  for (const channel of CHANNELS) {
+    ipcMain.removeHandler(channel);
+  }
+}

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -1,0 +1,30 @@
+/**
+ * providers.ts — shared types for the omnibox autocomplete system.
+ *
+ * OmniboxSuggestion is the canonical result type returned by all
+ * providers (history, bookmarks, open tabs, shortcuts) and consumed
+ * by the renderer's URL-bar dropdown.
+ */
+
+export type SuggestionType =
+  | 'history'
+  | 'bookmark'
+  | 'tab'
+  | 'shortcut'
+  | 'search';
+
+export interface OmniboxSuggestion {
+  /** Unique key for React rendering (provider:id). */
+  id: string;
+  type: SuggestionType;
+  /** Primary display text (title or description). */
+  title: string;
+  /** Destination URL or search query. */
+  url: string;
+  /** Secondary line shown below title (elided URL, hostname, etc.). */
+  description?: string;
+  /** Data-URI or absolute URL for the favicon (optional). */
+  favicon?: string;
+  /** Relative relevance score used for ranking (higher = better). */
+  relevance: number;
+}

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -672,13 +672,4 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('passwords:autofill', id),
   },
 
-  // Omnibox — suggestion providers for the URL bar autocomplete
-  omnibox: {
-    suggest: (payload?: { input?: string }): Promise<unknown[]> =>
-      ipcRenderer.invoke('omnibox:suggest', payload),
-    recordSelection: (payload: { inputText: string; url: string; title: string }): Promise<boolean> =>
-      ipcRenderer.invoke('omnibox:record-selection', payload),
-    removeHistory: (id: string): Promise<boolean> =>
-      ipcRenderer.invoke('omnibox:remove-history', id),
-  },
 });

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -671,4 +671,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     autofill: (id: string): Promise<string | null> =>
       ipcRenderer.invoke('passwords:autofill', id),
   },
+
+  // Omnibox — suggestion providers for the URL bar autocomplete
+  omnibox: {
+    suggest: (payload?: { input?: string }): Promise<unknown[]> =>
+      ipcRenderer.invoke('omnibox:suggest', payload),
+    recordSelection: (payload: { inputText: string; url: string; title: string }): Promise<boolean> =>
+      ipcRenderer.invoke('omnibox:record-selection', payload),
+    removeHistory: (id: string): Promise<boolean> =>
+      ipcRenderer.invoke('omnibox:remove-history', id),
+  },
 });

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -154,25 +154,21 @@ export function URLBar({
     return () => clearTimeout(t);
   }, [focused, onFocusClear]);
 
-  // Fetch suggestions on input change (debounced 80ms)
+  // Fetch suggestions on input change (debounced 80ms); empty input → ZeroSuggest
   useEffect(() => {
     if (!isEditing) return;
     if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
-    if (!inputValue.trim()) {
-      setSuggestions([]);
-      setDropdownOpen(false);
-      return;
-    }
     suggestTimerRef.current = setTimeout(async () => {
       try {
         const results = await electronAPI.omnibox.suggest({ input: inputValue.trim() });
-        setSuggestions(results ?? []);
-        setDropdownOpen((results ?? []).length > 0);
+        const limited = (results ?? []).slice(0, inputValue.trim() ? 8 : 6);
+        setSuggestions(limited);
+        setDropdownOpen(limited.length > 0);
         setSelectedIdx(-1);
       } catch {
         setSuggestions([]);
       }
-    }, 80);
+    }, inputValue.trim() ? 80 : 0);
     return () => {
       if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
     };

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -11,6 +11,29 @@ import React, {
 } from 'react';
 
 // ---------------------------------------------------------------------------
+// Omnibox types (mirrored from main/omnibox/providers.ts)
+// ---------------------------------------------------------------------------
+interface OmniboxSuggestion {
+  id: string;
+  type: 'history' | 'bookmark' | 'tab' | 'shortcut' | 'search';
+  title: string;
+  url: string;
+  description?: string;
+  favicon?: string;
+  relevance: number;
+}
+
+declare const electronAPI: {
+  omnibox: {
+    suggest: (p: { input: string }) => Promise<OmniboxSuggestion[]>;
+    recordSelection: (p: { inputText: string; url: string; title: string }) => Promise<boolean>;
+    removeHistory: (id: string) => Promise<boolean>;
+  };
+};
+
+const GOOGLE_FAVICON_API = 'https://www.google.com/s2/favicons?sz=32&domain_url=';
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 const SECURE_RE = /^https:\/\//i;
@@ -101,6 +124,12 @@ export function URLBar({
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(() => displayUrl(url));
   const [isEditing, setIsEditing] = useState(false);
+  const [suggestions, setSuggestions] = useState<OmniboxSuggestion[]>([]);
+  const [selectedIdx, setSelectedIdx] = useState(-1);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track the input text used when the user started editing (for recordSelection)
+  const editInputRef = useRef('');
 
   // Sync display when URL changes externally (not while editing)
   useEffect(() => {
@@ -125,37 +154,114 @@ export function URLBar({
     return () => clearTimeout(t);
   }, [focused, onFocusClear]);
 
+  // Fetch suggestions on input change (debounced 80ms)
+  useEffect(() => {
+    if (!isEditing) return;
+    if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+    if (!inputValue.trim()) {
+      setSuggestions([]);
+      setDropdownOpen(false);
+      return;
+    }
+    suggestTimerRef.current = setTimeout(async () => {
+      try {
+        const results = await electronAPI.omnibox.suggest({ input: inputValue.trim() });
+        setSuggestions(results ?? []);
+        setDropdownOpen((results ?? []).length > 0);
+        setSelectedIdx(-1);
+      } catch {
+        setSuggestions([]);
+      }
+    }, 80);
+    return () => {
+      if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+    };
+  }, [inputValue, isEditing]);
+
   const handleFocus = useCallback(() => {
     setIsEditing(true);
+    editInputRef.current = inputValue;
     // On focus, show the full URL so the user can edit it — except for blank
     // new-tab placeholders, where the input stays empty so typing is fresh.
     setInputValue(BLANK_RE.test(url) ? '' : url);
     inputRef.current?.select();
-  }, [url]);
+  }, [url, inputValue]);
+
+  const closeDropdown = useCallback(() => {
+    setDropdownOpen(false);
+    setSuggestions([]);
+    setSelectedIdx(-1);
+  }, []);
 
   const handleBlur = useCallback(() => {
-    setIsEditing(false);
-    setInputValue(displayUrl(url));
-  }, [url]);
+    // Delay to let click-on-suggestion fire first
+    setTimeout(() => {
+      setIsEditing(false);
+      setInputValue(displayUrl(url));
+      closeDropdown();
+    }, 150);
+  }, [url, closeDropdown]);
+
+  const confirmNavigate = useCallback((target: string, suggestion?: OmniboxSuggestion) => {
+    closeDropdown();
+    onNavigate(target);
+    if (suggestion) {
+      electronAPI.omnibox.recordSelection({
+        inputText: editInputRef.current,
+        url: suggestion.url,
+        title: suggestion.title,
+      }).catch(() => {});
+    }
+    inputRef.current?.blur();
+  }, [onNavigate, closeDropdown]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.min(i + 1, suggestions.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.max(i - 1, -1));
+        return;
+      }
       if (e.key === 'Enter') {
         e.preventDefault();
-        const trimmed = inputValue.trim();
-        if (trimmed) {
-          onNavigate(trimmed);
+        const sel = suggestions[selectedIdx];
+        if (sel) {
+          confirmNavigate(sel.url, sel);
+        } else {
+          const trimmed = inputValue.trim();
+          if (trimmed) confirmNavigate(trimmed);
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        if (dropdownOpen) {
+          closeDropdown();
+        } else {
+          setIsEditing(false);
+          setInputValue(displayUrl(url));
           inputRef.current?.blur();
         }
       }
-      if (e.key === 'Escape') {
-        setIsEditing(false);
-        setInputValue(displayUrl(url));
-        inputRef.current?.blur();
-      }
     },
-    [inputValue, onNavigate, url],
+    [inputValue, suggestions, selectedIdx, dropdownOpen, confirmNavigate, closeDropdown, url],
   );
+
+  const handleRemoveSuggestion = useCallback(async (s: OmniboxSuggestion, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (s.id.startsWith('history:')) {
+      const id = s.id.slice('history:'.length);
+      await electronAPI.omnibox.removeHistory(id).catch(() => {});
+    }
+    setSuggestions((prev) => prev.filter((x) => x.id !== s.id));
+    if (suggestions.filter((x) => x.id !== s.id).length === 0) {
+      setDropdownOpen(false);
+    }
+  }, [suggestions]);
 
   const security = getSecurityStatus(url);
   // Hide the star on blank/new-tab URLs — nothing meaningful to bookmark.
@@ -236,6 +342,54 @@ export function URLBar({
 
       {/* Loading indicator */}
       {isLoading && <span className="url-bar__loading" aria-hidden="true" />}
+
+      {/* Autocomplete dropdown */}
+      {dropdownOpen && suggestions.length > 0 && (
+        <div className="omnibox-dropdown" role="listbox" aria-label="Suggestions">
+          {suggestions.map((s, idx) => (
+            <div
+              key={s.id}
+              className={`omnibox-dropdown__item${idx === selectedIdx ? ' omnibox-dropdown__item--selected' : ''}`}
+              role="option"
+              aria-selected={idx === selectedIdx}
+              onMouseDown={(e) => { e.preventDefault(); confirmNavigate(s.url, s); }}
+              onMouseEnter={() => setSelectedIdx(idx)}
+            >
+              <span className="omnibox-dropdown__icon">
+                {s.favicon ? (
+                  <img src={s.favicon} width={16} height={16} alt="" />
+                ) : (
+                  <img
+                    src={GOOGLE_FAVICON_API + encodeURIComponent(s.url)}
+                    width={16}
+                    height={16}
+                    alt=""
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                )}
+              </span>
+              <span className="omnibox-dropdown__text">
+                <span className="omnibox-dropdown__title">{s.title || s.url}</span>
+                {s.title && s.url !== s.title && (
+                  <span className="omnibox-dropdown__url">{s.url}</span>
+                )}
+              </span>
+              <span className="omnibox-dropdown__type">{s.type}</span>
+              {(s.type === 'history' || s.type === 'shortcut') && (
+                <button
+                  type="button"
+                  className="omnibox-dropdown__remove"
+                  title="Remove from suggestions"
+                  onMouseDown={(e) => handleRemoveSuggestion(s, e)}
+                  aria-label="Remove suggestion"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -128,6 +128,7 @@ export function URLBar({
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suggestGenRef = useRef(0);
   // Track the input text used when the user started editing (for recordSelection)
   const editInputRef = useRef('');
 
@@ -158,15 +159,17 @@ export function URLBar({
   useEffect(() => {
     if (!isEditing) return;
     if (suggestTimerRef.current) clearTimeout(suggestTimerRef.current);
+    const gen = ++suggestGenRef.current;
     suggestTimerRef.current = setTimeout(async () => {
       try {
         const results = await electronAPI.omnibox.suggest({ input: inputValue.trim() });
+        if (gen !== suggestGenRef.current) return; // stale response — newer request is in-flight
         const limited = (results ?? []).slice(0, inputValue.trim() ? 8 : 6);
         setSuggestions(limited);
         setDropdownOpen(limited.length > 0);
         setSelectedIdx(-1);
       } catch {
-        setSuggestions([]);
+        if (gen === suggestGenRef.current) setSuggestions([]);
       }
     }, inputValue.trim() ? 80 : 0);
     return () => {

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -352,6 +352,7 @@
   background: var(--color-bg-overlay);
   border-color: var(--color-border-strong);
   box-shadow: none;
+  overflow: visible;
 }
 
 .url-bar--insecure .url-bar__security {
@@ -439,6 +440,102 @@
   0%   { transform: translateX(-100%); opacity: 0.9; }
   50%  { transform: translateX(0%);    opacity: 1; }
   100% { transform: translateX(100%);  opacity: 0.9; }
+}
+
+/* ---------------------------------------------------------------------------
+   Omnibox dropdown — autocomplete suggestion list
+   --------------------------------------------------------------------------- */
+.omnibox-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: -2px;
+  right: -2px;
+  background: var(--color-bg-elevated, #2a2a2a);
+  border: 1px solid var(--color-border-default, rgba(255,255,255,0.1));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  z-index: 1000;
+  overflow: hidden;
+  padding: 4px 0;
+}
+
+.omnibox-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+  min-width: 0;
+}
+
+.omnibox-dropdown__item--selected,
+.omnibox-dropdown__item:hover {
+  background: var(--color-bg-hover, rgba(255,255,255,0.08));
+}
+
+.omnibox-dropdown__icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.omnibox-dropdown__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.omnibox-dropdown__title {
+  font-size: 13px;
+  color: var(--color-text-primary, #e8e8e8);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.omnibox-dropdown__url {
+  font-size: 11px;
+  color: var(--color-text-muted, rgba(255,255,255,0.45));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.omnibox-dropdown__type {
+  flex-shrink: 0;
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--color-text-muted, rgba(255,255,255,0.3));
+  letter-spacing: 0.05em;
+}
+
+.omnibox-dropdown__remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--color-text-muted, rgba(255,255,255,0.4));
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.omnibox-dropdown__item:hover .omnibox-dropdown__remove,
+.omnibox-dropdown__item--selected .omnibox-dropdown__remove {
+  opacity: 1;
+}
+
+.omnibox-dropdown__remove:hover {
+  background: var(--color-bg-hover, rgba(255,255,255,0.12));
+  color: var(--color-text-primary, #e8e8e8);
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #17 (partial: history, bookmarks, tabs, shortcuts providers)
- Adds omnibox suggestion dropdown to URLBar when typing
- Keyboard navigation: Arrow Up/Down to select, Enter to confirm, Escape to close
- Click on suggestion navigates to that URL
- × button removes history/shortcut suggestions
- Suggestions debounced 80ms; deduped and ranked by relevance
- Backend providers (history, bookmarks, open tabs, shortcuts) already existed in main/omnibox/

## Test plan
- [ ] Type in URL bar: dropdown shows matching history/bookmarks/tabs
- [ ] Arrow keys move selection
- [ ] Enter on selected suggestion navigates there
- [ ] × removes suggestion from list
- [ ] Escape closes dropdown without navigating
- [ ] Click suggestion navigates
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an omnibox autocomplete dropdown to the URL bar with suggestions from history, bookmarks, open tabs, and persisted shortcuts, plus ZeroSuggest on empty input. Addresses #17 by shipping the suggestion UI, ranking, IPC handlers, and key interactions.

- **New Features**
  - Main: registers `omnibox:suggest`, `omnibox:record-selection`, `omnibox:remove-history`; aggregates shortcuts, history, bookmarks, and open tabs; dedupes by URL keeping the highest-relevance entry and ranks results.
  - New `ShortcutsStore` persists user-confirmed selections (debounced writes) to boost future ranking; ZeroSuggest on focus with empty input.
  - UI: 80 ms debounce, keyboard (Up/Down/Enter/Escape), click to navigate, remove button on history/shortcut items, favicon fallback and type badges; uses a generation counter to discard stale async responses.

- **Bug Fixes**
  - Added the missing main-process omnibox IPC handlers so the renderer can fetch suggestions and record selections.
  - Removed a duplicate omnibox preload section to avoid conflicts and ensure IPC is exposed once.
  - Enforce `MAX_SHORTCUTS` cap at load time to prevent store bloat.
  - Flush `ShortcutsStore` on quit to persist selections.

<sup>Written for commit 9b06176f2640acb7b37a40bbc423c41f31b4b875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

