### PR TITLE
feat(omnibox): did-you-mean typo correction for misspelled hostnames

### DIFF
--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -214,7 +214,15 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
         }
 
         if (bestEntry) {
-          const correctedUrl = `https://${bestEntry.hostname}`;
+          // Rewrite only the hostname in the original URL, preserving scheme, port, and path.
+          let correctedUrl: string;
+          try {
+            const parsed = new URL(bestEntry.url);
+            parsed.hostname = bestEntry.hostname;
+            correctedUrl = parsed.toString();
+          } catch {
+            correctedUrl = `https://${bestEntry.hostname}`;
+          }
           push({
             id: `did-you-mean:${bestEntry.hostname}`,
             type: 'did-you-mean',

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -57,6 +57,42 @@ function scoreText(text: string, lower: string): number {
   return 0;
 }
 
+// Levenshtein distance for "did you mean" typo detection.
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const matrix: number[][] = [];
+  for (let i = 0; i <= b.length; i++) matrix[i] = [i];
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b[i - 1] === a[j - 1]) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1,     // insertion
+          matrix[i - 1][j] + 1,     // deletion
+        );
+      }
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+// Looks like a bare domain (no scheme, no spaces, has a dot + TLD).
+const BARE_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*)?(\.[a-z0-9][a-z0-9-]*)+$/i;
+
+function extractHostname(url: string): string {
+  try {
+    const u = new URL(url.startsWith('http') ? url : `https://${url}`);
+    return u.hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
 function scoreEntry(title: string, url: string, inputLower: string): number {
   return Math.max(scoreText(title, inputLower), scoreText(url, inputLower));
 }
@@ -147,6 +183,45 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
             title: tab.title || tab.url,
             url: tab.url,
             relevance: 600 + base,
+          });
+        }
+      }
+
+      // 5. Did-you-mean: fuzzy hostname match against visited URLs (baseline = 750).
+      // Only fires when the input looks like a domain, has no exact history match,
+      // and a close variant (Levenshtein ≤ 2) exists in history.
+      if (
+        historyStore &&
+        input.length >= 4 &&
+        BARE_DOMAIN_RE.test(lower) &&
+        results.filter((r) => r.type === 'history' || r.type === 'shortcut').length === 0
+      ) {
+        const inputHost = extractHostname(lower);
+        const { entries: histEntries } = historyStore.query({ limit: 200 });
+        const hostsSeen = new Set<string>();
+        let bestDistance = 3;
+        let bestEntry: { url: string; title: string; hostname: string } | null = null;
+
+        for (const e of histEntries) {
+          const hostname = extractHostname(e.url);
+          if (hostsSeen.has(hostname)) continue;
+          hostsSeen.add(hostname);
+          const dist = levenshtein(inputHost, hostname);
+          if (dist > 0 && dist < bestDistance) {
+            bestDistance = dist;
+            bestEntry = { url: e.url, title: e.title || e.url, hostname };
+          }
+        }
+
+        if (bestEntry) {
+          const correctedUrl = `https://${bestEntry.hostname}`;
+          push({
+            id: `did-you-mean:${bestEntry.hostname}`,
+            type: 'did-you-mean',
+            title: `Did you mean: ${bestEntry.hostname}?`,
+            url: correctedUrl,
+            description: correctedUrl,
+            relevance: 750,
           });
         }
       }

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -11,7 +11,8 @@ export type SuggestionType =
   | 'bookmark'
   | 'tab'
   | 'shortcut'
-  | 'search';
+  | 'search'
+  | 'did-you-mean';
 
 export interface OmniboxSuggestion {
   /** Unique key for React rendering (provider:id). */


### PR DESCRIPTION
## Summary
- Closes #22
- Adds Levenshtein distance-based typo correction for mistyped domain names
- When the user types something that looks like a domain (no spaces, has TLD) with no history matches, the omnibox searches history for close hostnames (distance ≤ 2)
- Shows 'Did you mean: facebook.com?' as a suggestion in the dropdown

## Test plan
- [ ] Type 'facebok.com' after visiting facebook.com — see 'Did you mean: facebook.com?'
- [ ] Exact matches in history don't show did-you-mean (falls through to normal results)
- [ ] Selecting the suggestion navigates to the correct site
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Did you mean" omnibox suggestion to catch mistyped hostnames and navigate to the intended site. Preserves scheme, port, and path when opening the corrected URL. Closes #22.

- **New Features**
  - Suggests the closest visited hostname when the input looks like a domain and no exact history/shortcut match exists.
  - Uses Levenshtein distance ≤ 2 over recent history (deduped hosts, up to 200); shows "Did you mean: host?" (relevance 750) via the new `did-you-mean` suggestion type.

- **Bug Fixes**
  - The suggestion URL keeps the original scheme, port, and path instead of defaulting to https://host.

<sup>Written for commit ef8182076ea98c48f60f7c9287b300cd8b008ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

