### PR TITLE
feat(bookmarks): chrome://bookmarks manager page with folder tree and search

### DIFF
--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -192,6 +192,12 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
+        {
+          // Issue #31: bookmarks manager preload
+          entry: 'src/preload/bookmarks.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
         // Issue #37: downloads internal page preload — disabled in CI until
         // src/preload/downloads.ts lands alongside the downloads renderer.
         // {
@@ -260,6 +266,11 @@ const config: ForgeConfig = {
           // Issue #40: history internal page renderer
           name: 'history',
           config: 'vite.history.config.ts',
+        },
+        {
+          // Issue #31: bookmarks manager renderer
+          name: 'bookmarks',
+          config: 'vite.bookmarks.config.ts',
         },
         // Issue #37: downloads internal page renderer — disabled in CI until
         // the missing vite.downloads.config.ts + src/renderer/downloads/

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1326,7 +1326,7 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
         { type: 'separator' },
         {
           label: 'Bookmark Manager',
-          accelerator: 'CommandOrControl+Alt+B',
+          accelerator: 'CommandOrControl+Shift+O',
           click: () => {
             mainLogger.debug('shortcuts.bookmarkManager');
             tabManager?.createTab('chrome://bookmarks');

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -110,6 +110,8 @@ declare const HISTORY_VITE_DEV_SERVER_URL: string | undefined;
 declare const HISTORY_VITE_NAME: string | undefined;
 declare const DOWNLOADS_VITE_DEV_SERVER_URL: string | undefined;
 declare const DOWNLOADS_VITE_NAME: string | undefined;
+declare const BOOKMARKS_VITE_DEV_SERVER_URL: string | undefined;
+declare const BOOKMARKS_VITE_NAME: string | undefined;
 declare const CHROME_PAGES_VITE_DEV_SERVER_URL: string | undefined;
 declare const CHROME_PAGES_VITE_NAME: string | undefined;
 
@@ -749,6 +751,7 @@ export class TabManager {
     const preloadMap: Record<string, string> = {
       history: 'history.js',
       downloads: 'downloads.js',
+      bookmarks: 'bookmarks.js',
     };
     const preloadFile = CHROME_PAGES_PAGES.has(page) ? 'chrome.js' : (preloadMap[page] ?? 'history.js');
     const preloadPath = path.join(__dirname, preloadFile);
@@ -787,6 +790,13 @@ export class TabManager {
       } else {
         const name = typeof DOWNLOADS_VITE_NAME !== 'undefined' ? DOWNLOADS_VITE_NAME : 'downloads';
         url = 'file://' + path.join(__dirname, '..', '..', 'renderer', name, 'downloads.html');
+      }
+    } else if (page === 'bookmarks') {
+      if (typeof BOOKMARKS_VITE_DEV_SERVER_URL !== 'undefined' && BOOKMARKS_VITE_DEV_SERVER_URL) {
+        url = BOOKMARKS_VITE_DEV_SERVER_URL + '/src/renderer/bookmarks/bookmarks.html';
+      } else {
+        const name = typeof BOOKMARKS_VITE_NAME !== 'undefined' ? BOOKMARKS_VITE_NAME : 'bookmarks';
+        url = 'file://' + path.join(__dirname, '..', '..', 'renderer', name, 'bookmarks.html');
       }
     } else if (CHROME_PAGES_PAGES.has(page)) {
       let baseUrl: string;

--- a/my-app/src/preload/bookmarks.ts
+++ b/my-app/src/preload/bookmarks.ts
@@ -1,0 +1,39 @@
+/**
+ * Preload script for the chrome://bookmarks internal page.
+ * Exposes a safe contextBridge API for querying and managing bookmarks.
+ */
+
+import { contextBridge, ipcRenderer } from 'electron';
+import type { PersistedBookmarks } from '../main/bookmarks/BookmarkStore';
+
+contextBridge.exposeInMainWorld('bookmarksAPI', {
+  list: (): Promise<PersistedBookmarks> =>
+    ipcRenderer.invoke('bookmarks:list'),
+
+  add: (p: { name: string; url: string; parentId?: string }) =>
+    ipcRenderer.invoke('bookmarks:add', p),
+
+  addFolder: (p: { name: string; parentId?: string }) =>
+    ipcRenderer.invoke('bookmarks:add-folder', p),
+
+  remove: (id: string) =>
+    ipcRenderer.invoke('bookmarks:remove', id),
+
+  rename: (p: { id: string; newName: string }) =>
+    ipcRenderer.invoke('bookmarks:rename', p),
+
+  move: (p: { id: string; newParentId: string; index: number }) =>
+    ipcRenderer.invoke('bookmarks:move', p),
+
+  navigateTo: (url: string) =>
+    ipcRenderer.invoke('tabs:navigate-active', url),
+
+  openInNewTab: (url: string) =>
+    ipcRenderer.invoke('tabs:create', { url }),
+
+  onBookmarksUpdated: (cb: (data: PersistedBookmarks) => void) => {
+    const handler = (_e: unknown, data: PersistedBookmarks) => cb(data);
+    ipcRenderer.on('bookmarks-updated', handler);
+    return () => ipcRenderer.removeListener('bookmarks-updated', handler);
+  },
+});

--- a/my-app/src/renderer/bookmarks/BookmarkManager.tsx
+++ b/my-app/src/renderer/bookmarks/BookmarkManager.tsx
@@ -86,7 +86,7 @@ interface ContextMenuProps {
   onRename: (node: BookmarkNode) => void;
   onDelete: (node: BookmarkNode) => void;
   onCopyUrl: (node: BookmarkNode) => void;
-  onAddFolder: () => void;
+  onAddFolder: (parentId: string) => void;
 }
 
 function ContextMenu({
@@ -141,7 +141,7 @@ function ContextMenu({
         </>
       )}
       {item('Edit Name', () => onRename(menu.node))}
-      {item('Add Folder Here', () => onAddFolder())}
+      {item('Add Folder Here', () => onAddFolder(menu.node.type === 'folder' ? menu.node.id : (menu.node.parentId ?? 'other')))}
       <div className="bookmarks__context-menu-separator" />
       {item('Delete', () => onDelete(menu.node), true)}
     </div>
@@ -319,11 +319,11 @@ export function BookmarkManager() {
     setRenamingId(null);
   }, [renamingId, renameValue]);
 
-  const handleAddFolder = useCallback(() => {
+  const handleAddFolder = useCallback((parentId: string) => {
     bookmarksAPI
-      .addFolder({ name: 'New folder', parentId: selectedFolderId })
+      .addFolder({ name: 'New folder', parentId })
       .catch(console.error);
-  }, [selectedFolderId]);
+  }, []);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, node: BookmarkNode) => {

--- a/my-app/src/renderer/bookmarks/BookmarkManager.tsx
+++ b/my-app/src/renderer/bookmarks/BookmarkManager.tsx
@@ -309,6 +309,7 @@ export function BookmarkManager() {
   }, []);
 
   const startRename = useCallback((node: BookmarkNode) => {
+    renameCancelledRef.current = false;
     setRenamingId(node.id);
     setRenameValue(node.name);
   }, []);

--- a/my-app/src/renderer/bookmarks/BookmarkManager.tsx
+++ b/my-app/src/renderer/bookmarks/BookmarkManager.tsx
@@ -1,0 +1,510 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Types (mirrored from BookmarkStore — no import, preload bridges the gap)
+// ---------------------------------------------------------------------------
+
+interface BookmarkNode {
+  id: string;
+  type: 'bookmark' | 'folder';
+  name: string;
+  url?: string;
+  children?: BookmarkNode[];
+  parentId: string | null;
+  createdAt: number;
+}
+
+interface PersistedBookmarks {
+  version: 1;
+  visibility: 'always' | 'never' | 'ntp-only';
+  roots: [BookmarkNode, BookmarkNode];
+}
+
+declare const bookmarksAPI: {
+  list: () => Promise<PersistedBookmarks>;
+  add: (p: { name: string; url: string; parentId?: string }) => Promise<BookmarkNode>;
+  addFolder: (p: { name: string; parentId?: string }) => Promise<BookmarkNode>;
+  remove: (id: string) => Promise<boolean>;
+  rename: (p: { id: string; newName: string }) => Promise<boolean>;
+  move: (p: { id: string; newParentId: string; index: number }) => Promise<boolean>;
+  navigateTo: (url: string) => Promise<void>;
+  openInNewTab: (url: string) => Promise<void>;
+  onBookmarksUpdated: (cb: (data: PersistedBookmarks) => void) => () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getFaviconUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `https://www.google.com/s2/favicons?domain=${u.hostname}&sz=16`;
+  } catch {
+    return '';
+  }
+}
+
+function collectAllBookmarks(node: BookmarkNode, results: BookmarkNode[]): void {
+  if (node.type === 'bookmark') {
+    results.push(node);
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      collectAllBookmarks(child, results);
+    }
+  }
+}
+
+function collectAllFolders(node: BookmarkNode, results: BookmarkNode[]): void {
+  if (node.type === 'folder') {
+    results.push(node);
+    if (node.children) {
+      for (const child of node.children) {
+        collectAllFolders(child, results);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context Menu
+// ---------------------------------------------------------------------------
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  node: BookmarkNode;
+}
+
+interface ContextMenuProps {
+  menu: ContextMenuState;
+  selectedFolderId: string;
+  onClose: () => void;
+  onOpen: (node: BookmarkNode) => void;
+  onOpenNewTab: (node: BookmarkNode) => void;
+  onRename: (node: BookmarkNode) => void;
+  onDelete: (node: BookmarkNode) => void;
+  onCopyUrl: (node: BookmarkNode) => void;
+  onAddFolder: () => void;
+}
+
+function ContextMenu({
+  menu,
+  onClose,
+  onOpen,
+  onOpenNewTab,
+  onRename,
+  onDelete,
+  onCopyUrl,
+  onAddFolder,
+}: ContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  const item = (label: string, action: () => void, danger = false) => (
+    <button
+      className={`bookmarks__context-menu-item${danger ? ' bookmarks__context-menu-item--danger' : ''}`}
+      onMouseDown={(e) => { e.preventDefault(); action(); onClose(); }}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div
+      ref={ref}
+      className="bookmarks__context-menu"
+      style={{ left: menu.x, top: menu.y }}
+    >
+      {menu.node.type === 'bookmark' && (
+        <>
+          {item('Open', () => onOpen(menu.node))}
+          {item('Open in New Tab', () => onOpenNewTab(menu.node))}
+          {item('Copy URL', () => onCopyUrl(menu.node))}
+          <div className="bookmarks__context-menu-separator" />
+        </>
+      )}
+      {menu.node.type === 'folder' && (
+        <>
+          {item('Open Folder', () => onOpen(menu.node))}
+          <div className="bookmarks__context-menu-separator" />
+        </>
+      )}
+      {item('Edit Name', () => onRename(menu.node))}
+      {item('Add Folder Here', () => onAddFolder())}
+      <div className="bookmarks__context-menu-separator" />
+      {item('Delete', () => onDelete(menu.node), true)}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Folder Tree (sidebar)
+// ---------------------------------------------------------------------------
+
+interface FolderTreeItemProps {
+  node: BookmarkNode;
+  depth: number;
+  selectedFolderId: string;
+  onSelect: (id: string) => void;
+}
+
+function FolderTreeItem({ node, depth, selectedFolderId, onSelect }: FolderTreeItemProps) {
+  const [expanded, setExpanded] = useState(true);
+  const subFolders = (node.children ?? []).filter((c) => c.type === 'folder');
+  const isSelected = node.id === selectedFolderId;
+  const hasChildren = subFolders.length > 0;
+
+  return (
+    <div>
+      <div
+        className={`bookmarks__tree-item${isSelected ? ' bookmarks__tree-item--selected' : ''}`}
+        style={{ paddingLeft: 12 + depth * 12 }}
+        onClick={() => onSelect(node.id)}
+      >
+        {hasChildren ? (
+          <span
+            className="bookmarks__tree-icon"
+            onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+            style={{ cursor: 'pointer', fontSize: 10 }}
+          >
+            {expanded ? '▾' : '▸'}
+          </span>
+        ) : (
+          <span className="bookmarks__tree-icon" style={{ width: 10, display: 'inline-block' }} />
+        )}
+        <svg
+          className="bookmarks__tree-icon"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
+        </svg>
+        <span className="bookmarks__tree-name">{node.name}</span>
+      </div>
+      {expanded && hasChildren && (
+        <div className="bookmarks__tree-children">
+          {subFolders.map((child) => (
+            <FolderTreeItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              selectedFolderId={selectedFolderId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main BookmarkManager component
+// ---------------------------------------------------------------------------
+
+type SortMode = 'name' | 'date';
+
+export function BookmarkManager() {
+  const [data, setData] = useState<PersistedBookmarks | null>(null);
+  const [selectedFolderId, setSelectedFolderId] = useState<string>('bookmarks-bar');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortMode, setSortMode] = useState<SortMode>('date');
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  // ── Load data ──
+  useEffect(() => {
+    bookmarksAPI.list().then(setData).catch(console.error);
+    const unsubscribe = bookmarksAPI.onBookmarksUpdated(setData);
+    return unsubscribe;
+  }, []);
+
+  // ── Focus rename input ──
+  useEffect(() => {
+    if (renamingId && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [renamingId]);
+
+  // ── Find folder by id ──
+  const findFolder = useCallback(
+    (id: string): BookmarkNode | null => {
+      if (!data) return null;
+      for (const root of data.roots) {
+        const folders: BookmarkNode[] = [];
+        collectAllFolders(root, folders);
+        const found = folders.find((f) => f.id === id);
+        if (found) return found;
+      }
+      return null;
+    },
+    [data],
+  );
+
+  // ── Items to display ──
+  const displayItems: BookmarkNode[] = (() => {
+    if (!data) return [];
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase();
+      const allBookmarks: BookmarkNode[] = [];
+      for (const root of data.roots) {
+        collectAllBookmarks(root, allBookmarks);
+      }
+      return allBookmarks.filter(
+        (b) =>
+          b.name.toLowerCase().includes(q) ||
+          (b.url ?? '').toLowerCase().includes(q),
+      );
+    }
+    const folder = findFolder(selectedFolderId);
+    if (!folder) return [];
+    const items = folder.children ?? [];
+    return [...items].sort((a, b) => {
+      if (sortMode === 'name') return a.name.localeCompare(b.name);
+      return b.createdAt - a.createdAt;
+    });
+  })();
+
+  // ── Actions ──
+  const handleOpen = useCallback((node: BookmarkNode) => {
+    if (node.type === 'folder') {
+      setSelectedFolderId(node.id);
+      setSearchQuery('');
+    } else if (node.url) {
+      bookmarksAPI.navigateTo(node.url).catch(console.error);
+    }
+  }, []);
+
+  const handleOpenNewTab = useCallback((node: BookmarkNode) => {
+    if (node.url) {
+      bookmarksAPI.openInNewTab(node.url).catch(console.error);
+    }
+  }, []);
+
+  const handleDelete = useCallback((node: BookmarkNode) => {
+    bookmarksAPI.remove(node.id).catch(console.error);
+  }, []);
+
+  const handleCopyUrl = useCallback((node: BookmarkNode) => {
+    if (node.url) {
+      navigator.clipboard.writeText(node.url).catch(console.error);
+    }
+  }, []);
+
+  const startRename = useCallback((node: BookmarkNode) => {
+    setRenamingId(node.id);
+    setRenameValue(node.name);
+  }, []);
+
+  const commitRename = useCallback(() => {
+    if (renamingId && renameValue.trim()) {
+      bookmarksAPI.rename({ id: renamingId, newName: renameValue.trim() }).catch(console.error);
+    }
+    setRenamingId(null);
+  }, [renamingId, renameValue]);
+
+  const handleAddFolder = useCallback(() => {
+    bookmarksAPI
+      .addFolder({ name: 'New folder', parentId: selectedFolderId })
+      .catch(console.error);
+  }, [selectedFolderId]);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, node: BookmarkNode) => {
+      e.preventDefault();
+      setContextMenu({ x: e.clientX, y: e.clientY, node });
+    },
+    [],
+  );
+
+  // ── Render loading state ──
+  if (!data) {
+    return (
+      <div className="bookmarks">
+        <div className="bookmarks__empty">Loading bookmarks…</div>
+      </div>
+    );
+  }
+
+  const isSearching = searchQuery.trim().length > 0;
+  const selectedFolder = findFolder(selectedFolderId);
+
+  return (
+    <div className="bookmarks" onClick={() => setContextMenu(null)}>
+      {/* Header */}
+      <div className="bookmarks__header">
+        <h1 className="bookmarks__title">Bookmarks</h1>
+        <div className="bookmarks__search-container">
+          <svg
+            className="bookmarks__search-icon"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <input
+            className="bookmarks__search"
+            type="search"
+            placeholder="Search bookmarks"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+        <div className="bookmarks__toolbar-actions">
+          <button
+            className={`bookmarks__sort-btn${sortMode === 'name' ? ' bookmarks__sort-btn--active' : ''}`}
+            onClick={() => setSortMode('name')}
+          >
+            By Name
+          </button>
+          <button
+            className={`bookmarks__sort-btn${sortMode === 'date' ? ' bookmarks__sort-btn--active' : ''}`}
+            onClick={() => setSortMode('date')}
+          >
+            By Date
+          </button>
+          <button className="bookmarks__add-folder-btn" onClick={handleAddFolder}>
+            + New Folder
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="bookmarks__body">
+        {/* Sidebar */}
+        <div className="bookmarks__sidebar">
+          {data.roots.map((root) => (
+            <FolderTreeItem
+              key={root.id}
+              node={root}
+              depth={0}
+              selectedFolderId={selectedFolderId}
+              onSelect={(id) => { setSelectedFolderId(id); setSearchQuery(''); }}
+            />
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="bookmarks__content">
+          {isSearching ? (
+            <div className="bookmarks__search-results">
+              {displayItems.length} result{displayItems.length !== 1 ? 's' : ''} for &quot;{searchQuery}&quot;
+            </div>
+          ) : selectedFolder ? (
+            <div className="bookmarks__content-header">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
+              </svg>
+              {selectedFolder.name}
+            </div>
+          ) : null}
+
+          {displayItems.length === 0 ? (
+            <div className="bookmarks__empty">
+              {isSearching ? 'No bookmarks match your search.' : 'This folder is empty.'}
+            </div>
+          ) : (
+            displayItems.map((node) => (
+              <div
+                key={node.id}
+                className="bookmarks__item"
+                onDoubleClick={() => startRename(node)}
+                onContextMenu={(e) => handleContextMenu(e, node)}
+              >
+                {/* Icon */}
+                <div className="bookmarks__item-icon">
+                  {node.type === 'folder' ? (
+                    <svg
+                      className="bookmarks__item-folder-icon"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                    >
+                      <path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" />
+                    </svg>
+                  ) : node.url ? (
+                    <img
+                      className="bookmarks__item-favicon"
+                      src={getFaviconUrl(node.url)}
+                      alt=""
+                      width={16}
+                      height={16}
+                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                    />
+                  ) : null}
+                </div>
+
+                {/* Name — inline rename or clickable label */}
+                {renamingId === node.id ? (
+                  <input
+                    ref={renameInputRef}
+                    className="bookmarks__rename-input"
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitRename();
+                      if (e.key === 'Escape') setRenamingId(null);
+                    }}
+                  />
+                ) : (
+                  <span
+                    className={`bookmarks__item-name${node.type === 'bookmark' || node.type === 'folder' ? ' bookmarks__item-name--link' : ''}`}
+                    onClick={() => handleOpen(node)}
+                    title={node.name}
+                  >
+                    {node.name}
+                  </span>
+                )}
+
+                {/* URL preview for bookmarks */}
+                {node.type === 'bookmark' && node.url && renamingId !== node.id && (
+                  <span className="bookmarks__item-url" title={node.url}>
+                    {node.url}
+                  </span>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Context Menu */}
+      {contextMenu && (
+        <ContextMenu
+          menu={contextMenu}
+          selectedFolderId={selectedFolderId}
+          onClose={() => setContextMenu(null)}
+          onOpen={handleOpen}
+          onOpenNewTab={handleOpenNewTab}
+          onRename={startRename}
+          onDelete={handleDelete}
+          onCopyUrl={handleCopyUrl}
+          onAddFolder={handleAddFolder}
+        />
+      )}
+    </div>
+  );
+}

--- a/my-app/src/renderer/bookmarks/BookmarkManager.tsx
+++ b/my-app/src/renderer/bookmarks/BookmarkManager.tsx
@@ -226,6 +226,7 @@ export function BookmarkManager() {
   const [renameValue, setRenameValue] = useState('');
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const renameCancelledRef = useRef(false);
 
   // ── Load data ──
   useEffect(() => {
@@ -313,6 +314,10 @@ export function BookmarkManager() {
   }, []);
 
   const commitRename = useCallback(() => {
+    if (renameCancelledRef.current) {
+      renameCancelledRef.current = false;
+      return;
+    }
     if (renamingId && renameValue.trim()) {
       bookmarksAPI.rename({ id: renamingId, newName: renameValue.trim() }).catch(console.error);
     }
@@ -466,7 +471,10 @@ export function BookmarkManager() {
                     onBlur={commitRename}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') commitRename();
-                      if (e.key === 'Escape') setRenamingId(null);
+                      if (e.key === 'Escape') {
+                        renameCancelledRef.current = true;
+                        setRenamingId(null);
+                      }
                     }}
                   />
                 ) : (

--- a/my-app/src/renderer/bookmarks/BookmarkManager.tsx
+++ b/my-app/src/renderer/bookmarks/BookmarkManager.tsx
@@ -384,7 +384,7 @@ export function BookmarkManager() {
           >
             By Date
           </button>
-          <button className="bookmarks__add-folder-btn" onClick={handleAddFolder}>
+          <button className="bookmarks__add-folder-btn" onClick={() => handleAddFolder(selectedFolderId)}>
             + New Folder
           </button>
         </div>

--- a/my-app/src/renderer/bookmarks/bookmarks.css
+++ b/my-app/src/renderer/bookmarks/bookmarks.css
@@ -1,0 +1,329 @@
+/* ── Bookmarks Manager Layout ── */
+
+.bookmarks {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  font-family: var(--font-ui);
+  color: var(--color-fg-primary);
+  background-color: var(--color-bg-base);
+  overflow: hidden;
+}
+
+/* ── Header / Toolbar ── */
+
+.bookmarks__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-border-default);
+  flex-shrink: 0;
+}
+
+.bookmarks__title {
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.bookmarks__search-container {
+  position: relative;
+  flex: 1;
+  max-width: 400px;
+}
+
+.bookmarks__search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-fg-tertiary);
+  pointer-events: none;
+}
+
+.bookmarks__search {
+  width: 100%;
+  padding: 7px 10px 7px 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 120ms ease;
+}
+
+.bookmarks__search:focus {
+  border-color: var(--color-accent-default);
+}
+
+.bookmarks__search::placeholder {
+  color: var(--color-fg-tertiary);
+}
+
+.bookmarks__toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.bookmarks__sort-btn,
+.bookmarks__add-folder-btn {
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+  white-space: nowrap;
+}
+
+.bookmarks__sort-btn:hover,
+.bookmarks__add-folder-btn:hover {
+  background-color: var(--color-surface-interactive-hover);
+  border-color: var(--color-border-strong);
+}
+
+.bookmarks__sort-btn--active {
+  color: var(--color-accent-default);
+  border-color: var(--color-accent-default);
+}
+
+/* ── Two-pane body ── */
+
+.bookmarks__body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ── Left Sidebar (Folder Tree) ── */
+
+.bookmarks__sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--color-border-default);
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.bookmarks__tree-root-label {
+  padding: 6px 12px 4px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-fg-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bookmarks__tree-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  margin: 1px 4px;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-secondary);
+  transition: background-color 80ms ease;
+  user-select: none;
+}
+
+.bookmarks__tree-item:hover {
+  background-color: var(--color-surface-interactive-hover);
+  color: var(--color-fg-primary);
+}
+
+.bookmarks__tree-item--selected {
+  background-color: var(--color-surface-interactive-active);
+  color: var(--color-fg-primary);
+}
+
+.bookmarks__tree-icon {
+  flex-shrink: 0;
+  color: var(--color-fg-tertiary);
+}
+
+.bookmarks__tree-item--selected .bookmarks__tree-icon {
+  color: var(--color-accent-default);
+}
+
+.bookmarks__tree-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.bookmarks__tree-children {
+  padding-left: 16px;
+}
+
+/* ── Right Content Area ── */
+
+.bookmarks__content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.bookmarks__content-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 20px 8px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  margin-bottom: 4px;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-fg-secondary);
+}
+
+/* ── Bookmark / Folder Items ── */
+
+.bookmarks__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 20px;
+  border-radius: var(--radius-sm);
+  margin: 1px 8px;
+  transition: background-color 80ms ease;
+  cursor: default;
+  min-height: 36px;
+}
+
+.bookmarks__item:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.bookmarks__item-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bookmarks__item-favicon {
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+}
+
+.bookmarks__item-folder-icon {
+  color: var(--color-fg-tertiary);
+}
+
+.bookmarks__item-name {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmarks__item-name--link {
+  cursor: pointer;
+}
+
+.bookmarks__item-name--link:hover {
+  text-decoration: underline;
+}
+
+.bookmarks__item-url {
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+  flex-shrink: 0;
+}
+
+/* ── Rename input ── */
+
+.bookmarks__rename-input {
+  flex: 1;
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-accent-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  outline: none;
+}
+
+/* ── Context Menu ── */
+
+.bookmarks__context-menu {
+  position: fixed;
+  z-index: 9999;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);
+  padding: 4px 0;
+  min-width: 160px;
+}
+
+.bookmarks__context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 7px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  color: var(--color-fg-primary);
+  cursor: pointer;
+  transition: background-color 80ms ease;
+}
+
+.bookmarks__context-menu-item:hover {
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.bookmarks__context-menu-item--danger {
+  color: var(--color-status-danger);
+}
+
+.bookmarks__context-menu-separator {
+  height: 1px;
+  background: var(--color-border-subtle);
+  margin: 4px 0;
+}
+
+/* ── Empty state ── */
+
+.bookmarks__empty {
+  text-align: center;
+  padding: 48px 0;
+  color: var(--color-fg-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+/* ── Search results ── */
+
+.bookmarks__search-results {
+  padding: 4px 12px 8px;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-tertiary);
+}

--- a/my-app/src/renderer/bookmarks/bookmarks.html
+++ b/my-app/src/renderer/bookmarks/bookmarks.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en" data-theme="shell">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bookmarks</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/my-app/src/renderer/bookmarks/index.tsx
+++ b/my-app/src/renderer/bookmarks/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BookmarkManager } from './BookmarkManager';
+import '../design/theme.global.css';
+import './bookmarks.css';
+
+window.addEventListener('error', (e) => {
+  console.error('bookmarks.error', { message: e.message, file: e.filename, line: e.lineno });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('bookmarks.unhandledrejection', { reason: String(e.reason) });
+});
+
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('[bookmarks] #root element not found');
+
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <BookmarkManager />
+  </React.StrictMode>,
+);

--- a/my-app/vite.bookmarks.config.ts
+++ b/my-app/vite.bookmarks.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Vite config for the bookmarks renderer (chrome://bookmarks).
+ * Follows the same pattern as vite.history.config.ts.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/bookmarks/bookmarks.html'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Closes #31
- Full bookmark manager at chrome://bookmarks (Cmd+Shift+O)
- Two-pane layout: recursive folder tree sidebar + content list
- Search across all bookmarks by title/URL
- Sort by Name or Date
- Add Folder button
- Right-click context menu: Open, Open in New Tab, Copy URL, Edit Name, Add Folder Here, Delete
- Double-click to inline rename
- Live updates via bookmarks-updated event

## Test plan
- [ ] Cmd+Shift+O opens bookmark manager
- [ ] Folder tree shows all folders recursively
- [ ] Click folder selects it and shows contents
- [ ] Search filters across all bookmarks
- [ ] Context menu works for all actions
- [ ] Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full bookmark manager at `chrome://bookmarks` with a two‑pane UI, search, sort, and context actions. Implements #31 and opens via Cmd/Ctrl+Shift+O.

- **New Features**
  - Two‑pane page: recursive folder tree sidebar and item list.
  - Global search by title or URL; sort by name or date.
  - Inline rename (double‑click), Add Folder, and context menu: Open, Open in New Tab, Copy URL, Edit Name, Add Folder Here, Delete.
  - Live updates via `bookmarks-updated`.

- **Bug Fixes**
  - Add Folder Here now targets the right‑clicked folder; fixed a TypeScript error in the New Folder button handler.
  - Escape now cancels inline rename and does not save on blur.
  - Reset rename cancel flag when starting a new rename to prevent a previous Escape from blocking it.

<sup>Written for commit baf28011a59954242dfcdd67b6cb5a0b0d484a72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

