### PR TITLE
feat(tabs): multi-select tabs with Cmd+click, Shift+click, and bulk close

### DIFF
--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -315,12 +315,16 @@ export function TabStrip({
     }
   }, []);
 
-  // Prune stale selections when tabs are removed.
+  // Prune stale selections and reset anchor index when tabs are removed.
   useEffect(() => {
     const currentIds = new Set(tabs.map((t) => t.id));
     setSelectedTabIds((prev) => {
       const next = new Set([...prev].filter((id) => currentIds.has(id)));
       return next.size === prev.size ? prev : next;
+    });
+    setLastClickedIdx((prev) => {
+      if (prev === null) return null;
+      return tabs[prev] ? prev : null;
     });
   }, [tabs]);
 

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -315,6 +315,15 @@ export function TabStrip({
     }
   }, []);
 
+  // Prune stale selections when tabs are removed.
+  useEffect(() => {
+    const currentIds = new Set(tabs.map((t) => t.id));
+    setSelectedTabIds((prev) => {
+      const next = new Set([...prev].filter((id) => currentIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [tabs]);
+
   // ---------------------------------------------------------------------------
   // ResizeObserver: measure each tab's rendered width and update icon-only state
   // ---------------------------------------------------------------------------

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -61,8 +61,9 @@ interface TabItemProps {
   tab: TabState;
   index: number;
   isActive: boolean;
+  isSelected: boolean;
   isIconOnly: boolean;
-  onActivate: () => void;
+  onTabClick: (e: React.MouseEvent) => void;
   onClose: (e: React.MouseEvent) => void;
   onDragStart: (e: React.DragEvent, tabId: string, index: number) => void;
   onDragOver: (e: React.DragEvent, index: number) => void;
@@ -78,8 +79,9 @@ function TabItem({
   tab,
   index,
   isActive,
+  isSelected,
   isIconOnly,
-  onActivate,
+  onTabClick,
   onClose,
   onDragStart,
   onDragOver,
@@ -101,14 +103,16 @@ function TabItem({
         isDragOver ? 'tab-item--drag-over' : '',
         isPinned ? 'tab-item--pinned' : '',
         isIconOnly && !isPinned ? 'tab-item--icon-only' : '',
+        isSelected ? 'tab-item--selected' : '',
       ]
         .filter(Boolean)
         .join(' ')}
       role="tab"
       aria-selected={isActive}
+      data-selected={isSelected || undefined}
       tabIndex={isActive ? 0 : -1}
       draggable
-      onClick={onActivate}
+      onClick={onTabClick}
       onKeyDown={onKeyDown}
       onDragStart={(e) => onDragStart(e, tab.id, index)}
       onDragOver={(e) => onDragOver(e, index)}
@@ -294,6 +298,8 @@ export function TabStrip({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [iconOnlySet, setIconOnlySet] = useState<Set<string>>(new Set());
   const [searchOpen, setSearchOpen] = useState(false);
+  const [selectedTabIds, setSelectedTabIds] = useState<Set<string>>(new Set());
+  const [lastClickedIdx, setLastClickedIdx] = useState<number | null>(null);
   const dragTabId = useRef<string | null>(null);
   const tabRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const tabsContainerRef = useRef<HTMLDivElement>(null);
@@ -350,6 +356,18 @@ export function TabStrip({
     return show || iconOnlySet.size > 0;
   })();
 
+  // Escape clears multi-selection
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && selectedTabIds.size > 0) {
+        setSelectedTabIds(new Set());
+        setLastClickedIdx(null);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [selectedTabIds]);
+
   // Close search dropdown when clicking outside
   useEffect(() => {
     if (!searchOpen) return;
@@ -363,6 +381,47 @@ export function TabStrip({
     window.addEventListener('mousedown', handler);
     return () => window.removeEventListener('mousedown', handler);
   }, [searchOpen]);
+
+  const handleTabClick = useCallback(
+    (e: React.MouseEvent, tab: TabState, index: number) => {
+      if (e.metaKey || e.ctrlKey) {
+        // Toggle this tab in the selection without changing active tab
+        e.stopPropagation();
+        setSelectedTabIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(tab.id)) {
+            next.delete(tab.id);
+          } else {
+            next.add(tab.id);
+          }
+          return next;
+        });
+        setLastClickedIdx(index);
+      } else if (e.shiftKey && lastClickedIdx !== null) {
+        // Select range from lastClickedIdx to current index
+        e.stopPropagation();
+        const start = Math.min(lastClickedIdx, index);
+        const end = Math.max(lastClickedIdx, index);
+        const rangeIds = new Set<string>();
+        for (let i = start; i <= end; i++) {
+          if (tabs[i]) rangeIds.add(tabs[i].id);
+        }
+        setSelectedTabIds(rangeIds);
+      } else {
+        // Normal click: clear selection and activate
+        setSelectedTabIds(new Set());
+        setLastClickedIdx(index);
+        onActivate(tab.id);
+      }
+    },
+    [tabs, lastClickedIdx, onActivate],
+  );
+
+  const handleCloseSelected = useCallback(() => {
+    selectedTabIds.forEach((id) => onClose(id));
+    setSelectedTabIds(new Set());
+    setLastClickedIdx(null);
+  }, [selectedTabIds, onClose]);
 
   const handleTabKeyDown = useCallback(
     (e: React.KeyboardEvent, tab: TabState, index: number) => {
@@ -457,8 +516,9 @@ export function TabStrip({
             tab={tab}
             index={index}
             isActive={tab.id === activeTabId}
+            isSelected={selectedTabIds.has(tab.id)}
             isIconOnly={iconOnlySet.has(tab.id)}
-            onActivate={() => onActivate(tab.id)}
+            onTabClick={(e) => handleTabClick(e, tab, index)}
             onClose={(e) => {
               e.stopPropagation();
               onClose(tab.id);
@@ -498,6 +558,47 @@ export function TabStrip({
           </svg>
         </button>
       </div>
+
+      {/* Multi-select bulk-action toolbar — appears when 2+ tabs are selected */}
+      {selectedTabIds.size > 0 && (
+        <div className="tab-strip__multiselect-bar">
+          <span className="tab-strip__multiselect-count">
+            {selectedTabIds.size} selected
+          </span>
+          <button
+            type="button"
+            className="tab-strip__multiselect-btn"
+            onClick={handleCloseSelected}
+            title={`Close ${selectedTabIds.size} tab${selectedTabIds.size > 1 ? 's' : ''}`}
+          >
+            Close {selectedTabIds.size} tab{selectedTabIds.size > 1 ? 's' : ''}
+          </button>
+          <button
+            type="button"
+            className="tab-strip__multiselect-btn tab-strip__multiselect-btn--secondary"
+            onClick={() => {
+              // Stub: move selected tabs to new window
+              console.log('[TabStrip] Move to new window (stub):', [...selectedTabIds]);
+              setSelectedTabIds(new Set());
+            }}
+            title="Move to new window"
+          >
+            New window
+          </button>
+          <button
+            type="button"
+            className="tab-strip__multiselect-btn tab-strip__multiselect-btn--secondary"
+            onClick={() => {
+              // Stub: pin/unpin selected tabs
+              console.log('[TabStrip] Pin/unpin tabs (stub):', [...selectedTabIds]);
+              setSelectedTabIds(new Set());
+            }}
+            title="Pin/unpin selected tabs"
+          >
+            Pin/unpin
+          </button>
+        </div>
+      )}
 
       {/* Tab search button — appears when tabs are too narrow to read titles */}
       {showSearchBtn && (

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -580,9 +580,9 @@ export function TabStrip({
             className="tab-strip__multiselect-btn tab-strip__multiselect-btn--secondary"
             onClick={() => {
               const selected = tabs.filter((t) => selectedTabIds.has(t.id));
-              const anyAudible = selected.some((t) => t.audible && !t.muted);
+              const anyUnmuted = selected.some((t) => !t.muted);
               selected.forEach((t) => {
-                if (anyAudible ? !t.muted : t.muted) {
+                if (anyUnmuted ? !t.muted : t.muted) {
                   electronAPI.tabs.muteTab(t.id).catch(() => {});
                 }
               });
@@ -590,7 +590,7 @@ export function TabStrip({
             }}
             title="Mute/unmute selected tabs"
           >
-            Mute
+            {tabs.filter((t) => selectedTabIds.has(t.id)).some((t) => !t.muted) ? 'Mute' : 'Unmute'}
           </button>
           <button
             type="button"

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -301,7 +301,7 @@ export function TabStrip({
   const [iconOnlySet, setIconOnlySet] = useState<Set<string>>(new Set());
   const [searchOpen, setSearchOpen] = useState(false);
   const [selectedTabIds, setSelectedTabIds] = useState<Set<string>>(new Set());
-  const [lastClickedIdx, setLastClickedIdx] = useState<number | null>(null);
+  const [lastClickedTabId, setLastClickedTabId] = useState<string | null>(null);
   const dragTabId = useRef<string | null>(null);
   const tabRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const tabsContainerRef = useRef<HTMLDivElement>(null);
@@ -322,9 +322,9 @@ export function TabStrip({
       const next = new Set([...prev].filter((id) => currentIds.has(id)));
       return next.size === prev.size ? prev : next;
     });
-    setLastClickedIdx((prev) => {
+    setLastClickedTabId((prev) => {
       if (prev === null) return null;
-      return tabs[prev] ? prev : null;
+      return tabs.some((t) => t.id === prev) ? prev : null;
     });
   }, [tabs]);
 
@@ -376,7 +376,7 @@ export function TabStrip({
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && selectedTabIds.size > 0) {
         setSelectedTabIds(new Set());
-        setLastClickedIdx(null);
+        setLastClickedTabId(null);
       }
     };
     window.addEventListener('keydown', handler);
@@ -411,31 +411,34 @@ export function TabStrip({
           }
           return next;
         });
-        setLastClickedIdx(index);
-      } else if (e.shiftKey && lastClickedIdx !== null) {
-        // Select range from lastClickedIdx to current index
+        setLastClickedTabId(tab.id);
+      } else if (e.shiftKey && lastClickedTabId !== null) {
+        // Select range from anchor tab to current tab
         e.stopPropagation();
-        const start = Math.min(lastClickedIdx, index);
-        const end = Math.max(lastClickedIdx, index);
-        const rangeIds = new Set<string>();
-        for (let i = start; i <= end; i++) {
-          if (tabs[i]) rangeIds.add(tabs[i].id);
+        const anchorIndex = tabs.findIndex((t) => t.id === lastClickedTabId);
+        if (anchorIndex !== -1) {
+          const start = Math.min(anchorIndex, index);
+          const end = Math.max(anchorIndex, index);
+          const rangeIds = new Set<string>();
+          for (let i = start; i <= end; i++) {
+            if (tabs[i]) rangeIds.add(tabs[i].id);
+          }
+          setSelectedTabIds(rangeIds);
         }
-        setSelectedTabIds(rangeIds);
       } else {
         // Normal click: clear selection and activate
         setSelectedTabIds(new Set());
-        setLastClickedIdx(index);
+        setLastClickedTabId(tab.id);
         onActivate(tab.id);
       }
     },
-    [tabs, lastClickedIdx, onActivate],
+    [tabs, lastClickedTabId, onActivate],
   );
 
   const handleCloseSelected = useCallback(() => {
     selectedTabIds.forEach((id) => onClose(id));
     setSelectedTabIds(new Set());
-    setLastClickedIdx(null);
+    setLastClickedTabId(null);
   }, [selectedTabIds, onClose]);
 
   const handleTabKeyDown = useCallback(

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -18,6 +18,8 @@ declare const electronAPI: {
   tabs: {
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
+    pin: (tabId: string) => Promise<void>;
+    unpin: (tabId: string) => Promise<void>;
   };
 };
 
@@ -577,25 +579,35 @@ export function TabStrip({
             type="button"
             className="tab-strip__multiselect-btn tab-strip__multiselect-btn--secondary"
             onClick={() => {
-              // Stub: move selected tabs to new window
-              console.log('[TabStrip] Move to new window (stub):', [...selectedTabIds]);
+              const selected = tabs.filter((t) => selectedTabIds.has(t.id));
+              const anyAudible = selected.some((t) => t.audible && !t.muted);
+              selected.forEach((t) => {
+                if (anyAudible ? !t.muted : t.muted) {
+                  electronAPI.tabs.muteTab(t.id).catch(() => {});
+                }
+              });
               setSelectedTabIds(new Set());
             }}
-            title="Move to new window"
+            title="Mute/unmute selected tabs"
           >
-            New window
+            Mute
           </button>
           <button
             type="button"
             className="tab-strip__multiselect-btn tab-strip__multiselect-btn--secondary"
             onClick={() => {
-              // Stub: pin/unpin selected tabs
-              console.log('[TabStrip] Pin/unpin tabs (stub):', [...selectedTabIds]);
+              const selected = tabs.filter((t) => selectedTabIds.has(t.id));
+              const anyUnpinned = selected.some((t) => !t.pinned);
+              selected.forEach((t) => {
+                if (anyUnpinned ? !t.pinned : t.pinned) {
+                  (anyUnpinned ? electronAPI.tabs.pin : electronAPI.tabs.unpin)(t.id).catch(() => {});
+                }
+              });
               setSelectedTabIds(new Set());
             }}
             title="Pin/unpin selected tabs"
           >
-            Pin/unpin
+            {tabs.filter((t) => selectedTabIds.has(t.id)).some((t) => !t.pinned) ? 'Pin' : 'Unpin'}
           </button>
         </div>
       )}

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -402,6 +402,75 @@
   color: var(--color-fg-primary);
 }
 
+/* ---------------------------------------------------------------------------
+   Multi-select tab state
+   --------------------------------------------------------------------------- */
+.tab-item--selected {
+  background: var(--color-tab-selected-bg, rgba(100, 150, 255, 0.2));
+  border-color: var(--color-accent-default, #6b8cff);
+  outline: 1px solid var(--color-accent-default, #6b8cff);
+  outline-offset: -1px;
+}
+
+.tab-item--selected:hover {
+  background: var(--color-tab-selected-bg, rgba(100, 150, 255, 0.28));
+}
+
+/* Show the close button on selected tabs too */
+.tab-item--selected .tab-item__close {
+  display: flex;
+}
+
+/* Multi-select action bar — floats at the right of the tab strip */
+.tab-strip__multiselect-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 0 4px 2px;
+  -webkit-app-region: no-drag;
+}
+
+.tab-strip__multiselect-count {
+  font-size: 11px;
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  padding: 0 4px;
+}
+
+.tab-strip__multiselect-btn {
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--color-accent-default, #6b8cff);
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-default, #6b8cff);
+  color: var(--color-fg-on-accent, #fff);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    opacity    var(--duration-fast) var(--ease-out);
+}
+
+.tab-strip__multiselect-btn:hover {
+  opacity: 0.85;
+}
+
+.tab-strip__multiselect-btn--secondary {
+  background: transparent;
+  color: var(--color-fg-secondary);
+  border-color: var(--color-border-default);
+}
+
+.tab-strip__multiselect-btn--secondary:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-fg-primary);
+  opacity: 1;
+}
+
 .tab-strip__new-tab {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## Summary

- Adds multi-select support to the tab strip (Cmd/Ctrl+click to toggle, Shift+click for range selection)
- Shows a multiselect action bar when ≥2 tabs are selected with a "Close Selected" button
- Selected tabs get a blue-tinted highlight with an accent outline
- Normal click clears selection and activates the tab as before

## Test plan
- [ ] Cmd+click multiple tabs → each gets selected/deselected independently
- [ ] Shift+click a tab → selects range from last-clicked to target
- [ ] "Close Selected" button closes all selected tabs
- [ ] Normal click clears selection and switches to the tab
- [ ] Selection clears when a tab is activated normally

Closes #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-select to the tab strip with Cmd/Ctrl+click and Shift+click, plus a toolbar for bulk Close, Mute/Unmute, and Pin/Unpin (closes #4). Normal clicks still activate a tab and clear selection.

- **New Features**
  - Cmd/Ctrl+click toggles selection; Shift+click selects from the last clicked tab.
  - Selected tabs are highlighted; toolbar shows count and actions (Close, Mute/Unmute, Pin/Unpin) with dynamic labels; bulk mute/unmute is based on muted state.
  - Escape or a normal click clears selection; actions clear selection after running.

- **Bug Fixes**
  - Track the Shift-click anchor by tab ID (not index), prune stale selections, and reset the anchor when tabs close so ranges stay valid.

<sup>Written for commit 42590f1da35886f3e1281f65b7df9ea91c83f33e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

