### PR TITLE
feat(omnibox): search engine keyword mode and Tab-to-search

### DIFF
--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -78,7 +78,7 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
     const keyword = trimmed.slice(0, firstSpaceIdx).toLowerCase();
     const query = trimmed.slice(firstSpaceIdx + 1);
     const template = keywordEngines.get(keyword);
-    if (template && query.trim()) {
+    if (template && template.includes('%s') && query.trim()) {
       const url = template.replace('%s', encodeURIComponent(query.trim()));
       mainLogger.info('navigation.parse.keywordSearch', { keyword, query, url });
       return url;

--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -28,6 +28,31 @@ const HAS_WHITESPACE_RE = /\s/;
 const GOOGLE_SEARCH_BASE = 'https://www.google.com/search?q=';
 
 // ---------------------------------------------------------------------------
+// Keyword search engines (Tab-to-search / keyword mode).
+// Maps keyword → %s URL template. Populated from SearchEngineStore at runtime;
+// falls back to built-in defaults when the store is unavailable.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KEYWORD_ENGINES: Map<string, string> = new Map([
+  ['g', 'https://www.google.com/search?q=%s'],
+  ['b', 'https://www.bing.com/search?q=%s'],
+  ['d', 'https://duckduckgo.com/?q=%s'],
+  ['y', 'https://search.yahoo.com/search?p=%s'],
+  ['e', 'https://www.ecosia.org/search?q=%s'],
+  ['br', 'https://search.brave.com/search?q=%s'],
+]);
+
+let keywordEngines: Map<string, string> = new Map(DEFAULT_KEYWORD_ENGINES);
+
+export function setKeywordEngines(engines: Map<string, string>): void {
+  keywordEngines = engines;
+}
+
+export function getKeywordEngines(): Map<string, string> {
+  return keywordEngines;
+}
+
+// ---------------------------------------------------------------------------
 // Bookmark / history lookup callback
 // ---------------------------------------------------------------------------
 
@@ -45,6 +70,19 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
   if (EXPLICIT_URL_RE.test(trimmed)) {
     mainLogger.info('navigation.parse.explicitScheme', { input: trimmed });
     return trimmed;
+  }
+
+  // 1.5. Keyword search: "keyword query" pattern (e.g. "g react hooks" → Google search)
+  const firstSpaceIdx = trimmed.indexOf(' ');
+  if (firstSpaceIdx > 0 && !HAS_WHITESPACE_RE.test(trimmed.slice(0, firstSpaceIdx))) {
+    const keyword = trimmed.slice(0, firstSpaceIdx).toLowerCase();
+    const query = trimmed.slice(firstSpaceIdx + 1);
+    const template = keywordEngines.get(keyword);
+    if (template && query.trim()) {
+      const url = template.replace('%s', encodeURIComponent(query.trim()));
+      mainLogger.info('navigation.parse.keywordSearch', { keyword, query, url });
+      return url;
+    }
   }
 
   // 2. Bookmark / history exact match — try common URL expansions of the raw input

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -19,11 +19,13 @@ import { ShortcutsStore } from './ShortcutsStore';
 import type { OmniboxSuggestion } from './providers';
 import { assertString } from '../ipc-validators';
 import { mainLogger } from '../logger';
+import { getKeywordEngines } from '../navigation';
 
 const CHANNELS = [
   'omnibox:suggest',
   'omnibox:record-selection',
   'omnibox:remove-history',
+  'omnibox:get-keyword-engines',
 ] as const;
 
 export interface OmniboxIpcOptions {
@@ -151,6 +153,27 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
         }
       }
 
+      // 5. Keyword-search: when input matches "keyword" exactly (no space yet),
+      //    show a "Search with [Engine] — press Tab" suggestion.
+      if (input.length > 0 && !input.includes(' ')) {
+        const engines = getKeywordEngines();
+        const template = engines.get(lower);
+        if (template) {
+          const engineNames: Record<string, string> = {
+            g: 'Google', b: 'Bing', d: 'DuckDuckGo', y: 'Yahoo', e: 'Ecosia', br: 'Brave Search',
+          };
+          const name = engineNames[lower] ?? lower;
+          results.unshift({
+            id: `keyword-search:${lower}`,
+            type: 'keyword-search',
+            title: `Search with ${name}`,
+            url: `keyword:${lower}`,
+            description: 'Press Tab to enter keyword search mode',
+            relevance: 1000,
+          });
+        }
+      }
+
       // Sort by relevance descending, cap at 10
       results.sort((a, b) => b.relevance - a.relevance);
       return results.slice(0, 10);
@@ -181,6 +204,21 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
     mainLogger.debug('omnibox:remove-history', { id });
     if (!historyStore) return false;
     return historyStore.removeEntry(id);
+  });
+
+  // -------------------------------------------------------------------------
+  // omnibox:get-keyword-engines — returns keyword→name map for Tab-to-search UI.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('omnibox:get-keyword-engines', (): Array<{ keyword: string; name: string; template: string }> => {
+    const engines = getKeywordEngines();
+    const engineNames: Record<string, string> = {
+      g: 'Google', b: 'Bing', d: 'DuckDuckGo', y: 'Yahoo', e: 'Ecosia', br: 'Brave Search',
+    };
+    return Array.from(engines.entries()).map(([keyword, template]) => ({
+      keyword,
+      name: engineNames[keyword] ?? keyword,
+      template,
+    }));
   });
 }
 

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -11,7 +11,8 @@ export type SuggestionType =
   | 'bookmark'
   | 'tab'
   | 'shortcut'
-  | 'search';
+  | 'search'
+  | 'keyword-search';
 
 export interface OmniboxSuggestion {
   /** Unique key for React rendering (provider:id). */

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -699,6 +699,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     removeHistory: (id: string): Promise<boolean> =>
       ipcRenderer.invoke('omnibox:remove-history', id),
+
+    getKeywordEngines: (): Promise<Array<{ keyword: string; name: string; template: string }>> =>
+      ipcRenderer.invoke('omnibox:get-keyword-engines'),
   },
 
   // Passwords


### PR DESCRIPTION
## Summary

- Adds keyword search engine shortcuts: type `g react hooks` → searches Google, `b typescript` → Bing, `d privacy` → DuckDuckGo, etc.
- When typing a bare keyword (e.g. `g`), shows a "Search with Google — press Tab" suggestion in the omnibox dropdown
- Adds `omnibox:get-keyword-engines` IPC handler returning all keyword→engine mappings
- Adds `getKeywordEngines()` / `setKeywordEngines()` in navigation.ts for runtime engine override

## Supported keywords
| Keyword | Engine |
|---------|--------|
| g | Google |
| b | Bing |
| d | DuckDuckGo |
| y | Yahoo |
| e | Ecosia |
| br | Brave Search |

## Test plan
- [ ] Type `g react hooks` in the URL bar → navigates to Google search for "react hooks"
- [ ] Type `d privacy` → navigates to DuckDuckGo search
- [ ] Type `g` alone → omnibox dropdown shows "Search with Google — press Tab" suggestion
- [ ] Select the keyword-search suggestion → enters keyword mode

Closes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyword search mode and Tab-to-search in the omnibox so you can type “g react hooks” to search Google, or press Tab after a keyword to enter engine mode. This makes switching search engines fast and predictable. Closes #20.

- **New Features**
  - Keyword shortcuts: `g` (Google), `b` (Bing), `d` (DuckDuckGo), `y` (Yahoo), `e` (Ecosia), `br` (Brave Search).
  - Omnibox shows “Search with <Engine> — press Tab” when a bare keyword is typed; new suggestion type: `keyword-search`.
  - Navigation parser supports “keyword query” and builds the engine URL using `%s` templates.
  - Runtime engine control: `getKeywordEngines()` / `setKeywordEngines()` with built-in defaults.
  - New IPC: `omnibox:get-keyword-engines` (exposed via `electronAPI.omnibox.getKeywordEngines`) to power Tab-to-search UI.

- **Bug Fixes**
  - Guarded engine templates to require a `%s` placeholder before building search URLs.

<sup>Written for commit f76e51d4bc759258e7ae0a9a67b54ff5bcb1d898. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

