### PR TITLE
feat(downloads): Safe Browsing tiered warnings for dangerous/suspicious files

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -48,9 +48,10 @@ const SUSPICIOUS_EXTS = new Set(['.dmg', '.pkg', '.deb', '.rpm', '.sh', '.bash',
 
 function classifyDownload(url: string, referrer: string, filename: string): 'dangerous' | 'suspicious' | 'insecure' | null {
   const ext = path.extname(filename).toLowerCase();
-  if (referrer.startsWith('https://') && url.startsWith('http://')) return 'insecure';
+  // Extension checks take precedence over transport — a dangerous .exe over HTTP is still dangerous.
   if (DANGEROUS_EXTS.has(ext)) return 'dangerous';
   if (SUSPICIOUS_EXTS.has(ext)) return 'suspicious';
+  if (referrer.startsWith('https://') && url.startsWith('http://')) return 'insecure';
   return null;
 }
 

--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -32,10 +32,27 @@ export interface DownloadItem {
   openWhenDone: boolean;
   speed: number;
   eta: number;
+  warningLevel?: 'dangerous' | 'suspicious' | 'insecure' | null;
+  warningDismissed?: boolean;
 }
 
 // Serializable version sent to renderer
 export type DownloadItemDTO = Omit<DownloadItem, never>;
+
+// ---------------------------------------------------------------------------
+// Safe-browsing heuristics
+// ---------------------------------------------------------------------------
+
+const DANGEROUS_EXTS = new Set(['.exe', '.msi', '.bat', '.cmd', '.scr', '.pif', '.com', '.jar', '.vbs', '.ps1', '.psm1']);
+const SUSPICIOUS_EXTS = new Set(['.dmg', '.pkg', '.deb', '.rpm', '.sh', '.bash', '.zsh', '.app', '.crx', '.xpi']);
+
+function classifyDownload(url: string, referrer: string, filename: string): 'dangerous' | 'suspicious' | 'insecure' | null {
+  const ext = path.extname(filename).toLowerCase();
+  if (referrer.startsWith('https://') && url.startsWith('http://')) return 'insecure';
+  if (DANGEROUS_EXTS.has(ext)) return 'dangerous';
+  if (SUSPICIOUS_EXTS.has(ext)) return 'suspicious';
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -59,6 +76,7 @@ const CH_REMOVE = 'downloads:remove';
 const CH_CLEAR_ALL = 'downloads:clear-all';
 const CH_GET_SHOW_ON_COMPLETE = 'downloads:get-show-on-complete';
 const CH_SET_SHOW_ON_COMPLETE = 'downloads:set-show-on-complete';
+const CH_DISMISS_WARNING = 'downloads:dismiss-warning';
 
 // Events (main → renderer)
 const EVT_DOWNLOAD_STARTED = 'download-started';
@@ -104,6 +122,9 @@ export class DownloadManager {
         totalBytes,
       });
 
+      const referrer = (webContents?.getURL?.() ?? '');
+      const warningLevel = classifyDownload(url, referrer, filename);
+
       const dlItem: DownloadItem = {
         id,
         filename,
@@ -117,10 +138,18 @@ export class DownloadManager {
         openWhenDone: false,
         speed: 0,
         eta: 0,
+        warningLevel,
+        warningDismissed: false,
       };
 
       this.downloads.set(id, dlItem);
       this.electronItems.set(id, item);
+
+      if (warningLevel === 'dangerous') {
+        item.pause();
+        dlItem.status = 'paused';
+        mainLogger.info('DownloadManager.dangerousDownloadPaused', { id, filename, warningLevel });
+      }
 
       // Update savePath after dialog (Electron sets it after user picks location)
       item.once('done', () => {
@@ -261,7 +290,11 @@ export class DownloadManager {
       this.setShowOnComplete(value);
     });
 
-    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 12 });
+    ipcMain.handle(CH_DISMISS_WARNING, (_e, id: string) => {
+      this.dismissWarning(id);
+    });
+
+    mainLogger.info('DownloadManager.ipc.registered', { channelCount: 13 });
   }
 
   // ---------------------------------------------------------------------------
@@ -339,6 +372,22 @@ export class DownloadManager {
     }
     mainLogger.info('DownloadManager.showInFolder', { id, path: dl.savePath });
     shell.showItemInFolder(dl.savePath);
+  }
+
+  private dismissWarning(id: string): void {
+    const dl = this.downloads.get(id);
+    const eItem = this.electronItems.get(id);
+    if (!dl) {
+      mainLogger.warn('DownloadManager.dismissWarning.notFound', { id });
+      return;
+    }
+    dl.warningDismissed = true;
+    if (eItem && dl.status === 'paused' && eItem.canResume()) {
+      eItem.resume();
+      dl.status = 'in-progress';
+    }
+    mainLogger.info('DownloadManager.dismissWarning', { id, filename: dl.filename });
+    this.broadcastState();
   }
 
   private setOpenWhenDone(id: string, value: boolean): void {
@@ -553,6 +602,7 @@ export class DownloadManager {
     ipcMain.removeHandler(CH_CLEAR_ALL);
     ipcMain.removeHandler(CH_GET_SHOW_ON_COMPLETE);
     ipcMain.removeHandler(CH_SET_SHOW_ON_COMPLETE);
+    ipcMain.removeHandler(CH_DISMISS_WARNING);
     for (const timer of this.throttleTimers.values()) {
       clearTimeout(timer);
     }

--- a/my-app/src/preload/downloads.ts
+++ b/my-app/src/preload/downloads.ts
@@ -20,6 +20,8 @@ export interface DownloadItemDTO {
   openWhenDone: boolean;
   speed: number;
   eta: number;
+  warningLevel?: 'dangerous' | 'suspicious' | 'insecure' | null;
+  warningDismissed?: boolean;
 }
 
 contextBridge.exposeInMainWorld('downloadsAPI', {
@@ -46,6 +48,9 @@ contextBridge.exposeInMainWorld('downloadsAPI', {
 
   clearAll: (): Promise<void> =>
     ipcRenderer.invoke('downloads:clear-all'),
+
+  dismissWarning: (id: string): Promise<void> =>
+    ipcRenderer.invoke('downloads:dismiss-warning', id),
 
   onStateChanged: (cb: (downloads: DownloadItemDTO[]) => void): (() => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: DownloadItemDTO[]) => cb(data);

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -207,6 +207,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('downloads:get-show-on-complete'),
     setShowOnComplete: (value: boolean): Promise<void> =>
       ipcRenderer.invoke('downloads:set-show-on-complete', value),
+    dismissWarning: (id: string): Promise<void> =>
+      ipcRenderer.invoke('downloads:dismiss-warning', id),
   },
 
   // Permissions — renderer -> main decision relay + query API

--- a/my-app/src/renderer/shell/DownloadBubble.tsx
+++ b/my-app/src/renderer/shell/DownloadBubble.tsx
@@ -220,7 +220,7 @@ function DownloadRow({
                   <rect x="8" y="3" width="2.5" height="8" rx="0.5" fill="currentColor" />
                 </svg>
               </button>
-            ) : (
+            ) : !(dl.warningLevel && !dl.warningDismissed) && (
               <button
                 className="download-row__action-btn"
                 title="Resume"

--- a/my-app/src/renderer/shell/DownloadBubble.tsx
+++ b/my-app/src/renderer/shell/DownloadBubble.tsx
@@ -220,7 +220,7 @@ function DownloadRow({
                   <rect x="8" y="3" width="2.5" height="8" rx="0.5" fill="currentColor" />
                 </svg>
               </button>
-            ) : !(dl.warningLevel && !dl.warningDismissed) && (
+            ) : !(dl.warningLevel && dl.warningLevel !== 'insecure' && !dl.warningDismissed) && (
               <button
                 className="download-row__action-btn"
                 title="Resume"

--- a/my-app/src/renderer/shell/DownloadBubble.tsx
+++ b/my-app/src/renderer/shell/DownloadBubble.tsx
@@ -19,6 +19,7 @@ interface DownloadBubbleProps {
   onSetOpenWhenDone: (id: string, value: boolean) => void;
   onClearCompleted: () => void;
   onSetShowOnComplete: (value: boolean) => void;
+  onDismissWarning: (id: string) => void;
 }
 
 export function DownloadBubble({
@@ -33,6 +34,7 @@ export function DownloadBubble({
   onSetOpenWhenDone,
   onClearCompleted,
   onSetShowOnComplete,
+  onDismissWarning,
 }: DownloadBubbleProps): React.ReactElement {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -86,6 +88,7 @@ export function DownloadBubble({
               onOpenFile={onOpenFile}
               onShowInFolder={onShowInFolder}
               onSetOpenWhenDone={onSetOpenWhenDone}
+              onDismissWarning={onDismissWarning}
             />
           ))}
         </ul>
@@ -117,6 +120,7 @@ interface DownloadRowProps {
   onOpenFile: (id: string) => void;
   onShowInFolder: (id: string) => void;
   onSetOpenWhenDone: (id: string, value: boolean) => void;
+  onDismissWarning: (id: string) => void;
 }
 
 function DownloadRow({
@@ -127,6 +131,7 @@ function DownloadRow({
   onOpenFile,
   onShowInFolder,
   onSetOpenWhenDone,
+  onDismissWarning,
 }: DownloadRowProps): React.ReactElement {
   const isActive = dl.status === 'in-progress' || dl.status === 'paused';
   const isCompleted = dl.status === 'completed';
@@ -166,6 +171,15 @@ function DownloadRow({
             </span>
           )}
         </div>
+
+        {dl.warningLevel && !dl.warningDismissed && (
+          <DownloadWarningBanner
+            id={dl.id}
+            level={dl.warningLevel}
+            onCancel={onCancel}
+            onDismissWarning={onDismissWarning}
+          />
+        )}
 
         {isActive && (
           <div className="download-row__progress-wrap">
@@ -264,6 +278,61 @@ function DownloadRow({
         </label>
       )}
     </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DownloadWarningBanner
+// ---------------------------------------------------------------------------
+
+interface DownloadWarningBannerProps {
+  id: string;
+  level: 'dangerous' | 'suspicious' | 'insecure';
+  onCancel: (id: string) => void;
+  onDismissWarning: (id: string) => void;
+}
+
+function DownloadWarningBanner({ id, level, onCancel, onDismissWarning }: DownloadWarningBannerProps): React.ReactElement {
+  return (
+    <div className={`download-warning download-warning--${level}`}>
+      <div className="download-warning__text">
+        {level === 'dangerous' && (
+          <>
+            <div>This file may be dangerous. Are you sure you want to download it?</div>
+            <div className="download-warning__actions">
+              <button className="download-warning__btn" onClick={() => onCancel(id)}>Cancel</button>
+              <button className="download-warning__btn download-warning__btn--primary" onClick={() => onDismissWarning(id)}>
+                <span>Keep anyway</span>
+              </button>
+            </div>
+          </>
+        )}
+        {level === 'suspicious' && (
+          <>
+            <div>This file type can harm your device.</div>
+            <div className="download-warning__actions">
+              <button className="download-warning__btn" onClick={() => onCancel(id)}>Cancel</button>
+              <button className="download-warning__btn download-warning__btn--primary" onClick={() => onDismissWarning(id)}>
+                <span>Keep</span>
+              </button>
+            </div>
+          </>
+        )}
+        {level === 'insecure' && (
+          <div>This file was downloaded over an insecure connection.</div>
+        )}
+      </div>
+      {level === 'insecure' && (
+        <button
+          className="download-warning__btn"
+          title="Dismiss"
+          onClick={() => onDismissWarning(id)}
+          aria-label="Dismiss warning"
+        >
+          &#x2715;
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -99,6 +99,7 @@ declare const electronAPI: {
     clearCompleted: () => Promise<void>;
     getShowOnComplete: () => Promise<boolean>;
     setShowOnComplete: (value: boolean) => Promise<void>;
+    dismissWarning: (id: string) => Promise<void>;
   };
   shell: {
     setChromeHeight: (height: number) => Promise<void>;
@@ -623,6 +624,7 @@ export function WindowChrome(): React.ReactElement {
               onSetOpenWhenDone={(id, v) => electronAPI.downloads.setOpenWhenDone(id, v)}
               onClearCompleted={() => electronAPI.downloads.clearCompleted()}
               onSetShowOnComplete={handleSetShowOnComplete}
+              onDismissWarning={(id) => electronAPI.downloads.dismissWarning(id)}
             />
           )}
         </div>

--- a/my-app/src/renderer/shell/downloads.css
+++ b/my-app/src/renderer/shell/downloads.css
@@ -250,6 +250,28 @@
   cursor: pointer;
 }
 
+/* ---------------------------------------------------------------------------
+   Download warning banners
+   --------------------------------------------------------------------------- */
+.download-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  line-height: 1.4;
+  margin-bottom: 4px;
+}
+.download-warning--dangerous { background: rgba(var(--color-danger-rgb, 211,47,47), 0.12); color: var(--color-danger, #d32f2f); border: 1px solid rgba(211,47,47,0.3); }
+.download-warning--suspicious { background: rgba(230,162,30,0.12); color: #b26a00; border: 1px solid rgba(230,162,30,0.3); }
+.download-warning--insecure { background: rgba(230,162,30,0.08); color: #7a5800; border: 1px solid rgba(230,162,30,0.2); }
+.download-warning__text { flex: 1; }
+.download-warning__actions { display: flex; gap: 4px; margin-top: 4px; }
+.download-warning__btn { font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid currentColor; background: transparent; cursor: pointer; color: inherit; }
+.download-warning__btn--primary { background: currentColor; }
+.download-warning__btn--primary span { color: white; }
+
 @media (prefers-reduced-motion: reduce) {
   .download-bubble {
     animation: none;


### PR DESCRIPTION
## Summary

- Adds heuristic-based download safety classification (no external API calls) with three warning tiers: **dangerous** (blocked/paused until user confirms), **suspicious** (soft-blocked with warning), and **insecure** (HTTP download from HTTPS page)
- Dangerous downloads (`.exe`, `.msi`, `.bat`, `.cmd`, `.scr`, `.pif`, `.com`, `.jar`, `.vbs`, `.ps1`, `.psm1`) are paused immediately and require a two-click "Keep anyway" override
- Suspicious downloads (`.dmg`, `.pkg`, `.deb`, `.rpm`, `.sh`, `.bash`, `.zsh`, `.app`, `.crx`, `.xpi`) show a yellow warning with one-click proceed
- Insecure downloads show an orange dismissible banner

## Test plan

- [ ] Download an `.exe` file — verify it is paused and a red danger banner appears with "Cancel" and "Keep anyway" buttons
- [ ] Click "Keep anyway" — verify the download resumes
- [ ] Click "Cancel" on a dangerous download — verify it is cancelled
- [ ] Download a `.dmg` file — verify a yellow suspicious banner appears with "Cancel" and "Keep" buttons
- [ ] Download a file over HTTP from an HTTPS page — verify the orange insecure banner appears with a dismiss X
- [ ] Download a safe file (e.g. `.pdf`) — verify no warning banner appears
- [ ] TypeScript typecheck passes: `npx tsc --noEmit`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Safe Browsing–style, heuristic download checks with three tiers: dangerous (paused), suspicious (warn), and insecure (informational). No external API calls; fulfills #38.

- **New Features**
  - Heuristic classifier by extension and HTTPS→HTTP; extension takes precedence.
  - Dangerous auto‑paused; “Keep anyway” resumes. Suspicious shows a soft warning. Insecure shows a dismissible banner and can resume without dismissal.
  - Resume is hidden until dismissal for dangerous/suspicious. Exposes `downloads:dismiss-warning` in `preload/downloads.ts` and `preload/shell.ts` to acknowledge and resume, updating `warningLevel`/`warningDismissed`.

<sup>Written for commit e5f611969ae3b9a2a2f2472e85b4884124aa7c64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

