### PR TITLE
feat(tabs): tab groups with colored chips and collapse/expand

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -96,6 +96,9 @@ import { DeviceManager } from './devices/DeviceManager';
 import { registerDeviceHandlers, unregisterDeviceHandlers } from './devices/ipc';
 // Issue #100 — Picture-in-Picture
 import { registerPipHandlers, unregisterPipHandlers } from './pip/PictureInPictureManager';
+// Issue #5 — Tab groups
+import { TabGroupStore } from './tabs/TabGroupStore';
+import { registerTabGroupHandlers, unregisterTabGroupHandlers } from './tabs/tab-groups-ipc';
 
 // ---------------------------------------------------------------------------
 // Crash telemetry: catch unhandled errors before anything else
@@ -185,6 +188,7 @@ let activeProfileId = 'default';
 let isGuestSession = false;
 let guestPartitionName: string | null = null;
 
+const tabGroupStore = new TabGroupStore();
 const accountStore = new AccountStore();
 const oauthClient = new OAuthClient({ clientId: process.env.GOOGLE_CLIENT_ID ?? '42357852543-62lvdghq5hatidr3ovmq1rig9q5r5mcg.apps.googleusercontent.com' });
 const keychainStore = new KeychainStore();
@@ -200,6 +204,7 @@ function openShellAndWire(profileId?: string): BrowserWindow {
   mainLogger.info('main.openShellAndWire.profile', { profileId: pid, dataDir: profileDataDir, partition: profilePartition });
   shellWindow = createShellWindow();
   tabManager = new TabManager(shellWindow, { dataDir: profileDataDir, partition: profilePartition });
+  tabManager.setTabGroupStore(tabGroupStore);
   downloadManager?.destroy();
   downloadManager = new DownloadManager(shellWindow);
 
@@ -537,6 +542,8 @@ app.whenReady().then(async () => {
 
   // Issue #98 — Share menu
   registerShareHandlers(tabManager!, shellWindow!);
+  // Issue #5 — Tab groups
+  registerTabGroupHandlers(tabGroupStore, () => shellWindow);
   registerChromeHandlers(
     (page: string) => tabManager?.openInternalPage(page),
     () => openSettingsWindow(),
@@ -776,6 +783,7 @@ app.whenReady().then(async () => {
     unregisterPermissionHandlers();
     unregisterDeviceHandlers();
     unregisterPipHandlers();
+    unregisterTabGroupHandlers();
     unregisterExtensionsHandlers();
     unregisterAutofillHandlers();
     // ExtensionManager currently has no dispose()/destroy() hook; its

--- a/my-app/src/main/tabs/TabGroupStore.ts
+++ b/my-app/src/main/tabs/TabGroupStore.ts
@@ -67,6 +67,10 @@ export class TabGroupStore {
     return JSON.stringify([...this.groups.values()]);
   }
 
+  private static readonly VALID_COLORS = new Set<string>([
+    'grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan',
+  ]);
+
   deserialize(json: string): void {
     try {
       const parsed: unknown = JSON.parse(json);
@@ -76,7 +80,9 @@ export class TabGroupStore {
           g !== null &&
           typeof g === 'object' &&
           typeof (g as TabGroup).id === 'string' &&
-          typeof (g as TabGroup).name === 'string',
+          typeof (g as TabGroup).name === 'string' &&
+          TabGroupStore.VALID_COLORS.has((g as TabGroup).color) &&
+          Array.isArray((g as TabGroup).tabIds),
       );
       this.groups.clear();
       for (const g of arr) {

--- a/my-app/src/main/tabs/TabGroupStore.ts
+++ b/my-app/src/main/tabs/TabGroupStore.ts
@@ -69,7 +69,15 @@ export class TabGroupStore {
 
   deserialize(json: string): void {
     try {
-      const arr: TabGroup[] = JSON.parse(json);
+      const parsed: unknown = JSON.parse(json);
+      if (!Array.isArray(parsed)) return;
+      const arr = parsed.filter(
+        (g): g is TabGroup =>
+          g !== null &&
+          typeof g === 'object' &&
+          typeof (g as TabGroup).id === 'string' &&
+          typeof (g as TabGroup).name === 'string',
+      );
       this.groups.clear();
       for (const g of arr) {
         this.groups.set(g.id, g);

--- a/my-app/src/main/tabs/TabGroupStore.ts
+++ b/my-app/src/main/tabs/TabGroupStore.ts
@@ -1,0 +1,79 @@
+export interface TabGroup {
+  id: string;
+  name: string;
+  color: 'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan';
+  tabIds: string[];
+  collapsed: boolean;
+}
+
+export class TabGroupStore {
+  private groups = new Map<string, TabGroup>();
+
+  createGroup(name: string, color: TabGroup['color'], tabIds: string[]): TabGroup {
+    const id = 'grp_' + Date.now();
+    const group: TabGroup = { id, name, color, tabIds: [...tabIds], collapsed: false };
+    this.groups.set(id, group);
+    return group;
+  }
+
+  getGroup(id: string): TabGroup | undefined {
+    return this.groups.get(id);
+  }
+
+  listGroups(): TabGroup[] {
+    return [...this.groups.values()];
+  }
+
+  updateGroup(id: string, patch: Partial<Pick<TabGroup, 'name' | 'color' | 'collapsed'>>): void {
+    const group = this.groups.get(id);
+    if (!group) return;
+    Object.assign(group, patch);
+  }
+
+  addTabToGroup(groupId: string, tabId: string): void {
+    this.removeTabFromGroup(tabId);
+    const group = this.groups.get(groupId);
+    if (!group) return;
+    if (!group.tabIds.includes(tabId)) {
+      group.tabIds.push(tabId);
+    }
+  }
+
+  removeTabFromGroup(tabId: string): void {
+    for (const group of this.groups.values()) {
+      const idx = group.tabIds.indexOf(tabId);
+      if (idx !== -1) {
+        group.tabIds.splice(idx, 1);
+        if (group.tabIds.length === 0) {
+          this.groups.delete(group.id);
+        }
+        return;
+      }
+    }
+  }
+
+  deleteGroup(id: string): void {
+    this.groups.delete(id);
+  }
+
+  getGroupForTab(tabId: string): TabGroup | undefined {
+    for (const group of this.groups.values()) {
+      if (group.tabIds.includes(tabId)) return group;
+    }
+    return undefined;
+  }
+
+  serialize(): string {
+    return JSON.stringify([...this.groups.values()]);
+  }
+
+  deserialize(json: string): void {
+    try {
+      const arr: TabGroup[] = JSON.parse(json);
+      this.groups.clear();
+      for (const g of arr) {
+        this.groups.set(g.id, g);
+      }
+    } catch { /* ignore */ }
+  }
+}

--- a/my-app/src/main/tabs/TabGroupStore.ts
+++ b/my-app/src/main/tabs/TabGroupStore.ts
@@ -7,10 +7,13 @@ export interface TabGroup {
 }
 
 export class TabGroupStore {
-  private groups = new Map<string, TabGroup>();
+  private groups: Map<string, TabGroup> = new Map();
 
   createGroup(name: string, color: TabGroup['color'], tabIds: string[]): TabGroup {
-    const id = 'grp_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 7);
+    let id: string;
+    do {
+      id = 'grp_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 7);
+    } while (this.groups.has(id));
     const group: TabGroup = { id, name, color, tabIds: [...tabIds], collapsed: false };
     this.groups.set(id, group);
     return group;
@@ -84,10 +87,11 @@ export class TabGroupStore {
           TabGroupStore.VALID_COLORS.has((g as TabGroup).color) &&
           Array.isArray((g as TabGroup).tabIds),
       );
-      this.groups.clear();
+      const newGroups = new Map<string, TabGroup>();
       for (const g of arr) {
-        this.groups.set(g.id, g);
+        newGroups.set(g.id, g);
       }
+      this.groups = newGroups;
     } catch { /* ignore */ }
   }
 }

--- a/my-app/src/main/tabs/TabGroupStore.ts
+++ b/my-app/src/main/tabs/TabGroupStore.ts
@@ -10,7 +10,7 @@ export class TabGroupStore {
   private groups = new Map<string, TabGroup>();
 
   createGroup(name: string, color: TabGroup['color'], tabIds: string[]): TabGroup {
-    const id = 'grp_' + Date.now();
+    const id = 'grp_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 7);
     const group: TabGroup = { id, name, color, tabIds: [...tabIds], collapsed: false };
     this.groups.set(id, group);
     return group;

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -512,6 +512,12 @@ export class TabManager {
     this.pinnedTabs.delete(tabId);
     this.tabOrder = this.tabOrder.filter((id) => id !== tabId);
 
+    // Remove tab from its group before any early return so the store is always clean.
+    if (this.tabGroupStore?.getGroupForTab(tabId)) {
+      this.tabGroupStore.removeTabFromGroup(tabId);
+      this.safeSend('tab-groups:updated', this.tabGroupStore.listGroups());
+    }
+
     if (this.activeTabId === tabId) {
       const newActive = this.tabOrder[this.tabOrder.length - 1] ?? null;
       this.activeTabId = null;
@@ -524,12 +530,6 @@ export class TabManager {
         if (!this.win.isDestroyed()) this.win.close();
         return;
       }
-    }
-
-    // Remove tab from its group, if any, so the group store doesn't hold stale IDs.
-    if (this.tabGroupStore?.getGroupForTab(tabId)) {
-      this.tabGroupStore.removeTabFromGroup(tabId);
-      this.safeSend('tab-groups:updated', this.tabGroupStore.listGroups());
     }
 
     this.saveSession();

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2056,25 +2056,27 @@ export class TabManager {
       },
     }));
 
-    const existingGroup = this.tabGroupStore?.getGroupForTab(tabId);
-    if (existingGroup) {
-      menu.append(new MenuItem({
-        label: 'Remove from Group',
-        click: () => {
-          this.tabGroupStore?.removeTabFromGroup(tabId);
-          this.safeSend('tab-groups:updated', this.tabGroupStore?.listGroups() ?? []);
-        },
-      }));
-    } else {
-      menu.append(new MenuItem({
-        label: 'Add to New Group',
-        click: () => {
-          const colors: Array<import('./TabGroupStore').TabGroup['color']> = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan'];
-          const color = colors[Math.floor(Math.random() * colors.length)];
-          this.tabGroupStore?.createGroup('New group', color, [tabId]);
-          this.safeSend('tab-groups:updated', this.tabGroupStore?.listGroups() ?? []);
-        },
-      }));
+    if (this.tabGroupStore) {
+      const existingGroup = this.tabGroupStore.getGroupForTab(tabId);
+      if (existingGroup) {
+        menu.append(new MenuItem({
+          label: 'Remove from Group',
+          click: () => {
+            this.tabGroupStore!.removeTabFromGroup(tabId);
+            this.safeSend('tab-groups:updated', this.tabGroupStore!.listGroups());
+          },
+        }));
+      } else {
+        menu.append(new MenuItem({
+          label: 'Add to New Group',
+          click: () => {
+            const colors: Array<import('./TabGroupStore').TabGroup['color']> = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan'];
+            const color = colors[Math.floor(Math.random() * colors.length)];
+            this.tabGroupStore!.createGroup('New group', color, [tabId]);
+            this.safeSend('tab-groups:updated', this.tabGroupStore!.listGroups());
+          },
+        }));
+      }
     }
 
     menu.append(new MenuItem({ type: 'separator' }));

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -66,6 +66,7 @@ import {
   CERT_ERROR_PROCEED_PREFIX,
   CERT_ERROR_BACK_PREFIX,
 } from '../errors/NetworkErrorController';
+import type { TabGroupStore } from './TabGroupStore';
 
 // Forge VitePlugin globals for the new-tab page (injected at build time)
 declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
@@ -180,6 +181,7 @@ export class TabManager {
   private urlMatchFn: UrlMatchFn | null = null;
   private historyStore: HistoryStore | null = null;
   private passwordStore: PasswordStore | null = null;
+  private tabGroupStore: TabGroupStore | null = null;
   readonly isGuest: boolean;
   private readonly partition: string | null;
 
@@ -213,6 +215,10 @@ export class TabManager {
   /** Called by DeviceManager to attach select-bluetooth-device on new tabs */
   setOnWebContentsCreated(cb: ((wc: import("electron").WebContents) => void) | null): void {
     this.onWebContentsCreated = cb;
+  }
+
+  setTabGroupStore(store: TabGroupStore | null): void {
+    this.tabGroupStore = store;
   }
 
   setHistoryStore(store: HistoryStore): void {
@@ -2043,6 +2049,27 @@ export class TabManager {
         }
       },
     }));
+
+    const existingGroup = this.tabGroupStore?.getGroupForTab(tabId);
+    if (existingGroup) {
+      menu.append(new MenuItem({
+        label: 'Remove from Group',
+        click: () => {
+          this.tabGroupStore?.removeTabFromGroup(tabId);
+          this.safeSend('tab-groups:updated', this.tabGroupStore?.listGroups() ?? []);
+        },
+      }));
+    } else {
+      menu.append(new MenuItem({
+        label: 'Add to New Group',
+        click: () => {
+          const colors: Array<import('./TabGroupStore').TabGroup['color']> = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan'];
+          const color = colors[Math.floor(Math.random() * colors.length)];
+          this.tabGroupStore?.createGroup('New group', color, [tabId]);
+          this.safeSend('tab-groups:updated', this.tabGroupStore?.listGroups() ?? []);
+        },
+      }));
+    }
 
     menu.append(new MenuItem({ type: 'separator' }));
 

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -526,6 +526,12 @@ export class TabManager {
       }
     }
 
+    // Remove tab from its group, if any, so the group store doesn't hold stale IDs.
+    if (this.tabGroupStore?.getGroupForTab(tabId)) {
+      this.tabGroupStore.removeTabFromGroup(tabId);
+      this.safeSend('tab-groups:updated', this.tabGroupStore.listGroups());
+    }
+
     this.saveSession();
     this.broadcastState();
   }

--- a/my-app/src/main/tabs/tab-groups-ipc.ts
+++ b/my-app/src/main/tabs/tab-groups-ipc.ts
@@ -1,0 +1,51 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { TabGroupStore } from './TabGroupStore';
+
+export function registerTabGroupHandlers(
+  store: TabGroupStore,
+  getShellWindow: () => BrowserWindow | null,
+): void {
+  const broadcast = () => {
+    const win = getShellWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('tab-groups:updated', store.listGroups());
+    }
+  };
+
+  ipcMain.handle('tab-groups:list', () => store.listGroups());
+
+  ipcMain.handle('tab-groups:create', (_e, { name, color, tabIds }: { name: string; color: string; tabIds: string[] }) => {
+    const group = store.createGroup(name, color as Parameters<TabGroupStore['createGroup']>[1], tabIds);
+    broadcast();
+    return group;
+  });
+
+  ipcMain.handle('tab-groups:update', (_e, { id, patch }: { id: string; patch: object }) => {
+    store.updateGroup(id, patch as Parameters<TabGroupStore['updateGroup']>[1]);
+    broadcast();
+  });
+
+  ipcMain.handle('tab-groups:add-tab', (_e, { groupId, tabId }: { groupId: string; tabId: string }) => {
+    store.addTabToGroup(groupId, tabId);
+    broadcast();
+  });
+
+  ipcMain.handle('tab-groups:remove-tab', (_e, { tabId }: { tabId: string }) => {
+    store.removeTabFromGroup(tabId);
+    broadcast();
+  });
+
+  ipcMain.handle('tab-groups:delete', (_e, { id }: { id: string }) => {
+    store.deleteGroup(id);
+    broadcast();
+  });
+}
+
+export function unregisterTabGroupHandlers(): void {
+  ipcMain.removeHandler('tab-groups:list');
+  ipcMain.removeHandler('tab-groups:create');
+  ipcMain.removeHandler('tab-groups:update');
+  ipcMain.removeHandler('tab-groups:add-tab');
+  ipcMain.removeHandler('tab-groups:remove-tab');
+  ipcMain.removeHandler('tab-groups:delete');
+}

--- a/my-app/src/main/tabs/tab-groups-ipc.ts
+++ b/my-app/src/main/tabs/tab-groups-ipc.ts
@@ -1,5 +1,12 @@
 import { ipcMain, BrowserWindow } from 'electron';
+import type { TabGroup } from './TabGroupStore';
 import { TabGroupStore } from './TabGroupStore';
+
+const VALID_COLORS = new Set<TabGroup['color']>(['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan']);
+
+function isValidColor(c: unknown): c is TabGroup['color'] {
+  return typeof c === 'string' && VALID_COLORS.has(c as TabGroup['color']);
+}
 
 export function registerTabGroupHandlers(
   store: TabGroupStore,
@@ -15,13 +22,20 @@ export function registerTabGroupHandlers(
   ipcMain.handle('tab-groups:list', () => store.listGroups());
 
   ipcMain.handle('tab-groups:create', (_e, { name, color, tabIds }: { name: string; color: string; tabIds: string[] }) => {
-    const group = store.createGroup(name, color as Parameters<TabGroupStore['createGroup']>[1], tabIds);
+    if (!isValidColor(color)) return null;
+    const group = store.createGroup(String(name).slice(0, 64), color, Array.isArray(tabIds) ? tabIds.filter((t) => typeof t === 'string') : []);
     broadcast();
     return group;
   });
 
-  ipcMain.handle('tab-groups:update', (_e, { id, patch }: { id: string; patch: object }) => {
-    store.updateGroup(id, patch as Parameters<TabGroupStore['updateGroup']>[1]);
+  ipcMain.handle('tab-groups:update', (_e, { id, patch }: { id: string; patch: unknown }) => {
+    if (typeof patch !== 'object' || patch === null) return;
+    const safe: Parameters<TabGroupStore['updateGroup']>[1] = {};
+    const p = patch as Record<string, unknown>;
+    if (typeof p['name'] === 'string') safe.name = p['name'].slice(0, 64);
+    if (isValidColor(p['color'])) safe.color = p['color'];
+    if (typeof p['collapsed'] === 'boolean') safe.collapsed = p['collapsed'];
+    store.updateGroup(id, safe);
     broadcast();
   });
 

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -18,6 +18,7 @@ import type { DownloadItemDTO } from '../main/downloads/DownloadManager';
 import type { DevicePickerRequest } from '../main/devices/DeviceManager';
 import type { GrantedDevice, DeviceApiType } from '../main/devices/DeviceStore';
 import type { OmniboxSuggestion } from '../main/omnibox/providers';
+import type { TabGroup } from '../main/tabs/TabGroupStore';
 
 // ---------------------------------------------------------------------------
 // Type re-exports for renderer consumption
@@ -40,6 +41,7 @@ export type {
   GrantedDevice,
   DeviceApiType,
   OmniboxSuggestion,
+  TabGroup,
 };
 
 // ---------------------------------------------------------------------------
@@ -717,5 +719,32 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     autofill: (id: string): Promise<string | null> =>
       ipcRenderer.invoke('passwords:autofill', id),
+  },
+
+  // Issue #5 — Tab groups
+  tabGroups: {
+    list: (): Promise<TabGroup[]> =>
+      ipcRenderer.invoke('tab-groups:list'),
+
+    create: (p: { name: string; color: string; tabIds: string[] }): Promise<TabGroup> =>
+      ipcRenderer.invoke('tab-groups:create', p),
+
+    update: (p: { id: string; patch: object }): Promise<void> =>
+      ipcRenderer.invoke('tab-groups:update', p),
+
+    addTab: (p: { groupId: string; tabId: string }): Promise<void> =>
+      ipcRenderer.invoke('tab-groups:add-tab', p),
+
+    removeTab: (p: { tabId: string }): Promise<void> =>
+      ipcRenderer.invoke('tab-groups:remove-tab', p),
+
+    delete: (p: { id: string }): Promise<void> =>
+      ipcRenderer.invoke('tab-groups:delete', p),
+
+    onUpdated: (cb: (groups: TabGroup[]) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, groups: TabGroup[]) => cb(groups);
+      ipcRenderer.on('tab-groups:updated', handler);
+      return () => ipcRenderer.removeListener('tab-groups:updated', handler);
+    },
   },
 });

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -13,11 +13,21 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { TabState } from '../../main/tabs/TabManager';
+import type { TabGroup } from '../../main/tabs/TabGroupStore';
 
 declare const electronAPI: {
   tabs: {
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
+  };
+  tabGroups: {
+    list: () => Promise<TabGroup[]>;
+    create: (p: { name: string; color: string; tabIds: string[] }) => Promise<TabGroup>;
+    update: (p: { id: string; patch: object }) => Promise<void>;
+    addTab: (p: { groupId: string; tabId: string }) => Promise<void>;
+    removeTab: (p: { tabId: string }) => Promise<void>;
+    delete: (p: { id: string }) => Promise<void>;
+    onUpdated: (cb: (groups: TabGroup[]) => void) => () => void;
   };
 };
 
@@ -72,6 +82,7 @@ interface TabItemProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
   tabRef: (el: HTMLDivElement | null) => void;
   onMuteToggle: (e: React.MouseEvent) => void;
+  groupColor?: string;
 }
 
 function TabItem({
@@ -89,6 +100,7 @@ function TabItem({
   onKeyDown,
   tabRef,
   onMuteToggle,
+  groupColor,
 }: TabItemProps): React.ReactElement {
   const isPinned = tab.pinned;
   const favicon = faviconSrc(tab);
@@ -101,9 +113,11 @@ function TabItem({
         isDragOver ? 'tab-item--drag-over' : '',
         isPinned ? 'tab-item--pinned' : '',
         isIconOnly && !isPinned ? 'tab-item--icon-only' : '',
+        groupColor ? 'tab-item--grouped' : '',
       ]
         .filter(Boolean)
         .join(' ')}
+      style={groupColor ? { '--tab-group-color': groupColor } as React.CSSProperties : undefined}
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
@@ -280,6 +294,46 @@ function TabSearchDropdown({
 }
 
 // ---------------------------------------------------------------------------
+// Group chip color map
+// ---------------------------------------------------------------------------
+const GROUP_COLOR_MAP: Record<TabGroup['color'], string> = {
+  grey: '#9e9e9e',
+  blue: '#1a73e8',
+  red: '#d32f2f',
+  yellow: '#f9a825',
+  green: '#2e7d32',
+  pink: '#e91e63',
+  purple: '#7b1fa2',
+  cyan: '#0097a7',
+};
+
+// ---------------------------------------------------------------------------
+// GroupChip
+// ---------------------------------------------------------------------------
+interface GroupChipProps {
+  group: TabGroup;
+  onToggleCollapse: (id: string) => void;
+  onContextMenu: (e: React.MouseEvent, group: TabGroup) => void;
+}
+
+function GroupChip({ group, onToggleCollapse, onContextMenu }: GroupChipProps): React.ReactElement {
+  const color = GROUP_COLOR_MAP[group.color];
+  return (
+    <div
+      className={`tab-group-chip tab-group-chip--${group.color}`}
+      style={{ '--group-color': color } as React.CSSProperties}
+      onClick={() => onToggleCollapse(group.id)}
+      onContextMenu={(e) => onContextMenu(e, group)}
+      title={group.collapsed ? `Expand group: ${group.name || '…'}` : `Collapse group: ${group.name || '…'}`}
+    >
+      <span className="tab-group-chip__dot" />
+      <span className="tab-group-chip__name">{group.name || '…'}</span>
+      <span className="tab-group-chip__arrow">{group.collapsed ? '›' : '‹'}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // TabStrip
 // ---------------------------------------------------------------------------
 export function TabStrip({
@@ -294,6 +348,9 @@ export function TabStrip({
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [iconOnlySet, setIconOnlySet] = useState<Set<string>>(new Set());
   const [searchOpen, setSearchOpen] = useState(false);
+  const [groups, setGroups] = useState<TabGroup[]>([]);
+  const [renameGroupId, setRenameGroupId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
   const dragTabId = useRef<string | null>(null);
   const tabRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const tabsContainerRef = useRef<HTMLDivElement>(null);
@@ -338,6 +395,13 @@ export function TabStrip({
 
     return () => ro.disconnect();
   }, [tabs]);
+
+  // Load groups on mount and subscribe to updates
+  useEffect(() => {
+    electronAPI.tabGroups.list().then(setGroups).catch(() => {});
+    const unsub = electronAPI.tabGroups.onUpdated(setGroups);
+    return unsub;
+  }, []);
 
   // Show search button when any non-pinned tab is narrower than the threshold
   const showSearchBtn = (() => {
@@ -443,6 +507,56 @@ export function TabStrip({
     dragTabId.current = null;
   }, []);
 
+  const handleGroupContextMenu = useCallback((e: React.MouseEvent, group: TabGroup) => {
+    e.preventDefault();
+    const menu = [
+      {
+        label: 'Rename',
+        action: () => {
+          setRenameGroupId(group.id);
+          setRenameValue(group.name);
+        },
+      },
+      {
+        label: 'Ungroup',
+        action: () => {
+          electronAPI.tabGroups.delete({ id: group.id });
+        },
+      },
+      {
+        label: 'Close Group',
+        action: () => {
+          const tabIdsToClose = [...group.tabIds];
+          electronAPI.tabGroups.delete({ id: group.id });
+          tabIdsToClose.forEach((tid) => onClose(tid));
+        },
+      },
+    ];
+    const nativeMenu = document.createElement('div');
+    nativeMenu.className = 'tab-group-context-menu';
+    nativeMenu.style.cssText = `position:fixed;z-index:9999;left:${e.clientX}px;top:${e.clientY}px;background:var(--color-bg-elevated,#fff);border:1px solid var(--color-border-default,#ccc);border-radius:6px;padding:4px 0;box-shadow:0 4px 16px rgba(0,0,0,.18);min-width:140px;`;
+    menu.forEach((item) => {
+      const btn = document.createElement('button');
+      btn.textContent = item.label;
+      btn.style.cssText = 'display:block;width:100%;padding:6px 14px;text-align:left;background:none;border:none;cursor:pointer;font-size:13px;color:var(--color-fg-primary,#111);';
+      btn.onmouseenter = () => { btn.style.background = 'var(--color-bg-hover,rgba(0,0,0,.06))'; };
+      btn.onmouseleave = () => { btn.style.background = 'none'; };
+      btn.onclick = () => {
+        item.action();
+        document.body.removeChild(nativeMenu);
+      };
+      nativeMenu.appendChild(btn);
+    });
+    document.body.appendChild(nativeMenu);
+    const dismiss = (ev: MouseEvent) => {
+      if (!nativeMenu.contains(ev.target as Node)) {
+        if (document.body.contains(nativeMenu)) document.body.removeChild(nativeMenu);
+        document.removeEventListener('mousedown', dismiss);
+      }
+    };
+    document.addEventListener('mousedown', dismiss);
+  }, [onClose]);
+
   return (
     <div className="tab-strip" role="presentation" onDragEnd={handleDragEnd}>
       <div
@@ -451,35 +565,75 @@ export function TabStrip({
         role="tablist"
         aria-label="Browser tabs"
       >
-        {tabs.map((tab, index) => (
-          <TabItem
-            key={tab.id}
-            tab={tab}
-            index={index}
-            isActive={tab.id === activeTabId}
-            isIconOnly={iconOnlySet.has(tab.id)}
-            onActivate={() => onActivate(tab.id)}
-            onClose={(e) => {
-              e.stopPropagation();
-              onClose(tab.id);
-            }}
-            onDragStart={handleDragStart}
-            onDragOver={handleDragOver}
-            onDrop={handleDrop}
-            isDragOver={dragOverIndex === index}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              electronAPI.tabs.showContextMenu(tab.id);
-            }}
-            onKeyDown={(e) => handleTabKeyDown(e, tab, index)}
-            tabRef={setTabRef(index)}
-            onMuteToggle={(e) => {
-              e.stopPropagation();
-              onMuteToggle(tab.id);
-            }}
-          />
-        ))}
+        {(() => {
+          const groupMap = new Map<string, TabGroup>(groups.map((g) => [g.id, g]));
+          const collapsedGroupIds = new Set(groups.filter((g) => g.collapsed).map((g) => g.id));
+          const tabToGroup = new Map<string, TabGroup>();
+          for (const g of groups) {
+            for (const tid of g.tabIds) tabToGroup.set(tid, g);
+          }
+          const renderedGroupChips = new Set<string>();
+          const elements: React.ReactNode[] = [];
+
+          tabs.forEach((tab, index) => {
+            const group = tabToGroup.get(tab.id);
+            if (group) {
+              if (!renderedGroupChips.has(group.id)) {
+                renderedGroupChips.add(group.id);
+                elements.push(
+                  <GroupChip
+                    key={`grp-chip-${group.id}`}
+                    group={group}
+                    onToggleCollapse={(id) => {
+                      const g = groupMap.get(id);
+                      if (g) electronAPI.tabGroups.update({ id, patch: { collapsed: !g.collapsed } });
+                    }}
+                    onContextMenu={(e, g) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleGroupContextMenu(e, g);
+                    }}
+                  />,
+                );
+              }
+              if (collapsedGroupIds.has(group.id)) return;
+            }
+
+            const groupColor = group ? GROUP_COLOR_MAP[group.color] : undefined;
+            elements.push(
+              <TabItem
+                key={tab.id}
+                tab={tab}
+                index={index}
+                isActive={tab.id === activeTabId}
+                isIconOnly={iconOnlySet.has(tab.id)}
+                onActivate={() => onActivate(tab.id)}
+                onClose={(e) => {
+                  e.stopPropagation();
+                  onClose(tab.id);
+                }}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+                isDragOver={dragOverIndex === index}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  electronAPI.tabs.showContextMenu(tab.id);
+                }}
+                onKeyDown={(e) => handleTabKeyDown(e, tab, index)}
+                tabRef={setTabRef(index)}
+                onMuteToggle={(e) => {
+                  e.stopPropagation();
+                  onMuteToggle(tab.id);
+                }}
+                groupColor={groupColor}
+              />,
+            );
+          });
+
+          return elements;
+        })()}
         {/* + button sits right after the last tab (Chrome-style), not pinned right */}
         <button
           type="button"
@@ -524,6 +678,37 @@ export function TabStrip({
           onActivate={onActivate}
           onClose={() => setSearchOpen(false)}
         />
+      )}
+
+      {renameGroupId && (
+        <div className="tab-group-rename-overlay" onClick={() => setRenameGroupId(null)}>
+          <div className="tab-group-rename-dialog" onClick={(e) => e.stopPropagation()}>
+            <input
+              className="tab-group-rename-input"
+              autoFocus
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  electronAPI.tabGroups.update({ id: renameGroupId, patch: { name: renameValue } });
+                  setRenameGroupId(null);
+                } else if (e.key === 'Escape') {
+                  setRenameGroupId(null);
+                }
+              }}
+              placeholder="Group name"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                electronAPI.tabGroups.update({ id: renameGroupId, patch: { name: renameValue } });
+                setRenameGroupId(null);
+              }}
+            >
+              OK
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -493,7 +493,6 @@ export function TabStrip({
         onActivate(targetTab.id);
         const el = tabRefs.current.get(targetIndex);
         el?.focus();
-        console.log('[TabStrip] Arrow key navigation to index:', targetIndex, 'tab:', targetTab.title);
       }
     },
     [tabs, groups, onActivate, onClose],

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -515,7 +515,7 @@ export function TabStrip({
         label: 'New Tab in Group',
         action: () => {
           electronAPI.tabs.create().then((newTabId) => {
-            electronAPI.tabGroups.addTab({ groupId: group.id, tabId: newTabId });
+            return electronAPI.tabGroups.addTab({ groupId: group.id, tabId: newTabId });
           }).catch(() => {});
         },
       },

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -544,6 +544,8 @@ export function TabStrip({
     const nativeMenu = document.createElement('div');
     nativeMenu.className = 'tab-group-context-menu';
     nativeMenu.style.cssText = `position:fixed;z-index:9999;left:${e.clientX}px;top:${e.clientY}px;background:var(--color-bg-elevated,#fff);border:1px solid var(--color-border-default,#ccc);border-radius:6px;padding:4px 0;box-shadow:0 4px 16px rgba(0,0,0,.18);min-width:140px;`;
+    // Declare dismiss before btn.onclick so the onclick closure can reference it.
+    let dismiss: (ev: MouseEvent) => void;
     menu.forEach((item) => {
       const btn = document.createElement('button');
       btn.textContent = item.label;
@@ -553,11 +555,12 @@ export function TabStrip({
       btn.onclick = () => {
         item.action();
         document.body.removeChild(nativeMenu);
+        document.removeEventListener('mousedown', dismiss);
       };
       nativeMenu.appendChild(btn);
     });
     document.body.appendChild(nativeMenu);
-    const dismiss = (ev: MouseEvent) => {
+    dismiss = (ev: MouseEvent) => {
       if (!nativeMenu.contains(ev.target as Node)) {
         if (document.body.contains(nativeMenu)) document.body.removeChild(nativeMenu);
         document.removeEventListener('mousedown', dismiss);

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -434,19 +434,44 @@ export function TabStrip({
       const count = tabs.length;
       let targetIndex = -1;
 
+      // Skip tabs hidden by collapsed groups
+      const collapsedTabIds = new Set<string>();
+      for (const g of groups) {
+        if (g.collapsed) {
+          for (const tid of g.tabIds) collapsedTabIds.add(tid);
+        }
+      }
+      const isVisible = (i: number) => i >= 0 && i < count && !collapsedTabIds.has(tabs[i].id);
+
       switch (e.key) {
-        case 'ArrowRight':
-          targetIndex = (index + 1) % count;
+        case 'ArrowRight': {
+          let next = (index + 1) % count;
+          for (let i = 0; i < count; i++) {
+            if (isVisible(next)) { targetIndex = next; break; }
+            next = (next + 1) % count;
+          }
           break;
-        case 'ArrowLeft':
-          targetIndex = (index - 1 + count) % count;
+        }
+        case 'ArrowLeft': {
+          let next = (index - 1 + count) % count;
+          for (let i = 0; i < count; i++) {
+            if (isVisible(next)) { targetIndex = next; break; }
+            next = (next - 1 + count) % count;
+          }
           break;
-        case 'Home':
-          targetIndex = 0;
+        }
+        case 'Home': {
+          for (let i = 0; i < count; i++) {
+            if (isVisible(i)) { targetIndex = i; break; }
+          }
           break;
-        case 'End':
-          targetIndex = count - 1;
+        }
+        case 'End': {
+          for (let i = count - 1; i >= 0; i--) {
+            if (isVisible(i)) { targetIndex = i; break; }
+          }
           break;
+        }
         case 'Enter':
         case ' ':
           e.preventDefault();
@@ -471,7 +496,7 @@ export function TabStrip({
         console.log('[TabStrip] Arrow key navigation to index:', targetIndex, 'tab:', targetTab.title);
       }
     },
-    [tabs, onActivate, onClose],
+    [tabs, groups, onActivate, onClose],
   );
 
   const handleDragStart = useCallback(

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -17,6 +17,7 @@ import type { TabGroup } from '../../main/tabs/TabGroupStore';
 
 declare const electronAPI: {
   tabs: {
+    create: (url?: string) => Promise<string>;
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
   };
@@ -510,6 +511,14 @@ export function TabStrip({
   const handleGroupContextMenu = useCallback((e: React.MouseEvent, group: TabGroup) => {
     e.preventDefault();
     const menu = [
+      {
+        label: 'New Tab in Group',
+        action: () => {
+          electronAPI.tabs.create().then((newTabId) => {
+            electronAPI.tabGroups.addTab({ groupId: group.id, tabId: newTabId });
+          }).catch(() => {});
+        },
+      },
       {
         label: 'Rename',
         action: () => {

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2367,3 +2367,93 @@
     transition: none;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Tab groups (Issue #5)
+   --------------------------------------------------------------------------- */
+.tab-group-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px 0 6px;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--group-color) 20%, transparent);
+  border: 1.5px solid var(--group-color);
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--group-color);
+  flex-shrink: 0;
+  align-self: center;
+  margin: 0 2px;
+}
+.tab-group-chip:hover {
+  background: color-mix(in srgb, var(--group-color) 35%, transparent);
+}
+.tab-group-chip__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--group-color);
+}
+.tab-group-chip__name {
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tab-group-chip__arrow {
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+.tab-item--grouped {
+  border-left: 2px solid var(--tab-group-color, #1a73e8);
+}
+
+.tab-group-rename-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background: rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.tab-group-rename-dialog {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+.tab-group-rename-input {
+  font-size: 13px;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 4px;
+  background: var(--color-bg-base);
+  color: var(--color-fg-primary);
+  outline: none;
+  min-width: 160px;
+}
+.tab-group-rename-input:focus {
+  border-color: var(--color-accent, #1a73e8);
+}
+.tab-group-rename-dialog button {
+  font-size: 12px;
+  padding: 4px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 4px;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  cursor: pointer;
+}
+.tab-group-rename-dialog button:hover {
+  background: var(--color-bg-hover);
+}

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2388,6 +2388,7 @@
   flex-shrink: 0;
   align-self: center;
   margin: 0 2px;
+  -webkit-app-region: no-drag;
 }
 .tab-group-chip:hover {
   background: color-mix(in srgb, var(--group-color) 35%, transparent);
@@ -2421,6 +2422,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  -webkit-app-region: no-drag;
 }
 .tab-group-rename-dialog {
   background: var(--color-bg-elevated);


### PR DESCRIPTION
## Summary

- Adds tab groups with 8 colors (grey, blue, red, yellow, green, pink, purple, cyan)
- Group chips appear in the tab strip; click to collapse/expand the group
- Right-click a tab → Add to new group / Remove from group
- Group chip context menu: Rename / Ungroup / Close group

## Test plan
- [ ] Right-click tab → Add to new group → group chip appears with default name
- [ ] Click group chip → tabs collapse (hidden), click again → expand
- [ ] Group chip context menu: Rename renames the group, Ungroup removes grouping, Close group closes all member tabs
- [ ] Right-click a grouped tab → Remove from group removes it

Closes #5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tab groups with colored chips and collapse/expand to organize tabs in the strip. Adds context menus and IPC to create, rename, ungroup, close, and add tabs to groups, including opening a new tab directly into a group.

- **New Features**
  - 8 colors: grey, blue, red, yellow, green, pink, purple, cyan; click a chip to collapse/expand its tabs.
  - Tab context menu: Add to New Group or Remove from Group.
  - Group chip menu: New Tab in Group, Rename, Ungroup, Close Group.
  - Wiring: `TabGroupStore` in main, `tab-groups:*` IPC handlers and `electronAPI.tabGroups` bridge; renderer listens to `tab-groups:updated`.

- **Bug Fixes**
  - Make group chips and rename overlay `-webkit-app-region: no-drag` to avoid window drag conflicts.
  - Storage/IPC hardening: validate color enum and limit name in `tab-groups:create`; whitelist `name`, `color`, `collapsed` in `tab-groups:update`; validate color and `tabIds` in `deserialize` with an atomic swap; ensure unique group IDs; chain `addTab` promise when creating a new tab in a group.
  - Remove context menu dismiss listener on item click to prevent a leaked mousedown handler.
  - Clean up group membership and broadcast `tab-groups:updated` when a tab is closed, ensuring removal happens before any early return (including the last-tab case).
  - Keyboard navigation: skip tabs hidden by collapsed groups and remove a stray debug console.log.
  - Hide group menu items when `tabGroupStore` is unavailable.

<sup>Written for commit 39283e87b26187f29b6b6569731a0b41e1b83ee9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

