### PR TITLE
feat(tabs): drag tab below strip to detach; Move to New Window context menu

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -260,6 +260,10 @@ function openShellAndWire(profileId?: string): BrowserWindow {
     rebuildApplicationMenu();
   });
 
+  tabManager.setOnMoveTabToNewWindow((url: string) => {
+    openNewWindow(url);
+  });
+
   setTimeout(async () => {
     if (tabManager) {
       const port = await tabManager.discoverCdpPort();
@@ -398,7 +402,7 @@ function openGuestShell(): BrowserWindow {
 // ---------------------------------------------------------------------------
 // New window (Cmd+N) — fresh window sharing the active profile session
 // ---------------------------------------------------------------------------
-function openNewWindow(): BrowserWindow {
+function openNewWindow(initialUrl?: string): BrowserWindow {
   const pid = activeProfileId;
   const profileDataDir = getProfileDataDir(pid);
   const profilePartition = getProfilePartitionName(pid);
@@ -412,7 +416,11 @@ function openNewWindow(): BrowserWindow {
     const store = bookmarkStore;
     tm.setUrlMatchFn((candidate: string) => store.isUrlBookmarked(candidate) ? candidate : null);
   }
-  tm.restoreSession();
+  if (initialUrl) {
+    tm.createTab(initialUrl);
+  } else {
+    tm.restoreSession();
+  }
   tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
 
   win.webContents.once('did-finish-load', () => {
@@ -1696,6 +1704,18 @@ function switchTabRelative(delta: number): void {
 // IPC: window-level handlers
 // ---------------------------------------------------------------------------
 ipcMain.handle('shell:get-platform', () => process.platform);
+
+// Tab drag-to-detach / move to new window (issue #1)
+ipcMain.handle('tabs:move-to-new-window', (_e, tabId: string) => {
+  if (!tabManager) return false;
+  const { tabs } = tabManager.getState();
+  if (tabs.length <= 1) return false; // Can't detach the last tab
+  const tab = tabs.find((t) => t.id === tabId);
+  if (!tab) return false;
+  tabManager.closeTab(tabId);
+  openNewWindow(tab.url);
+  return true;
+});
 
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1706,13 +1706,15 @@ function switchTabRelative(delta: number): void {
 ipcMain.handle('shell:get-platform', () => process.platform);
 
 // Tab drag-to-detach / move to new window (issue #1)
-ipcMain.handle('tabs:move-to-new-window', (_e, tabId: string) => {
-  if (!tabManager) return false;
-  const { tabs } = tabManager.getState();
+ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
+  const callerWin = BrowserWindow.fromWebContents(e.sender);
+  const tm = (callerWin ? TabManager.instances.get(callerWin.id) : null) ?? tabManager;
+  if (!tm) return false;
+  const { tabs } = tm.getState();
   if (tabs.length <= 1) return false; // Can't detach the last tab
   const tab = tabs.find((t) => t.id === tabId);
   if (!tab) return false;
-  tabManager.closeTab(tabId);
+  tm.closeTab(tabId);
   openNewWindow(tab.url);
   return true;
 });

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -429,6 +429,7 @@ function openNewWindow(initialUrl?: string): BrowserWindow {
   });
 
   win.on('resize', () => tm.relayout());
+  win.on('closed', () => tm.destroy());
 
   mainLogger.info('main.openNewWindow.done', { windowId: win.id });
   return win;

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -308,6 +308,10 @@ function openShellAndWire(profileId?: string): BrowserWindow {
 
   shellWindow.on('resize', () => tabManager?.relayout());
 
+  // Capture before module-level tabManager can be reassigned by a profile switch.
+  const shellTm = tabManager;
+  shellWindow.on('closed', () => shellTm.destroy());
+
   // DEV/TEST: expose tabManager on the Node.js global object so E2E tests can
   // reach it via electronApp.evaluate() calls (which run in the same Node.js
   // process and share the global scope).  The BrowserWindow proxy returned by
@@ -384,11 +388,13 @@ function openGuestShell(): BrowserWindow {
 
   shellWindow.on('resize', () => tabManager?.relayout());
 
+  const guestTm = tabManager;
   shellWindow.on('closed', () => {
     mainLogger.info('main.guestShell.closed', {
       msg: 'Guest window closed — clearing ephemeral session data',
       guestPartitionName,
     });
+    guestTm.destroy();
     if (guestPartitionName) {
       void clearGuestSession(guestPartitionName);
     }

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -157,6 +157,7 @@ export class TabManager {
   private onClosedTabsChanged: (() => void) | null = null;
   private onTabClosed: ((tabId: string) => void) | null = null;
   private onWebContentsCreated: ((wc: import("electron").WebContents) => void) | null = null;
+  private onMoveTabToNewWindow: ((url: string, title: string) => void) | null = null;
   // Extra pixels the renderer added on top of the base chrome (e.g. 32 px
   // for a visible bookmarks bar). The page-hosting WebContentsView is then
   // positioned at CHROME_HEIGHT + chromeOffset.
@@ -213,6 +214,10 @@ export class TabManager {
   /** Called by DeviceManager to attach select-bluetooth-device on new tabs */
   setOnWebContentsCreated(cb: ((wc: import("electron").WebContents) => void) | null): void {
     this.onWebContentsCreated = cb;
+  }
+
+  setOnMoveTabToNewWindow(cb: ((url: string, title: string) => void) | null): void {
+    this.onMoveTabToNewWindow = cb;
   }
 
   setHistoryStore(store: HistoryStore): void {
@@ -2104,6 +2109,20 @@ export class TabManager {
         this.safeSend('bookmark-all-tabs-request', {});
       },
     }));
+
+    if (this.onMoveTabToNewWindow) {
+      menu.append(new MenuItem({ type: 'separator' }));
+      menu.append(new MenuItem({
+        label: 'Move Tab to New Window',
+        enabled: tabCount > 1,
+        click: () => {
+          const tabUrl = view.webContents.getURL();
+          const tabTitle = view.webContents.getTitle();
+          this.closeTab(tabId);
+          this.onMoveTabToNewWindow?.(tabUrl, tabTitle);
+        },
+      }));
+    }
 
     menu.popup({ window: this.win });
   }

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -144,6 +144,8 @@ const SKIP_HISTORY_RE = /^(data:|about:|chrome:|devtools:|view-source:)/i;
 const NEWTAB_URL_RE = /newtab\.html$/;
 
 export class TabManager {
+  static readonly instances = new Map<number, TabManager>();
+
   private win: BrowserWindow;
   private tabs: Map<string, WebContentsView> = new Map();
   private tabOrder: string[] = [];
@@ -186,6 +188,7 @@ export class TabManager {
 
   constructor(win: BrowserWindow, opts?: { dataDir?: string; partition?: string; guest?: boolean }) {
     this.win = win;
+    TabManager.instances.set(win.id, this);
     this.isGuest = opts?.guest ?? false;
     this.partition = opts?.partition ?? null;
     this.sessionStore = new SessionStore(opts?.dataDir);
@@ -2390,6 +2393,7 @@ export class TabManager {
   }
 
   destroy(): void {
+    TabManager.instances.delete(this.win.id);
     ipcMain.removeHandler('tabs:create');
     ipcMain.removeHandler('tabs:close');
     ipcMain.removeHandler('tabs:activate');

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -108,6 +108,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     showForwardHistory: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:show-forward-history', tabId),
+
+    moveToNewWindow: (tabId: string): Promise<boolean> =>
+      ipcRenderer.invoke('tabs:move-to-new-window', tabId),
   },
 
   // CDP info for agent integration

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -18,6 +18,7 @@ declare const electronAPI: {
   tabs: {
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
+    moveToNewWindow: (tabId: string) => Promise<boolean>;
   };
 };
 
@@ -426,10 +427,13 @@ export function TabStrip({
     [],
   );
 
+  const droppedRef = useRef(false);
+
   const handleDrop = useCallback(
     (e: React.DragEvent, toIndex: number) => {
       e.preventDefault();
       setDragOverIndex(null);
+      droppedRef.current = true;
       if (dragTabId.current) {
         onMove(dragTabId.current, toIndex);
         dragTabId.current = null;
@@ -438,13 +442,23 @@ export function TabStrip({
     [onMove],
   );
 
-  const handleDragEnd = useCallback(() => {
+  // Detach threshold: if the drag ends more than 80px below the tab strip top, treat it as detach.
+  const DETACH_Y_THRESHOLD = 80;
+
+  const handleDragEnd = useCallback((e: React.DragEvent) => {
+    const tabId = dragTabId.current;
+    const wasDroppedInStrip = droppedRef.current;
     setDragOverIndex(null);
     dragTabId.current = null;
+    droppedRef.current = false;
+
+    if (tabId && !wasDroppedInStrip && e.clientY > DETACH_Y_THRESHOLD) {
+      electronAPI.tabs.moveToNewWindow(tabId).catch(() => {/* ignore */});
+    }
   }, []);
 
   return (
-    <div className="tab-strip" role="presentation" onDragEnd={handleDragEnd}>
+    <div className="tab-strip" role="presentation" onDragEnd={(e) => handleDragEnd(e)}>
       <div
         ref={tabsContainerRef}
         className="tab-strip__tabs"


### PR DESCRIPTION
## Summary

- **Drag to detach**: dragging a tab and releasing it more than 80px below the tab strip opens it in a new window (closes #1)
- **Context menu**: right-clicking a tab shows "Move to New Window" (enabled when there are 2+ tabs)
- New window opens with the detached tab's URL; original tab is closed

## Implementation
- `TabManager.setOnMoveTabToNewWindow(cb)` — callback wired in index.ts to call `openNewWindow(url)`
- `openNewWindow(initialUrl?)` — accepts optional URL; opens that URL as the first tab instead of restoring session
- `tabs:move-to-new-window` IPC handler — callable from renderer for drag-detach
- TabStrip: `handleDragEnd` detects out-of-strip drags (`clientY > 80px`) and calls `moveToNewWindow`

## Test plan
- [ ] Right-click a tab → "Move to New Window" appears (disabled when only 1 tab open)
- [ ] Click "Move to New Window" → tab opens in a new browser window
- [ ] Drag a tab and release it below the tab strip → tab opens in a new window
- [ ] Dragging within the tab strip still reorders normally

Closes #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tab detaching so you can move a tab into a new window by dragging below the strip or via the context menu. Works across multiple windows and closes the original tab. Implements #1.

- **New Features**
  - Drag a tab and release >80px below the strip to detach into a new window.
  - Right-click → “Move Tab to New Window” (enabled when 2+ tabs).
  - Added IPC `tabs:move-to-new-window` and a `TabManager` callback to support both drag and context menu flows.

- **Bug Fixes**
  - Resolve `tabs:move-to-new-window` against the caller window’s `TabManager` via a static registry, ensuring correct behavior per window and preventing detaching the last tab.
  - Clean up `TabManager.instances` on all shell window closes (main, guest, new windows) to avoid stale entries and misrouted requests.

<sup>Written for commit 6ef866fbab5f8ac07c7e75c9dc5b6cd37cefabc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

