### PR TITLE
feat(settings): sync toggles panel with granular category controls

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -93,6 +93,8 @@ const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_SYNC_PREFS      = 'settings:get-sync-prefs';
+const CH_SET_SYNC_PREFS      = 'settings:set-sync-prefs';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -133,6 +135,19 @@ interface Preferences {
   theme?: string;
   fontSize?: number;
   defaultPageZoom?: number;
+  syncPrefs?: {
+    enabled: boolean;
+    syncEverything: boolean;
+    bookmarks: boolean;
+    readingList: boolean;
+    passwords: boolean;
+    addresses: boolean;
+    payments: boolean;
+    historyAndTabs: boolean;
+    savedTabGroups: boolean;
+    extensions: boolean;
+    settings: boolean;
+  };
   [key: string]: unknown;
 }
 
@@ -671,6 +686,31 @@ export function refreshPrivacyHeaders(): void {
   mainLogger.info('privacy.refreshHeaders.installed');
 }
 
+function handleGetSyncPrefs() {
+  const prefs = readPrefs();
+  return prefs.syncPrefs ?? {
+    enabled: false,
+    syncEverything: true,
+    bookmarks: true,
+    readingList: true,
+    passwords: true,
+    addresses: true,
+    payments: true,
+    historyAndTabs: true,
+    savedTabGroups: true,
+    extensions: true,
+    settings: true,
+  };
+}
+
+function handleSetSyncPrefs(_e: Electron.IpcMainInvokeEvent, patch: unknown): boolean {
+  if (typeof patch !== 'object' || patch === null) return false;
+  const prefs = readPrefs();
+  const current = prefs.syncPrefs ?? {};
+  mergePrefs({ syncPrefs: { ...current, ...(patch as object) } } as Partial<Preferences>);
+  return true;
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -719,6 +759,8 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_SYNC_PREFS,     handleGetSyncPrefs);
+  ipcMain.handle(CH_SET_SYNC_PREFS,     handleSetSyncPrefs);
 
   refreshPrivacyHeaders();
 
@@ -753,6 +795,8 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_SYNC_PREFS);
+  ipcMain.removeHandler(CH_SET_SYNC_PREFS);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -95,6 +95,9 @@ const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
 const CH_GET_SYNC_PREFS      = 'settings:get-sync-prefs';
 const CH_SET_SYNC_PREFS      = 'settings:set-sync-prefs';
+const CH_SET_SYNC_PASSPHRASE = 'settings:set-sync-passphrase';
+const CH_CLEAR_SYNC_PASSPHRASE = 'settings:clear-sync-passphrase';
+const CH_VERIFY_SYNC_PASSPHRASE = 'settings:verify-sync-passphrase';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -147,6 +150,9 @@ interface Preferences {
     savedTabGroups: boolean;
     extensions: boolean;
     settings: boolean;
+    encryptionEnabled: boolean;
+    // PBKDF2 hash of the passphrase (stored for verification, never the raw passphrase)
+    encryptionKeyHash?: string;
   };
   [key: string]: unknown;
 }
@@ -700,6 +706,7 @@ function handleGetSyncPrefs() {
     savedTabGroups: true,
     extensions: true,
     settings: true,
+    encryptionEnabled: false,
   };
 }
 
@@ -709,6 +716,44 @@ function handleSetSyncPrefs(_e: Electron.IpcMainInvokeEvent, patch: unknown): bo
   const current = prefs.syncPrefs ?? {};
   mergePrefs({ syncPrefs: { ...current, ...(patch as object) } } as Partial<Preferences>);
   return true;
+}
+
+async function handleSetSyncPassphrase(_e: Electron.IpcMainInvokeEvent, passphrase: unknown): Promise<boolean> {
+  if (typeof passphrase !== 'string' || passphrase.length < 8) return false;
+  // Derive a verification hash using PBKDF2 (never store the raw passphrase)
+  const { pbkdf2 } = await import('node:crypto');
+  const hash = await new Promise<string>((resolve, reject) => {
+    pbkdf2(passphrase, 'sync-passphrase-salt', 100000, 32, 'sha256', (err, key) => {
+      if (err) reject(err);
+      else resolve(key.toString('hex'));
+    });
+  });
+  const prefs = readPrefs();
+  const current = prefs.syncPrefs ?? {};
+  mergePrefs({ syncPrefs: { ...current, encryptionEnabled: true, encryptionKeyHash: hash } } as Partial<Preferences>);
+  return true;
+}
+
+async function handleVerifySyncPassphrase(_e: Electron.IpcMainInvokeEvent, passphrase: unknown): Promise<boolean> {
+  if (typeof passphrase !== 'string') return false;
+  const prefs = readPrefs();
+  const stored = prefs.syncPrefs?.encryptionKeyHash;
+  if (!stored) return false;
+  const { pbkdf2 } = await import('node:crypto');
+  const hash = await new Promise<string>((resolve, reject) => {
+    pbkdf2(passphrase, 'sync-passphrase-salt', 100000, 32, 'sha256', (err, key) => {
+      if (err) reject(err);
+      else resolve(key.toString('hex'));
+    });
+  });
+  return hash === stored;
+}
+
+function handleClearSyncPassphrase(): void {
+  const prefs = readPrefs();
+  const current = prefs.syncPrefs ?? {};
+  const { encryptionKeyHash: _removed, ...rest } = current as typeof current & { encryptionKeyHash?: string };
+  mergePrefs({ syncPrefs: { ...rest, encryptionEnabled: false } } as Partial<Preferences>);
 }
 
 function handleCloseWindow(): void {
@@ -759,8 +804,11 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
-  ipcMain.handle(CH_GET_SYNC_PREFS,     handleGetSyncPrefs);
-  ipcMain.handle(CH_SET_SYNC_PREFS,     handleSetSyncPrefs);
+  ipcMain.handle(CH_GET_SYNC_PREFS,          handleGetSyncPrefs);
+  ipcMain.handle(CH_SET_SYNC_PREFS,          handleSetSyncPrefs);
+  ipcMain.handle(CH_SET_SYNC_PASSPHRASE,     handleSetSyncPassphrase);
+  ipcMain.handle(CH_VERIFY_SYNC_PASSPHRASE,  handleVerifySyncPassphrase);
+  ipcMain.handle(CH_CLEAR_SYNC_PASSPHRASE,   handleClearSyncPassphrase);
 
   refreshPrivacyHeaders();
 
@@ -797,6 +845,9 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
   ipcMain.removeHandler(CH_GET_SYNC_PREFS);
   ipcMain.removeHandler(CH_SET_SYNC_PREFS);
+  ipcMain.removeHandler(CH_SET_SYNC_PASSPHRASE);
+  ipcMain.removeHandler(CH_VERIFY_SYNC_PASSPHRASE);
+  ipcMain.removeHandler(CH_CLEAR_SYNC_PASSPHRASE);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -696,7 +696,7 @@ export function refreshPrivacyHeaders(): void {
 
 function handleGetSyncPrefs() {
   const prefs = readPrefs();
-  return prefs.syncPrefs ?? {
+  const raw = prefs.syncPrefs ?? {
     enabled: false,
     syncEverything: true,
     bookmarks: true,
@@ -710,13 +710,29 @@ function handleGetSyncPrefs() {
     settings: true,
     encryptionEnabled: false,
   };
+  // Strip credential fields — never expose hash or salt to the renderer.
+  const { encryptionKeyHash: _h, encryptionSalt: _s, ...safe } = raw as typeof raw & {
+    encryptionKeyHash?: string; encryptionSalt?: string;
+  };
+  return safe;
 }
+
+const SYNC_BOOL_KEYS = new Set([
+  'enabled', 'syncEverything', 'bookmarks', 'readingList', 'passwords',
+  'addresses', 'payments', 'historyAndTabs', 'savedTabGroups', 'extensions',
+  'settings', 'encryptionEnabled',
+]);
 
 function handleSetSyncPrefs(_e: Electron.IpcMainInvokeEvent, patch: unknown): boolean {
   if (typeof patch !== 'object' || patch === null) return false;
   const prefs = readPrefs();
   const current = prefs.syncPrefs ?? {};
-  mergePrefs({ syncPrefs: { ...current, ...(patch as object) } } as Partial<Preferences>);
+  // Whitelist only known boolean keys to prevent renderer from injecting arbitrary data.
+  const safe: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(patch as Record<string, unknown>)) {
+    if (SYNC_BOOL_KEYS.has(k) && typeof v === 'boolean') safe[k] = v;
+  }
+  mergePrefs({ syncPrefs: { ...current, ...safe } } as Partial<Preferences>);
   return true;
 }
 
@@ -740,16 +756,28 @@ async function handleVerifySyncPassphrase(_e: Electron.IpcMainInvokeEvent, passp
   if (typeof passphrase !== 'string') return false;
   const prefs = readPrefs();
   const stored = prefs.syncPrefs?.encryptionKeyHash;
+  if (!stored) return false;
   const salt = prefs.syncPrefs?.encryptionSalt;
-  if (!stored || !salt) return false;
-  const { pbkdf2 } = await import('node:crypto');
-  const hash = await new Promise<string>((resolve, reject) => {
-    pbkdf2(passphrase, salt, 100000, 32, 'sha256', (err, key) => {
-      if (err) reject(err);
-      else resolve(key.toString('hex'));
+  const { pbkdf2, randomBytes } = await import('node:crypto');
+  const derive = (s: string): Promise<string> =>
+    new Promise<string>((resolve, reject) => {
+      pbkdf2(passphrase, s, 100000, 32, 'sha256', (err, key) => {
+        if (err) reject(err); else resolve(key.toString('hex'));
+      });
     });
-  });
-  return hash === stored;
+  // Try with stored random salt first; fall back to legacy static salt for
+  // passphrases set before the salted-hash migration.
+  const effectiveSalt = salt ?? 'sync-passphrase-salt';
+  const hash = await derive(effectiveSalt);
+  if (hash !== stored) return false;
+  // Opportunistically upgrade legacy (no-salt) records to salted format.
+  if (!salt) {
+    const newSalt = randomBytes(16).toString('hex');
+    const newHash = await derive(newSalt);
+    const current = readPrefs().syncPrefs ?? {};
+    mergePrefs({ syncPrefs: { ...current, encryptionKeyHash: newHash, encryptionSalt: newSalt } } as Partial<Preferences>);
+  }
+  return true;
 }
 
 function handleClearSyncPassphrase(): void {

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -153,6 +153,8 @@ interface Preferences {
     encryptionEnabled: boolean;
     // PBKDF2 hash of the passphrase (stored for verification, never the raw passphrase)
     encryptionKeyHash?: string;
+    // Random salt (hex) persisted alongside the hash for PBKDF2 verification
+    encryptionSalt?: string;
   };
   [key: string]: unknown;
 }
@@ -720,17 +722,17 @@ function handleSetSyncPrefs(_e: Electron.IpcMainInvokeEvent, patch: unknown): bo
 
 async function handleSetSyncPassphrase(_e: Electron.IpcMainInvokeEvent, passphrase: unknown): Promise<boolean> {
   if (typeof passphrase !== 'string' || passphrase.length < 8) return false;
-  // Derive a verification hash using PBKDF2 (never store the raw passphrase)
-  const { pbkdf2 } = await import('node:crypto');
+  const { pbkdf2, randomBytes } = await import('node:crypto');
+  const salt = randomBytes(16).toString('hex');
   const hash = await new Promise<string>((resolve, reject) => {
-    pbkdf2(passphrase, 'sync-passphrase-salt', 100000, 32, 'sha256', (err, key) => {
+    pbkdf2(passphrase, salt, 100000, 32, 'sha256', (err, key) => {
       if (err) reject(err);
       else resolve(key.toString('hex'));
     });
   });
   const prefs = readPrefs();
   const current = prefs.syncPrefs ?? {};
-  mergePrefs({ syncPrefs: { ...current, encryptionEnabled: true, encryptionKeyHash: hash } } as Partial<Preferences>);
+  mergePrefs({ syncPrefs: { ...current, encryptionEnabled: true, encryptionKeyHash: hash, encryptionSalt: salt } } as Partial<Preferences>);
   return true;
 }
 
@@ -738,10 +740,11 @@ async function handleVerifySyncPassphrase(_e: Electron.IpcMainInvokeEvent, passp
   if (typeof passphrase !== 'string') return false;
   const prefs = readPrefs();
   const stored = prefs.syncPrefs?.encryptionKeyHash;
-  if (!stored) return false;
+  const salt = prefs.syncPrefs?.encryptionSalt;
+  if (!stored || !salt) return false;
   const { pbkdf2 } = await import('node:crypto');
   const hash = await new Promise<string>((resolve, reject) => {
-    pbkdf2(passphrase, 'sync-passphrase-salt', 100000, 32, 'sha256', (err, key) => {
+    pbkdf2(passphrase, salt, 100000, 32, 'sha256', (err, key) => {
       if (err) reject(err);
       else resolve(key.toString('hex'));
     });

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -232,6 +232,12 @@ export interface SettingsAPI {
   /** Set whether Global Privacy Control header is enabled */
   setGpcEnabled: (enabled: boolean) => Promise<void>;
 
+  /** Get sync preferences */
+  getSyncPrefs: () => Promise<object>;
+
+  /** Set (patch) sync preferences */
+  setSyncPrefs: (patch: object) => Promise<boolean>;
+
   /** Get all global content category defaults */
   getContentCategoryDefaults: () => Promise<Record<ContentCategory, CategoryState>>;
 
@@ -571,6 +577,16 @@ const api: SettingsAPI = {
   deleteAllAutofill: async (): Promise<void> => {
     console.debug('[settings-preload] deleteAllAutofill');
     await ipcRenderer.invoke('autofill:delete-all');
+  },
+
+  getSyncPrefs: (): Promise<object> => {
+    console.debug('[settings-preload] getSyncPrefs');
+    return ipcRenderer.invoke('settings:get-sync-prefs') as Promise<object>;
+  },
+
+  setSyncPrefs: (patch: object): Promise<boolean> => {
+    console.debug('[settings-preload] setSyncPrefs');
+    return ipcRenderer.invoke('settings:set-sync-prefs', patch) as Promise<boolean>;
   },
 
 };

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -238,6 +238,15 @@ export interface SettingsAPI {
   /** Set (patch) sync preferences */
   setSyncPrefs: (patch: object) => Promise<boolean>;
 
+  /** Set sync encryption passphrase (min 8 chars); stores PBKDF2 hash */
+  setSyncPassphrase: (passphrase: string) => Promise<boolean>;
+
+  /** Verify the given passphrase against the stored hash */
+  verifySyncPassphrase: (passphrase: string) => Promise<boolean>;
+
+  /** Clear the sync encryption passphrase */
+  clearSyncPassphrase: () => Promise<void>;
+
   /** Get all global content category defaults */
   getContentCategoryDefaults: () => Promise<Record<ContentCategory, CategoryState>>;
 
@@ -588,6 +597,15 @@ const api: SettingsAPI = {
     console.debug('[settings-preload] setSyncPrefs');
     return ipcRenderer.invoke('settings:set-sync-prefs', patch) as Promise<boolean>;
   },
+
+  setSyncPassphrase: (passphrase: string): Promise<boolean> =>
+    ipcRenderer.invoke('settings:set-sync-passphrase', passphrase) as Promise<boolean>,
+
+  verifySyncPassphrase: (passphrase: string): Promise<boolean> =>
+    ipcRenderer.invoke('settings:verify-sync-passphrase', passphrase) as Promise<boolean>,
+
+  clearSyncPassphrase: (): Promise<void> =>
+    ipcRenderer.invoke('settings:clear-sync-passphrase') as Promise<void>,
 
 };
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -30,6 +30,7 @@ const TAB_APPEARANCE   = 'appearance'       as const;
 const TAB_SCOPES       = 'scopes'           as const;
 const TAB_DANGER       = 'danger'           as const;
 const TAB_PROFILES     = 'profiles'         as const;
+const TAB_SYNC         = 'sync'             as const;
 const TAB_PRIVACY      = 'privacy'          as const;
 const TAB_PASSWORDS    = 'passwords'        as const;
 const TAB_ZOOM         = 'site-zoom'        as const;
@@ -45,6 +46,7 @@ type TabId =
   | typeof TAB_SCOPES
   | typeof TAB_PASSWORDS
   | typeof TAB_PROFILES
+  | typeof TAB_SYNC
   | typeof TAB_PRIVACY
   | typeof TAB_ZOOM
   | typeof TAB_CONTENT
@@ -60,6 +62,7 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_SCOPES,     label: 'Google Scopes' },
   { id: TAB_PASSWORDS,  label: 'Passwords' },
   { id: TAB_PROFILES,   label: 'Profiles' },
+  { id: TAB_SYNC,       label: 'Sync' },
   { id: TAB_PRIVACY,    label: 'Privacy and security' },
   { id: TAB_ZOOM,       label: 'Site Zoom' },
   { id: TAB_CONTENT,    label: 'Content' },
@@ -194,9 +197,35 @@ declare global {
       }>;
       applyAutoRevokePermissions: (revocations: Array<{ origin: string; permissionType: string }>) => Promise<number>;
       optOutAutoRevoke: (origin: string, permissionType: string) => Promise<void>;
+      getSyncPrefs: () => Promise<SyncPrefs>;
+      setSyncPrefs: (patch: object) => Promise<boolean>;
     };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Sync types and defaults
+// ---------------------------------------------------------------------------
+
+interface SyncPrefs {
+  enabled: boolean;
+  syncEverything: boolean;
+  bookmarks: boolean;
+  readingList: boolean;
+  passwords: boolean;
+  addresses: boolean;
+  payments: boolean;
+  historyAndTabs: boolean;
+  savedTabGroups: boolean;
+  extensions: boolean;
+  settings: boolean;
+}
+
+const DEFAULT_SYNC_PREFS: SyncPrefs = {
+  enabled: false, syncEverything: true, bookmarks: true, readingList: true,
+  passwords: true, addresses: true, payments: true, historyAndTabs: true,
+  savedTabGroups: true, extensions: true, settings: true,
+};
 
 // ---------------------------------------------------------------------------
 // Eye icon (show/hide password)
@@ -2639,6 +2668,7 @@ function SettingsInner(): React.ReactElement {
     [TAB_SCOPES]:     <GoogleScopesTab />,
     [TAB_PASSWORDS]:  <PasswordsTab />,
     [TAB_PROFILES]:   <ProfilesTab />,
+    [TAB_SYNC]:       <SyncTab />,
     [TAB_PRIVACY]:    <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
     [TAB_ZOOM]:       <SiteZoomTab />,
     [TAB_PERMISSIONS]: <PermissionsTab />,
@@ -2710,6 +2740,119 @@ function SettingsInner(): React.ReactElement {
           {content[activeTab]}
         </main>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sync tab
+// ---------------------------------------------------------------------------
+
+function SyncTab(): React.ReactElement {
+  const [syncPrefs, setSyncPrefsState] = useState<SyncPrefs>(DEFAULT_SYNC_PREFS);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void window.settingsAPI.getSyncPrefs().then((p: SyncPrefs) => setSyncPrefsState(p));
+  }, []);
+
+  const toggle = useCallback(async (key: keyof SyncPrefs) => {
+    const next = { ...syncPrefs, [key]: !syncPrefs[key] };
+    // If toggling syncEverything ON, also enable all categories
+    if (key === 'syncEverything' && next.syncEverything) {
+      Object.keys(DEFAULT_SYNC_PREFS).forEach((k) => {
+        if (k !== 'enabled' && k !== 'syncEverything') {
+          (next as Record<string, boolean>)[k] = true;
+        }
+      });
+    }
+    setSyncPrefsState(next);
+    setSaving(true);
+    await window.settingsAPI.setSyncPrefs(next);
+    setSaving(false);
+  }, [syncPrefs]);
+
+  const categories: Array<{ key: keyof SyncPrefs; label: string; description: string }> = [
+    { key: 'bookmarks',      label: 'Bookmarks',             description: 'Sync bookmarks across devices' },
+    { key: 'readingList',    label: 'Reading list',          description: 'Sync reading list items' },
+    { key: 'passwords',      label: 'Passwords and passkeys', description: 'Sync saved passwords' },
+    { key: 'addresses',      label: 'Addresses and more',    description: 'Sync autofill data' },
+    { key: 'payments',       label: 'Payment methods',       description: 'Sync payment methods' },
+    { key: 'historyAndTabs', label: 'History and tabs',      description: 'Sync browsing history and open tabs' },
+    { key: 'savedTabGroups', label: 'Saved tab groups',      description: 'Sync saved tab groups' },
+    { key: 'extensions',     label: 'Extensions and apps',   description: 'Sync installed extensions' },
+    { key: 'settings',       label: 'Settings and theme',    description: 'Sync browser preferences' },
+  ];
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Sync</h2>
+      <p className="settings-section-desc">
+        Keep your data up-to-date across all your devices.
+        {saving && <span style={{ marginLeft: 8, color: 'var(--color-text-secondary, #666)', fontSize: 12 }}>Saving…</span>}
+      </p>
+
+      {/* Master enable toggle */}
+      <Card>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0' }}>
+          <div>
+            <div style={{ fontWeight: 500 }}>Sync is {syncPrefs.enabled ? 'on' : 'off'}</div>
+            <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #666)', marginTop: 2 }}>
+              {syncPrefs.enabled ? 'Your data is being synced.' : 'Turn on sync to keep your data up-to-date.'}
+            </div>
+          </div>
+          <button
+            className={`settings-sync-toggle ${syncPrefs.enabled ? 'settings-sync-toggle--on' : ''}`}
+            role="switch"
+            aria-checked={syncPrefs.enabled}
+            onClick={() => void toggle('enabled')}
+          />
+        </div>
+      </Card>
+
+      {syncPrefs.enabled && (
+        <>
+          {/* Sync everything toggle */}
+          <Card style={{ marginTop: 16 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 0' }}>
+              <div>
+                <div style={{ fontWeight: 500 }}>Sync everything</div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #666)', marginTop: 2 }}>
+                  Automatically sync all data types
+                </div>
+              </div>
+              <button
+                className={`settings-sync-toggle ${syncPrefs.syncEverything ? 'settings-sync-toggle--on' : ''}`}
+                role="switch"
+                aria-checked={syncPrefs.syncEverything}
+                onClick={() => void toggle('syncEverything')}
+              />
+            </div>
+          </Card>
+
+          {/* Individual category toggles */}
+          {!syncPrefs.syncEverything && (
+            <Card style={{ marginTop: 16 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {categories.map(({ key, label, description }) => (
+                  <div key={key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div>
+                      <div style={{ fontWeight: 500, fontSize: 14 }}>{label}</div>
+                      <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #666)', marginTop: 2 }}>{description}</div>
+                    </div>
+                    <button
+                      className={`settings-sync-toggle ${syncPrefs[key] ? 'settings-sync-toggle--on' : ''}`}
+                      role="switch"
+                      aria-checked={Boolean(syncPrefs[key])}
+                      onClick={() => void toggle(key)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </Card>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -199,6 +199,9 @@ declare global {
       optOutAutoRevoke: (origin: string, permissionType: string) => Promise<void>;
       getSyncPrefs: () => Promise<SyncPrefs>;
       setSyncPrefs: (patch: object) => Promise<boolean>;
+      setSyncPassphrase: (passphrase: string) => Promise<boolean>;
+      verifySyncPassphrase: (passphrase: string) => Promise<boolean>;
+      clearSyncPassphrase: () => Promise<void>;
     };
   }
 }
@@ -219,12 +222,13 @@ interface SyncPrefs {
   savedTabGroups: boolean;
   extensions: boolean;
   settings: boolean;
+  encryptionEnabled: boolean;
 }
 
 const DEFAULT_SYNC_PREFS: SyncPrefs = {
   enabled: false, syncEverything: true, bookmarks: true, readingList: true,
   passwords: true, addresses: true, payments: true, historyAndTabs: true,
-  savedTabGroups: true, extensions: true, settings: true,
+  savedTabGroups: true, extensions: true, settings: true, encryptionEnabled: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -2751,6 +2755,11 @@ function SettingsInner(): React.ReactElement {
 function SyncTab(): React.ReactElement {
   const [syncPrefs, setSyncPrefsState] = useState<SyncPrefs>(DEFAULT_SYNC_PREFS);
   const [saving, setSaving] = useState(false);
+  const [showPassphraseForm, setShowPassphraseForm] = useState(false);
+  const [newPassphrase, setNewPassphrase] = useState('');
+  const [confirmPassphrase, setConfirmPassphrase] = useState('');
+  const [passphraseError, setPassphraseError] = useState('');
+  const [passphraseSaved, setPassphraseSaved] = useState(false);
 
   useEffect(() => {
     void window.settingsAPI.getSyncPrefs().then((p: SyncPrefs) => setSyncPrefsState(p));
@@ -2851,6 +2860,87 @@ function SyncTab(): React.ReactElement {
               </div>
             </Card>
           )}
+
+          {/* Encryption passphrase section */}
+          <Card style={{ marginTop: 16 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div>
+                <div style={{ fontWeight: 500 }}>Encrypt synced data with your own passphrase</div>
+                <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #666)', marginTop: 2 }}>
+                  {syncPrefs.encryptionEnabled
+                    ? 'Your synced data is encrypted with your passphrase. Payment methods are excluded.'
+                    : 'Add a passphrase to encrypt all synced data. Payment methods via Google Pay are not encrypted.'}
+                </div>
+              </div>
+              <button
+                className={`settings-sync-toggle ${syncPrefs.encryptionEnabled ? 'settings-sync-toggle--on' : ''}`}
+                role="switch"
+                aria-checked={syncPrefs.encryptionEnabled}
+                onClick={() => {
+                  if (syncPrefs.encryptionEnabled) {
+                    void window.settingsAPI.clearSyncPassphrase().then(() => {
+                      setSyncPrefsState({ ...syncPrefs, encryptionEnabled: false });
+                      setPassphraseSaved(false);
+                      setShowPassphraseForm(false);
+                    });
+                  } else {
+                    setShowPassphraseForm(true);
+                  }
+                }}
+              />
+            </div>
+
+            {showPassphraseForm && !syncPrefs.encryptionEnabled && (
+              <div style={{ marginTop: 16, borderTop: '1px solid var(--color-border, #e0e0e0)', paddingTop: 16 }}>
+                <div style={{ marginBottom: 8, fontSize: 13, fontWeight: 500 }}>Set encryption passphrase</div>
+                <div style={{ marginBottom: 8 }}>
+                  <input
+                    type="password"
+                    value={newPassphrase}
+                    onChange={(e) => { setNewPassphrase(e.target.value); setPassphraseError(''); }}
+                    placeholder="Passphrase (min 8 characters)"
+                    style={{ width: '100%', padding: '6px 8px', borderRadius: 4, border: '1px solid var(--color-border, #ccc)', fontSize: 13, boxSizing: 'border-box' }}
+                  />
+                </div>
+                <div style={{ marginBottom: 8 }}>
+                  <input
+                    type="password"
+                    value={confirmPassphrase}
+                    onChange={(e) => { setConfirmPassphrase(e.target.value); setPassphraseError(''); }}
+                    placeholder="Confirm passphrase"
+                    style={{ width: '100%', padding: '6px 8px', borderRadius: 4, border: '1px solid var(--color-border, #ccc)', fontSize: 13, boxSizing: 'border-box' }}
+                  />
+                </div>
+                {passphraseError && (
+                  <div style={{ color: 'var(--color-danger, #d32f2f)', fontSize: 12, marginBottom: 8 }}>{passphraseError}</div>
+                )}
+                {passphraseSaved && (
+                  <div style={{ color: 'var(--color-success, #2e7d32)', fontSize: 12, marginBottom: 8 }}>Passphrase saved successfully.</div>
+                )}
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      if (newPassphrase.length < 8) { setPassphraseError('Passphrase must be at least 8 characters.'); return; }
+                      if (newPassphrase !== confirmPassphrase) { setPassphraseError('Passphrases do not match.'); return; }
+                      void window.settingsAPI.setSyncPassphrase(newPassphrase).then((ok) => {
+                        if (ok) {
+                          setSyncPrefsState({ ...syncPrefs, encryptionEnabled: true });
+                          setShowPassphraseForm(false);
+                          setPassphraseSaved(true);
+                          setNewPassphrase('');
+                          setConfirmPassphrase('');
+                        } else {
+                          setPassphraseError('Failed to save passphrase. Try again.');
+                        }
+                      });
+                    }}
+                  >Save passphrase</Button>
+                  <Button size="sm" variant="secondary" onClick={() => { setShowPassphraseForm(false); setNewPassphrase(''); setConfirmPassphrase(''); setPassphraseError(''); }}>Cancel</Button>
+                </div>
+              </div>
+            )}
+          </Card>
         </>
       )}
     </div>

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2753,6 +2753,7 @@ function SettingsInner(): React.ReactElement {
 // ---------------------------------------------------------------------------
 
 function SyncTab(): React.ReactElement {
+  const toast = useToast();
   const [syncPrefs, setSyncPrefsState] = useState<SyncPrefs>(DEFAULT_SYNC_PREFS);
   const [saving, setSaving] = useState(false);
   const [showPassphraseForm, setShowPassphraseForm] = useState(false);
@@ -2766,6 +2767,7 @@ function SyncTab(): React.ReactElement {
   }, []);
 
   const toggle = useCallback(async (key: keyof SyncPrefs) => {
+    const previous = syncPrefs;
     const next = { ...syncPrefs, [key]: !syncPrefs[key] };
     // If toggling syncEverything ON, enable all data categories (but not encryption settings)
     const NON_CATEGORY_KEYS = new Set(['enabled', 'syncEverything', 'encryptionEnabled']);
@@ -2780,10 +2782,13 @@ function SyncTab(): React.ReactElement {
     setSaving(true);
     try {
       await window.settingsAPI.setSyncPrefs(next);
+    } catch (err) {
+      setSyncPrefsState(previous);
+      toast.show({ variant: 'error', title: 'Failed to update sync setting', message: (err as Error).message });
     } finally {
       setSaving(false);
     }
-  }, [syncPrefs]);
+  }, [syncPrefs, toast]);
 
   const categories: Array<{ key: keyof SyncPrefs; label: string; description: string }> = [
     { key: 'bookmarks',      label: 'Bookmarks',             description: 'Sync bookmarks across devices' },
@@ -2882,11 +2887,15 @@ function SyncTab(): React.ReactElement {
                 aria-checked={syncPrefs.encryptionEnabled}
                 onClick={() => {
                   if (syncPrefs.encryptionEnabled) {
-                    void window.settingsAPI.clearSyncPassphrase().then(() => {
-                      setSyncPrefsState({ ...syncPrefs, encryptionEnabled: false });
-                      setPassphraseSaved(false);
-                      setShowPassphraseForm(false);
-                    });
+                    void window.settingsAPI.clearSyncPassphrase()
+                      .then(() => {
+                        setSyncPrefsState({ ...syncPrefs, encryptionEnabled: false });
+                        setPassphraseSaved(false);
+                        setShowPassphraseForm(false);
+                      })
+                      .catch((err: Error) => {
+                        toast.show({ variant: 'error', title: 'Failed to clear passphrase', message: err.message });
+                      });
                   } else {
                     setShowPassphraseForm(true);
                   }
@@ -2927,17 +2936,21 @@ function SyncTab(): React.ReactElement {
                     onClick={() => {
                       if (newPassphrase.length < 8) { setPassphraseError('Passphrase must be at least 8 characters.'); return; }
                       if (newPassphrase !== confirmPassphrase) { setPassphraseError('Passphrases do not match.'); return; }
-                      void window.settingsAPI.setSyncPassphrase(newPassphrase).then((ok) => {
-                        if (ok) {
-                          setSyncPrefsState({ ...syncPrefs, encryptionEnabled: true });
-                          setShowPassphraseForm(false);
-                          setPassphraseSaved(true);
-                          setNewPassphrase('');
-                          setConfirmPassphrase('');
-                        } else {
-                          setPassphraseError('Failed to save passphrase. Try again.');
-                        }
-                      });
+                      void window.settingsAPI.setSyncPassphrase(newPassphrase)
+                        .then((ok) => {
+                          if (ok) {
+                            setSyncPrefsState({ ...syncPrefs, encryptionEnabled: true });
+                            setShowPassphraseForm(false);
+                            setPassphraseSaved(true);
+                            setNewPassphrase('');
+                            setConfirmPassphrase('');
+                          } else {
+                            setPassphraseError('Failed to save passphrase. Try again.');
+                          }
+                        })
+                        .catch((err: Error) => {
+                          setPassphraseError(`Error: ${err.message}`);
+                        });
                     }}
                   >Save passphrase</Button>
                   <Button size="sm" variant="secondary" onClick={() => { setShowPassphraseForm(false); setNewPassphrase(''); setConfirmPassphrase(''); setPassphraseError(''); }}>Cancel</Button>

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2767,10 +2767,11 @@ function SyncTab(): React.ReactElement {
 
   const toggle = useCallback(async (key: keyof SyncPrefs) => {
     const next = { ...syncPrefs, [key]: !syncPrefs[key] };
-    // If toggling syncEverything ON, also enable all categories
+    // If toggling syncEverything ON, enable all data categories (but not encryption settings)
+    const NON_CATEGORY_KEYS = new Set(['enabled', 'syncEverything', 'encryptionEnabled']);
     if (key === 'syncEverything' && next.syncEverything) {
       Object.keys(DEFAULT_SYNC_PREFS).forEach((k) => {
-        if (k !== 'enabled' && k !== 'syncEverything') {
+        if (!NON_CATEGORY_KEYS.has(k)) {
           (next as Record<string, boolean>)[k] = true;
         }
       });

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2778,8 +2778,11 @@ function SyncTab(): React.ReactElement {
     }
     setSyncPrefsState(next);
     setSaving(true);
-    await window.settingsAPI.setSyncPrefs(next);
-    setSaving(false);
+    try {
+      await window.settingsAPI.setSyncPrefs(next);
+    } finally {
+      setSaving(false);
+    }
   }, [syncPrefs]);
 
   const categories: Array<{ key: keyof SyncPrefs; label: string; description: string }> = [

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2823,6 +2823,7 @@ function SyncTab(): React.ReactElement {
             className={`settings-sync-toggle ${syncPrefs.enabled ? 'settings-sync-toggle--on' : ''}`}
             role="switch"
             aria-checked={syncPrefs.enabled}
+            disabled={saving}
             onClick={() => void toggle('enabled')}
           />
         </div>
@@ -2843,6 +2844,7 @@ function SyncTab(): React.ReactElement {
                 className={`settings-sync-toggle ${syncPrefs.syncEverything ? 'settings-sync-toggle--on' : ''}`}
                 role="switch"
                 aria-checked={syncPrefs.syncEverything}
+                disabled={saving}
                 onClick={() => void toggle('syncEverything')}
               />
             </div>
@@ -2862,6 +2864,7 @@ function SyncTab(): React.ReactElement {
                       className={`settings-sync-toggle ${syncPrefs[key] ? 'settings-sync-toggle--on' : ''}`}
                       role="switch"
                       aria-checked={Boolean(syncPrefs[key])}
+                      disabled={saving}
                       onClick={() => void toggle(key)}
                     />
                   </div>

--- a/my-app/src/renderer/settings/settings.css
+++ b/my-app/src/renderer/settings/settings.css
@@ -707,3 +707,41 @@
   line-height: var(--line-height-relaxed);
   margin-top: -2px;
 }
+
+/* ---------------------------------------------------------------------------
+   Sync toggle button (button[role="switch"] style)
+--------------------------------------------------------------------------- */
+
+.settings-sync-toggle {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  border: none;
+  background: var(--color-bg-overlay, #e0e0e0);
+  cursor: pointer;
+  transition: background var(--duration-normal, 0.15s) var(--ease-out, ease);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.settings-sync-toggle::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  transition: transform var(--duration-normal, 0.15s) var(--ease-out, ease);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.settings-sync-toggle--on {
+  background: var(--color-accent-default, #1a73e8);
+}
+
+.settings-sync-toggle--on::after {
+  transform: translateX(20px);
+}


### PR DESCRIPTION
## Summary

- Adds Sync tab to Settings with master on/off toggle
- When enabled, shows 'Sync everything' toggle plus 9 granular category toggles (bookmarks, passwords, history, etc.)
- Toggle states persisted to preferences.json
- No sync backend (UI-only, with preference storage for future backend)

## Test plan
- [ ] Settings → Sync tab appears in sidebar
- [ ] Toggle 'Sync is on' → state persists across restarts
- [ ] 'Sync everything' ON hides individual category toggles
- [ ] 'Sync everything' OFF shows 9 granular toggles
- [ ] Each category toggle saves independently

Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sync tab in Settings with a master switch, “Sync everything,” nine granular toggles, and optional passphrase encryption. Preferences and passphrase state persist via IPC/preload; PBKDF2 uses a per-passphrase random salt, the renderer never sees credential data, and “Sync everything” does not affect encryption (aligns with #48 and #49).

- **New Features**
  - Sync tab with a master “Sync is on” switch and a “Sync everything” toggle; when off, show nine category toggles.
  - Passphrase encryption with PBKDF2; UI to set, verify, and clear.
  - Persistence via IPC/preload: `settings:get-sync-prefs`, `settings:set-sync-prefs`, `settings:set-sync-passphrase`, `settings:verify-sync-passphrase`, `settings:clear-sync-passphrase`; `getSyncPrefs`, `setSyncPrefs`, `setSyncPassphrase`, `verifySyncPassphrase`, `clearSyncPassphrase`.
  - New CSS switch component for sync toggles.

- **Bug Fixes**
  - `getSyncPrefs` strips `encryptionKeyHash`/`encryptionSalt` before returning to the renderer.
  - `setSyncPrefs` whitelists known boolean keys to block arbitrary data.
  - Passphrase verify supports legacy static-salt records and auto-upgrades to random salt.
  - Toggle and passphrase actions now handle errors with UI rollback; “Saving…” indicator no longer sticks.
  - Disable sync toggles while a save is in flight to prevent concurrent state mutations.

<sup>Written for commit 9e0401b70d81f4cd89c8b29f8ceb4e14b779a812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

