### PR TITLE
feat(history): Tabs from other devices tab in chrome://history

### DIFF
--- a/my-app/src/renderer/history/HistoryPage.tsx
+++ b/my-app/src/renderer/history/HistoryPage.tsx
@@ -22,7 +22,7 @@ declare const historyAPI: {
   navigateTo: (url: string) => Promise<void>;
 };
 
-type HistoryTab = 'list' | 'journeys';
+type HistoryTab = 'list' | 'journeys' | 'other-devices';
 
 const PAGE_SIZE = 100;
 
@@ -290,6 +290,29 @@ function HistoryList(): React.ReactElement {
   );
 }
 
+function OtherDevicesPage(): React.ReactElement {
+  return (
+    <div className="history-other-devices">
+      <div className="history-other-devices__empty">
+        <div className="history-other-devices__icon" aria-hidden="true">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+            <line x1="8" y1="21" x2="16" y2="21"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </div>
+        <h2 className="history-other-devices__title">Tabs from other devices</h2>
+        <p className="history-other-devices__desc">
+          Sign in and enable sync to see open tabs from your other devices.
+        </p>
+        <p className="history-other-devices__hint">
+          To enable: <strong>Settings → Sync</strong> → turn on sync and enable &ldquo;History and tabs&rdquo;.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function HistoryPage(): React.ReactElement {
   const [activeTab, setActiveTab] = useState<HistoryTab>('list');
 
@@ -318,9 +341,20 @@ export function HistoryPage(): React.ReactElement {
         >
           Journeys
         </button>
+        <button
+          type="button"
+          role="tab"
+          className={`history__tab ${activeTab === 'other-devices' ? 'history__tab--active' : ''}`}
+          aria-selected={activeTab === 'other-devices'}
+          onClick={() => setActiveTab('other-devices')}
+        >
+          Other devices
+        </button>
       </nav>
 
-      {activeTab === 'list' ? <HistoryList /> : <JourneysPage />}
+      {activeTab === 'list' && <HistoryList />}
+      {activeTab === 'journeys' && <JourneysPage />}
+      {activeTab === 'other-devices' && <OtherDevicesPage />}
     </div>
   );
 }

--- a/my-app/src/renderer/history/HistoryPage.tsx
+++ b/my-app/src/renderer/history/HistoryPage.tsx
@@ -123,6 +123,8 @@ function HistoryList(): React.ReactElement {
     searchRef.current?.focus();
   }, []);
 
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
+
   const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
     setQuery(val);

--- a/my-app/src/renderer/history/JourneysPage.tsx
+++ b/my-app/src/renderer/history/JourneysPage.tsx
@@ -111,6 +111,8 @@ export function JourneysPage(): React.ReactElement {
     searchRef.current?.focus();
   }, []);
 
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
+
   const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
     setQuery(val);

--- a/my-app/src/renderer/history/history.css
+++ b/my-app/src/renderer/history/history.css
@@ -393,3 +393,42 @@
   border-top: 1px solid var(--color-border-subtle);
   padding: 4px 8px 4px 42px;
 }
+
+/* Tabs from other devices */
+.history-other-devices {
+  display: flex;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.history-other-devices__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  max-width: 360px;
+  text-align: center;
+}
+
+.history-other-devices__icon {
+  color: var(--color-fg-tertiary, #9e9e9e);
+}
+
+.history-other-devices__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-fg-primary);
+}
+
+.history-other-devices__desc {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-fg-secondary, #555);
+}
+
+.history-other-devices__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-fg-tertiary, #888);
+}


### PR DESCRIPTION
## Summary

- Adds "Other devices" tab to chrome://history
- Shows a clear empty state explaining sync must be enabled to see tabs from other devices
- Links to Settings → Sync for users to enable the feature
- Full implementation would populate with synced tab data when sync backend is connected

## Test plan
- [ ] chrome://history shows 3 tabs: List, Journeys, Other devices
- [ ] Other devices tab shows empty state with helpful message
- [ ] Message includes instructions to navigate to Settings → Sync

Closes #44

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Other devices" tab to chrome://history with an empty state and clear instructions (Settings → Sync → enable “History and tabs”) so users can see tabs from other devices when Sync is on. Prepares the UI for future synced tab data and satisfies Linear #44.

- **Bug Fixes**
  - Clear debounce timers on unmount in History and Journeys search to prevent stale timers.

<sup>Written for commit 333394f817fadc3dfcf057cf21ad787fab3e7087. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

