### PR TITLE
feat(a11y): Live Caption toggle in Accessibility settings

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1697,6 +1697,14 @@ function switchTabRelative(delta: number): void {
 // ---------------------------------------------------------------------------
 ipcMain.handle('shell:get-platform', () => process.platform);
 
+// Issue #104 — Live Caption: toggle caption overlay in the shell window.
+ipcMain.handle('live-caption:toggle', (_e, enabled: boolean) => {
+  if (shellWindow && !shellWindow.isDestroyed()) {
+    shellWindow.webContents.send('live-caption:state-changed', enabled);
+  }
+  return true;
+});
+
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {
   if (!shellWindow || !tabManager) {

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -12,7 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app, ipcMain, session } from 'electron';
+import { app, BrowserWindow, ipcMain, session } from 'electron';
 import { mainLogger } from '../logger';
 import type { AccountStore } from '../identity/AccountStore';
 import type { KeychainStore } from '../identity/KeychainStore';
@@ -695,6 +695,12 @@ function handleSetLiveCaption(
   if (patch.enabled !== undefined) mergePrefs({ liveCaptionEnabled: Boolean(patch.enabled) });
   if (typeof patch.language === 'string') mergePrefs({ liveCaptionLanguage: patch.language });
   mainLogger.info(`${CH_SET_LIVE_CAPTION}.ok`);
+  const current = handleGetLiveCaption();
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('live-caption:state-changed', current);
+    }
+  }
   return true;
 }
 

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -93,6 +93,8 @@ const CH_GET_DNT_ENABLED     = 'settings:get-dnt-enabled';
 const CH_SET_DNT_ENABLED     = 'settings:set-dnt-enabled';
 const CH_GET_GPC_ENABLED     = 'settings:get-gpc-enabled';
 const CH_SET_GPC_ENABLED     = 'settings:set-gpc-enabled';
+const CH_GET_LIVE_CAPTION    = 'settings:get-live-caption';
+const CH_SET_LIVE_CAPTION    = 'settings:set-live-caption';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -133,6 +135,8 @@ interface Preferences {
   theme?: string;
   fontSize?: number;
   defaultPageZoom?: number;
+  liveCaptionEnabled?: boolean;
+  liveCaptionLanguage?: string;
   [key: string]: unknown;
 }
 
@@ -671,6 +675,29 @@ export function refreshPrivacyHeaders(): void {
   mainLogger.info('privacy.refreshHeaders.installed');
 }
 
+function handleGetLiveCaption(): { enabled: boolean; language: string } {
+  mainLogger.info(CH_GET_LIVE_CAPTION);
+  const prefs = readPrefs();
+  const result = {
+    enabled: prefs.liveCaptionEnabled === true,
+    language: typeof prefs.liveCaptionLanguage === 'string' ? prefs.liveCaptionLanguage : 'en-US',
+  };
+  mainLogger.info(`${CH_GET_LIVE_CAPTION}.ok`, result);
+  return result;
+}
+
+function handleSetLiveCaption(
+  _event: Electron.IpcMainInvokeEvent,
+  patch: { enabled?: boolean; language?: string },
+): boolean {
+  if (typeof patch !== 'object' || patch === null) return false;
+  mainLogger.info(CH_SET_LIVE_CAPTION, { patch });
+  if (patch.enabled !== undefined) mergePrefs({ liveCaptionEnabled: Boolean(patch.enabled) });
+  if (typeof patch.language === 'string') mergePrefs({ liveCaptionLanguage: patch.language });
+  mainLogger.info(`${CH_SET_LIVE_CAPTION}.ok`);
+  return true;
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -719,10 +746,12 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_SET_DNT_ENABLED,    handleSetDntEnabled);
   ipcMain.handle(CH_GET_GPC_ENABLED,    handleGetGpcEnabled);
   ipcMain.handle(CH_SET_GPC_ENABLED,    handleSetGpcEnabled);
+  ipcMain.handle(CH_GET_LIVE_CAPTION,   handleGetLiveCaption);
+  ipcMain.handle(CH_SET_LIVE_CAPTION,   handleSetLiveCaption);
 
   refreshPrivacyHeaders();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 25 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 27 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -753,6 +782,8 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_SET_DNT_ENABLED);
   ipcMain.removeHandler(CH_GET_GPC_ENABLED);
   ipcMain.removeHandler(CH_SET_GPC_ENABLED);
+  ipcMain.removeHandler(CH_GET_LIVE_CAPTION);
+  ipcMain.removeHandler(CH_SET_LIVE_CAPTION);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -232,6 +232,12 @@ export interface SettingsAPI {
   /** Set whether Global Privacy Control header is enabled */
   setGpcEnabled: (enabled: boolean) => Promise<void>;
 
+  /** Get Live Caption preferences (enabled state and language) */
+  getLiveCaption: () => Promise<{ enabled: boolean; language: string }>;
+
+  /** Set Live Caption preferences */
+  setLiveCaption: (patch: { enabled?: boolean; language?: string }) => Promise<boolean>;
+
   /** Get all global content category defaults */
   getContentCategoryDefaults: () => Promise<Record<ContentCategory, CategoryState>>;
 
@@ -479,6 +485,16 @@ const api: SettingsAPI = {
   setGpcEnabled: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setGpcEnabled', { enabled });
     await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
+  },
+
+  getLiveCaption: async (): Promise<{ enabled: boolean; language: string }> => {
+    console.debug('[settings-preload] getLiveCaption');
+    return ipcRenderer.invoke('settings:get-live-caption') as Promise<{ enabled: boolean; language: string }>;
+  },
+
+  setLiveCaption: async (patch: { enabled?: boolean; language?: string }): Promise<boolean> => {
+    console.debug('[settings-preload] setLiveCaption', { patch });
+    return ipcRenderer.invoke('settings:set-live-caption', patch) as Promise<boolean>;
   },
 
   getContentCategoryDefaults: async (): Promise<Record<ContentCategory, CategoryState>> => {

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -653,8 +653,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     // Issue #104 — Live Caption: receive state changes from main process
-    liveCaptionStateChanged: (cb: (enabled: boolean) => void): (() => void) => {
-      const handler = (_e: Electron.IpcRendererEvent, enabled: boolean) => cb(enabled);
+    liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, state: { enabled: boolean; language: string }) => cb(state);
       ipcRenderer.on('live-caption:state-changed', handler);
       return () => ipcRenderer.removeListener('live-caption:state-changed', handler);
     },

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -382,6 +382,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('ntp:pick-background-image'),
   },
 
+  // Issue #104 — Live Caption: get current persisted state for initial hydration
+  liveCaption: {
+    getState: (): Promise<{ enabled: boolean; language: string }> =>
+      ipcRenderer.invoke('settings:get-live-caption') as Promise<{ enabled: boolean; language: string }>,
+  },
+
   // Event listeners
   on: {
     tabsState: (

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -651,6 +651,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('open-tab-search', handler);
       return () => ipcRenderer.removeListener('open-tab-search', handler);
     },
+
+    // Issue #104 — Live Caption: receive state changes from main process
+    liveCaptionStateChanged: (cb: (enabled: boolean) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, enabled: boolean) => cb(enabled);
+      ipcRenderer.on('live-caption:state-changed', handler);
+      return () => ipcRenderer.removeListener('live-caption:state-changed', handler);
+    },
   },
 
   // Profiles — current profile info + switch

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2618,7 +2618,8 @@ function AccessibilityTab(): React.ReactElement {
   async function handleLiveCaptionToggle(checked: boolean): Promise<void> {
     setLiveCaptionEnabled(checked);
     try {
-      await window.settingsAPI.setLiveCaption({ enabled: checked });
+      const ok = await window.settingsAPI.setLiveCaption({ enabled: checked });
+      if (!ok) throw new Error('Settings update failed');
       toast.show({
         variant: 'success',
         title: checked ? 'Live Caption enabled' : 'Live Caption disabled',
@@ -2639,7 +2640,8 @@ function AccessibilityTab(): React.ReactElement {
     try {
       await window.settingsAPI.setLiveCaption({ language });
     } catch (err) {
-      setLiveCaptionLanguage(previous);
+      // Only roll back if the user hasn't already selected a different language.
+      setLiveCaptionLanguage((cur) => (cur === language ? previous : cur));
       toast.show({
         variant: 'error',
         title: 'Failed to update language',

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2634,10 +2634,12 @@ function AccessibilityTab(): React.ReactElement {
   }
 
   async function handleLanguageChange(language: string): Promise<void> {
+    const previous = liveCaptionLanguage;
     setLiveCaptionLanguage(language);
     try {
       await window.settingsAPI.setLiveCaption({ language });
     } catch (err) {
+      setLiveCaptionLanguage(previous);
       toast.show({
         variant: 'error',
         title: 'Failed to update language',

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -35,8 +35,9 @@ const TAB_PASSWORDS    = 'passwords'        as const;
 const TAB_ZOOM         = 'site-zoom'        as const;
 const TAB_CONTENT      = 'content'          as const;
 const TAB_PERMISSIONS  = 'permissions'     as const;
-const TAB_ADDRESSES    = 'addresses'        as const;
-const TAB_PAYMENTS     = 'payments'         as const;
+const TAB_ADDRESSES       = 'addresses'        as const;
+const TAB_PAYMENTS        = 'payments'         as const;
+const TAB_ACCESSIBILITY   = 'accessibility'    as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -51,6 +52,7 @@ type TabId =
   | typeof TAB_PERMISSIONS
   | typeof TAB_ADDRESSES
   | typeof TAB_PAYMENTS
+  | typeof TAB_ACCESSIBILITY
   | typeof TAB_DANGER;
 
 const TABS: Array<{ id: TabId; label: string }> = [
@@ -64,9 +66,10 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_ZOOM,       label: 'Site Zoom' },
   { id: TAB_CONTENT,    label: 'Content' },
   { id: TAB_PERMISSIONS, label: 'Permissions' },
-  { id: TAB_ADDRESSES,   label: 'Addresses' },
-  { id: TAB_PAYMENTS,    label: 'Payments' },
-  { id: TAB_DANGER,     label: 'Danger Zone' },
+  { id: TAB_ADDRESSES,      label: 'Addresses' },
+  { id: TAB_PAYMENTS,       label: 'Payments' },
+  { id: TAB_ACCESSIBILITY,  label: 'Accessibility' },
+  { id: TAB_DANGER,         label: 'Danger Zone' },
 ];
 
 const THEME_ONBOARDING = 'onboarding';
@@ -164,6 +167,8 @@ declare global {
       setDntEnabled: (enabled: boolean) => Promise<void>;
       getGpcEnabled: () => Promise<boolean>;
       setGpcEnabled: (enabled: boolean) => Promise<void>;
+      getLiveCaption: () => Promise<{ enabled: boolean; language: string }>;
+      setLiveCaption: (patch: { enabled?: boolean; language?: string }) => Promise<boolean>;
       getContentCategoryDefaults: () => Promise<Record<string, string>>;
       setContentCategoryDefault: (category: string, state: string) => Promise<void>;
       getContentCategorySite: (origin: string) => Promise<Array<{ origin: string; category: string; state: string; updatedAt: number }>>;
@@ -2581,6 +2586,118 @@ function PaymentsTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Accessibility tab
+// ---------------------------------------------------------------------------
+
+const LIVE_CAPTION_LANGUAGE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'en-US', label: 'English (US)' },
+  { value: 'en-GB', label: 'English (UK)' },
+  { value: 'de-DE', label: 'German' },
+  { value: 'fr-FR', label: 'French' },
+  { value: 'es-ES', label: 'Spanish' },
+  { value: 'ja-JP', label: 'Japanese' },
+];
+
+function AccessibilityTab(): React.ReactElement {
+  const toast = useToast();
+  const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void window.settingsAPI.getLiveCaption().then(({ enabled, language }) => {
+      setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
+    }).catch(() => {
+      // ignore; leave defaults
+    }).finally(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleLiveCaptionToggle(checked: boolean): Promise<void> {
+    setLiveCaptionEnabled(checked);
+    try {
+      await window.settingsAPI.setLiveCaption({ enabled: checked });
+      toast.show({
+        variant: 'success',
+        title: checked ? 'Live Caption enabled' : 'Live Caption disabled',
+      });
+    } catch (err) {
+      setLiveCaptionEnabled(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleLanguageChange(language: string): Promise<void> {
+    setLiveCaptionLanguage(language);
+    try {
+      await window.settingsAPI.setLiveCaption({ language });
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update language',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Accessibility</h2>
+      <p className="settings-section-desc">
+        Configure accessibility features to improve your browsing experience.
+      </p>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">Live Caption</span>
+            <span className="settings-toggle-desc">
+              Automatically caption speech in audio and video
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={liveCaptionEnabled}
+              disabled={loading}
+              onChange={(e) => void handleLiveCaptionToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+
+        {liveCaptionEnabled && (
+          <div className="settings-field" style={{ marginTop: 12 }}>
+            <label htmlFor="live-caption-language" className="settings-label">
+              Caption language
+            </label>
+            <select
+              id="live-caption-language"
+              className="settings-input"
+              value={liveCaptionLanguage}
+              disabled={loading}
+              onChange={(e) => void handleLanguageChange(e.target.value)}
+            >
+              {LIVE_CAPTION_LANGUAGE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Inner app (uses useToast — must be inside ToastProvider)
 // ---------------------------------------------------------------------------
 
@@ -2643,9 +2760,10 @@ function SettingsInner(): React.ReactElement {
     [TAB_ZOOM]:       <SiteZoomTab />,
     [TAB_PERMISSIONS]: <PermissionsTab />,
     [TAB_ADDRESSES]:   <AddressesTab />,
-    [TAB_PAYMENTS]:    <PaymentsTab />,
-    [TAB_CONTENT]:    <ContentCategoriesTab />,
-    [TAB_DANGER]:     <DangerZoneTab />,
+    [TAB_PAYMENTS]:       <PaymentsTab />,
+    [TAB_CONTENT]:        <ContentCategoriesTab />,
+    [TAB_ACCESSIBILITY]:  <AccessibilityTab />,
+    [TAB_DANGER]:         <DangerZoneTab />,
   };
 
   return (

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -153,6 +153,9 @@ declare const electronAPI: {
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
     liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void) => () => void;
   };
+  liveCaption: {
+    getState: () => Promise<{ enabled: boolean; language: string }>;
+  };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
     dismiss: (promptId: string) => Promise<void>;
@@ -191,7 +194,7 @@ export function WindowChrome(): React.ReactElement {
   // PiP state
   const [pipActive, setPipActive] = useState(false);
 
-  // Live Caption state
+  // Live Caption state — hydrated from prefs on mount
   const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
   const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
   const [captionText, setCaptionText] = useState('');
@@ -369,6 +372,16 @@ export function WindowChrome(): React.ReactElement {
   }, [bookmarksTree?.visibility]);
 
   // ---------------------------------------------------------------------------
+  // Live Caption — hydrate from persisted prefs on mount
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    electronAPI.liveCaption.getState().then(({ enabled, language }) => {
+      setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
+    }).catch(() => {});
+  }, []);
+
+  // ---------------------------------------------------------------------------
   // Live Caption — Web Speech API
   // ---------------------------------------------------------------------------
   useEffect(() => {
@@ -391,9 +404,13 @@ export function WindowChrome(): React.ReactElement {
       }
       setCaptionText(text);
     };
-    rec.onerror = () => { /* ignore */ };
+    let fatalError = false;
+    rec.onerror = (ev: any) => {
+      const fatal = ['not-allowed', 'service-not-available', 'audio-capture'];
+      if (fatal.includes(ev.error)) fatalError = true;
+    };
     rec.onend = () => {
-      if (liveCaptionEnabled) rec.start();
+      if (liveCaptionEnabled && !fatalError) rec.start();
     };
     rec.start();
     recognitionRef.current = rec;

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -151,7 +151,7 @@ declare const electronAPI: {
     downloadDone: (cb: (dl: DownloadItemDTO) => void) => () => void;
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
-    liveCaptionStateChanged: (cb: (enabled: boolean) => void) => () => void;
+    liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -193,7 +193,13 @@ export function WindowChrome(): React.ReactElement {
 
   // Live Caption state
   const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
   const [captionText, setCaptionText] = useState('');
+  const captionPos = useRef({ x: 0, y: 0 });
+  const captionDragStart = useRef<{ mx: number; my: number; ox: number; oy: number } | null>(null);
+  const captionRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
 
   // Side panel state
   const [sidePanelOpen, setSidePanelOpen] = useState(false);
@@ -338,8 +344,9 @@ export function WindowChrome(): React.ReactElement {
       setFocusBookmarksBarTick((n) => n + 1);
     });
 
-    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged((enabled) => {
+    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged(({ enabled, language }) => {
       setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
       if (!enabled) setCaptionText('');
     });
 
@@ -360,6 +367,41 @@ export function WindowChrome(): React.ReactElement {
       unsubLiveCaptionState();
     };
   }, [bookmarksTree?.visibility]);
+
+  // ---------------------------------------------------------------------------
+  // Live Caption — Web Speech API
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    const SR: (new () => any) | undefined = w.SpeechRecognition ?? w.webkitSpeechRecognition;
+    if (!liveCaptionEnabled || !SR) {
+      recognitionRef.current?.stop();
+      recognitionRef.current = null;
+      return;
+    }
+    const rec = new SR();
+    rec.lang = liveCaptionLanguage;
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.onresult = (ev: any) => {
+      let text = '';
+      for (let i = ev.resultIndex; i < ev.results.length; i++) {
+        text += ev.results[i][0].transcript;
+      }
+      setCaptionText(text);
+    };
+    rec.onerror = () => { /* ignore */ };
+    rec.onend = () => {
+      if (liveCaptionEnabled) rec.start();
+    };
+    rec.start();
+    recognitionRef.current = rec;
+    return () => {
+      rec.onend = null;
+      rec.stop();
+    };
+  }, [liveCaptionEnabled, liveCaptionLanguage]);
 
   // ---------------------------------------------------------------------------
   // Download IPC subscriptions
@@ -704,7 +746,43 @@ export function WindowChrome(): React.ReactElement {
       <StatusBar url={hoveredUrl} />
 
       {liveCaptionEnabled && (
-        <div className="caption-overlay" aria-live="polite" aria-label="Live captions">
+        <div
+          ref={captionRef}
+          className="caption-overlay"
+          aria-live="polite"
+          aria-label="Live captions"
+          style={captionPos.current.x || captionPos.current.y ? {
+            bottom: 'auto',
+            top: captionPos.current.y,
+            left: captionPos.current.x,
+            transform: 'none',
+          } : undefined}
+          onMouseDown={(e) => {
+            const el = captionRef.current;
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            captionDragStart.current = { mx: e.clientX, my: e.clientY, ox: rect.left, oy: rect.top };
+            const onMove = (ev: MouseEvent) => {
+              if (!captionDragStart.current) return;
+              const dx = ev.clientX - captionDragStart.current.mx;
+              const dy = ev.clientY - captionDragStart.current.my;
+              captionPos.current = { x: captionDragStart.current.ox + dx, y: captionDragStart.current.oy + dy };
+              if (el) {
+                el.style.bottom = 'auto';
+                el.style.top = captionPos.current.y + 'px';
+                el.style.left = captionPos.current.x + 'px';
+                el.style.transform = 'none';
+              }
+            };
+            const onUp = () => {
+              captionDragStart.current = null;
+              window.removeEventListener('mousemove', onMove);
+              window.removeEventListener('mouseup', onUp);
+            };
+            window.addEventListener('mousemove', onMove);
+            window.addEventListener('mouseup', onUp);
+          }}
+        >
           <span className="caption-overlay__text">{captionText || '\u00a0'}</span>
         </div>
       )}

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -151,6 +151,7 @@ declare const electronAPI: {
     downloadDone: (cb: (dl: DownloadItemDTO) => void) => () => void;
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
+    liveCaptionStateChanged: (cb: (enabled: boolean) => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -189,6 +190,10 @@ export function WindowChrome(): React.ReactElement {
 
   // PiP state
   const [pipActive, setPipActive] = useState(false);
+
+  // Live Caption state
+  const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [captionText, setCaptionText] = useState('');
 
   // Side panel state
   const [sidePanelOpen, setSidePanelOpen] = useState(false);
@@ -333,6 +338,11 @@ export function WindowChrome(): React.ReactElement {
       setFocusBookmarksBarTick((n) => n + 1);
     });
 
+    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged((enabled) => {
+      setLiveCaptionEnabled(enabled);
+      if (!enabled) setCaptionText('');
+    });
+
     return () => {
       unsubTabsState();
       unsubTabUpdated();
@@ -347,6 +357,7 @@ export function WindowChrome(): React.ReactElement {
       unsubOpenDialog();
       unsubToggleBar();
       unsubFocusBar();
+      unsubLiveCaptionState();
     };
   }, [bookmarksTree?.visibility]);
 
@@ -691,6 +702,12 @@ export function WindowChrome(): React.ReactElement {
       )}
       <FindBar activeTabId={activeTabId} />
       <StatusBar url={hoveredUrl} />
+
+      {liveCaptionEnabled && (
+        <div className="caption-overlay" aria-live="polite" aria-label="Live captions">
+          <span className="caption-overlay__text">{captionText || '\u00a0'}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2378,6 +2378,7 @@
   left: 50%;
   transform: translateX(-50%);
   max-width: 600px;
+  min-width: 200px;
   background: rgba(0, 0, 0, 0.85);
   color: #fff;
   border-radius: 8px;
@@ -2385,8 +2386,13 @@
   font-size: 16px;
   line-height: 1.5;
   z-index: 9999;
-  pointer-events: none;
+  pointer-events: auto;
   user-select: none;
+  cursor: grab;
+}
+
+.caption-overlay:active {
+  cursor: grabbing;
 }
 
 .caption-overlay__text {

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2367,3 +2367,29 @@
     transition: none;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Live Caption overlay (issue #104)
+   --------------------------------------------------------------------------- */
+
+.caption-overlay {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 600px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 16px;
+  line-height: 1.5;
+  z-index: 9999;
+  pointer-events: none;
+  user-select: none;
+}
+
+.caption-overlay__text {
+  display: block;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

- Adds Accessibility tab to Settings with Live Caption toggle
- Language selector (English US/UK, German, French, Spanish, Japanese)
- Caption overlay at bottom of screen when enabled
- Toggle preference persisted to preferences.json
- IPC bridge for future speech recognition integration

## Test plan
- [ ] Settings → Accessibility tab visible in sidebar
- [ ] Live Caption toggle saves and persists across restart
- [ ] Language dropdown saves selection
- [ ] Caption overlay appears at bottom of browser window when enabled

Closes #104

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Accessibility tab with a Live Caption toggle and language selector, plus a draggable caption overlay in the shell. Uses the Web Speech API to transcribe audio when enabled, persists and hydrates preferences on startup, and syncs state across windows; closes #104.

- **New Features**
  - Settings: Accessibility tab with Live Caption toggle and language dropdown (en-US, en-GB, de-DE, fr-FR, es-ES, ja-JP).
  - Preferences: stored as `liveCaptionEnabled` and `liveCaptionLanguage` in `preferences.json`.
  - IPC/Preload: `settings:get-live-caption`, `settings:set-live-caption`, `live-caption:toggle`, `live-caption:state-changed`; shell preload exposes `electronAPI.liveCaption.getState()` and `electronAPI.on.liveCaptionStateChanged(...)`; broadcasts `{ enabled, language }` to all windows.
  - Shell: hydrates persisted state, starts/stops Web Speech API with the selected language, and shows a draggable caption overlay.

- **Bug Fixes**
  - Speech recognition stops retrying after fatal errors (`not-allowed`, `service-not-available`, `audio-capture`).
  - Language changes roll back only if the selection is still current, and toggle updates verify `setLiveCaption` results before confirming.

<sup>Written for commit 1ea45ffcb98aac501e42ef16b66e57310522fb7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

