### PR TITLE
feat(omnibox): search engine keyword mode and Tab-to-search

### DIFF
--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -40,6 +40,11 @@ const DEFAULT_KEYWORD_ENGINES: Map<string, string> = new Map([
   ['y', 'https://search.yahoo.com/search?p=%s'],
   ['e', 'https://www.ecosia.org/search?q=%s'],
   ['br', 'https://search.brave.com/search?q=%s'],
+  // @-prefixed entries mirror SEARCH_ENGINES in omnibox/providers.ts so that
+  // keyword-mode inputs like "@bing cats" are resolved correctly.
+  ['@bing', 'https://www.bing.com/search?q=%s'],
+  ['@duckduckgo', 'https://duckduckgo.com/?q=%s'],
+  ['@yahoo', 'https://search.yahoo.com/search?p=%s'],
 ]);
 
 let keywordEngines: Map<string, string> = new Map(DEFAULT_KEYWORD_ENGINES);
@@ -73,17 +78,23 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
   }
 
   // 1.5. Keyword search: "keyword query" pattern (e.g. "g react hooks" → Google search)
+  // Also handles "@keyword query" mode-enter inputs (e.g. "@bing cats" → Bing search).
   const firstSpaceIdx = trimmed.indexOf(' ');
   if (firstSpaceIdx > 0 && !HAS_WHITESPACE_RE.test(trimmed.slice(0, firstSpaceIdx))) {
-    const keyword = trimmed.slice(0, firstSpaceIdx).toLowerCase();
+    const rawKeyword = trimmed.slice(0, firstSpaceIdx);
     const query = trimmed.slice(firstSpaceIdx + 1);
-    const template = keywordEngines.get(keyword);
+    // Try exact key first (handles both short keys like "g" and @-prefixed keys like "@bing").
+    const keyLower = rawKeyword.toLowerCase();
+    const template = keywordEngines.get(keyLower) ?? keywordEngines.get(keyLower.replace(/^@/, ''));
     if (template && template.includes('%s') && query.trim()) {
       const url = template.replace('%s', encodeURIComponent(query.trim()));
-      mainLogger.info('navigation.parse.keywordSearch', { keyword, query, url });
+      mainLogger.info('navigation.parse.keywordSearch', { keyword: keyLower, query, url });
       return url;
     }
   }
+
+  // 1.6. @keyword prefix without a query (e.g. "@bing" alone) — treat as regular search/URL.
+  // Handled by fall-through to steps 3–8 below.
 
   // 2. Bookmark / history exact match — try common URL expansions of the raw input
   if (findMatchingUrl) {

--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -78,7 +78,7 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
     const keyword = trimmed.slice(0, firstSpaceIdx).toLowerCase();
     const query = trimmed.slice(firstSpaceIdx + 1);
     const template = keywordEngines.get(keyword);
-    if (template && query.trim()) {
+    if (template && template.includes('%s') && query.trim()) {
       const url = template.replace('%s', encodeURIComponent(query.trim()));
       mainLogger.info('navigation.parse.keywordSearch', { keyword, query, url });
       return url;

--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -28,6 +28,31 @@ const HAS_WHITESPACE_RE = /\s/;
 const GOOGLE_SEARCH_BASE = 'https://www.google.com/search?q=';
 
 // ---------------------------------------------------------------------------
+// Keyword search engines (Tab-to-search / keyword mode).
+// Maps keyword → %s URL template. Populated from SearchEngineStore at runtime;
+// falls back to built-in defaults when the store is unavailable.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KEYWORD_ENGINES: Map<string, string> = new Map([
+  ['g', 'https://www.google.com/search?q=%s'],
+  ['b', 'https://www.bing.com/search?q=%s'],
+  ['d', 'https://duckduckgo.com/?q=%s'],
+  ['y', 'https://search.yahoo.com/search?p=%s'],
+  ['e', 'https://www.ecosia.org/search?q=%s'],
+  ['br', 'https://search.brave.com/search?q=%s'],
+]);
+
+let keywordEngines: Map<string, string> = new Map(DEFAULT_KEYWORD_ENGINES);
+
+export function setKeywordEngines(engines: Map<string, string>): void {
+  keywordEngines = engines;
+}
+
+export function getKeywordEngines(): Map<string, string> {
+  return keywordEngines;
+}
+
+// ---------------------------------------------------------------------------
 // Bookmark / history lookup callback
 // ---------------------------------------------------------------------------
 
@@ -45,6 +70,19 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
   if (EXPLICIT_URL_RE.test(trimmed)) {
     mainLogger.info('navigation.parse.explicitScheme', { input: trimmed });
     return trimmed;
+  }
+
+  // 1.5. Keyword search: "keyword query" pattern (e.g. "g react hooks" → Google search)
+  const firstSpaceIdx = trimmed.indexOf(' ');
+  if (firstSpaceIdx > 0 && !HAS_WHITESPACE_RE.test(trimmed.slice(0, firstSpaceIdx))) {
+    const keyword = trimmed.slice(0, firstSpaceIdx).toLowerCase();
+    const query = trimmed.slice(firstSpaceIdx + 1);
+    const template = keywordEngines.get(keyword);
+    if (template && query.trim()) {
+      const url = template.replace('%s', encodeURIComponent(query.trim()));
+      mainLogger.info('navigation.parse.keywordSearch', { keyword, query, url });
+      return url;
+    }
   }
 
   // 2. Bookmark / history exact match — try common URL expansions of the raw input

--- a/my-app/src/main/omnibox/ipc.ts
+++ b/my-app/src/main/omnibox/ipc.ts
@@ -14,11 +14,13 @@ import type { ShortcutsStore } from './ShortcutsStore';
 import type { HistoryStore } from '../history/HistoryStore';
 import type { BookmarkStore } from '../bookmarks/BookmarkStore';
 import { mainLogger } from '../logger';
+import { getKeywordEngines } from '../navigation';
 
 const CHANNELS = [
   'omnibox:suggest',
   'omnibox:record-selection',
   'omnibox:remove-history',
+  'omnibox:get-keyword-engines',
 ] as const;
 
 export interface OmniboxIpcOptions {
@@ -74,6 +76,21 @@ export function registerOmniboxHandlers(opts: OmniboxIpcOptions): void {
     assertString(id, 'id', 128);
     mainLogger.debug('omnibox:remove-history', { id });
     return historyStore.removeEntry(id);
+  });
+
+  // -------------------------------------------------------------------------
+  // omnibox:get-keyword-engines — returns keyword→name map for Tab-to-search UI.
+  // -------------------------------------------------------------------------
+  ipcMain.handle('omnibox:get-keyword-engines', (): Array<{ keyword: string; name: string; template: string }> => {
+    const engines = getKeywordEngines();
+    const engineNames: Record<string, string> = {
+      g: 'Google', b: 'Bing', d: 'DuckDuckGo', y: 'Yahoo', e: 'Ecosia', br: 'Brave Search',
+    };
+    return Array.from(engines.entries()).map(([keyword, template]) => ({
+      keyword,
+      name: engineNames[keyword] ?? keyword,
+      template,
+    }));
   });
 }
 

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -33,6 +33,7 @@ export type SuggestionType =
   | 'shortcut'
   | 'featured'
   | 'keyword'
+  | 'keyword-search'
   | 'zero-suggest'
   | 'url';
 
@@ -52,6 +53,12 @@ export interface OmniboxSuggestion {
   favicon?: string | null;
   /** Whether pressing → fills the input rather than navigating */
   allowTabCompletion?: boolean;
+  /**
+   * For keyword mode-enter suggestions (type === 'keyword' with allowTabCompletion):
+   * the keyword string (e.g. "@bing") so the URLBar can enter keyword mode
+   * by filling "<keyword> " into the input instead of navigating.
+   */
+  keywordTrigger?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -420,16 +427,18 @@ export function keywordProvider(input: string): OmniboxSuggestion[] {
   const trimmed = input.trim();
   for (const [keyword, engine] of Object.entries(SEARCH_ENGINES)) {
     if (trimmed === keyword) {
-      // Show mode-enter hint
+      // Mode-enter hint: selecting this suggestion fills "<keyword> " into the
+      // input so the user can type a query, rather than navigating immediately.
       return [
         {
           id: `keyword-mode-${keyword}`,
           type: 'keyword',
           title: `Search ${engine.name}`,
           url: engine.template.replace('%s', ''),
-          description: `Press Tab to search ${engine.name}`,
+          description: `Type a search query for ${engine.name}`,
           relevance: 1000,
           allowTabCompletion: true,
+          keywordTrigger: keyword,
         },
       ];
     }
@@ -458,6 +467,7 @@ export function keywordProvider(input: string): OmniboxSuggestion[] {
           description: `Keyword: ${keyword}`,
           relevance: 800,
           allowTabCompletion: true,
+          keywordTrigger: keyword,
         },
       ];
     }

--- a/my-app/src/main/omnibox/providers.ts
+++ b/my-app/src/main/omnibox/providers.ts
@@ -463,7 +463,7 @@ export function keywordProvider(input: string): OmniboxSuggestion[] {
           id: `keyword-autocomplete-${keyword}`,
           type: 'keyword',
           title: `Search ${engine.name}`,
-          url: engine.template.replace('%s', ''),
+          url: engine.template.replace('%s', encodeURIComponent('')),
           description: `Keyword: ${keyword}`,
           relevance: 800,
           allowTabCompletion: true,

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -743,6 +743,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     removeHistory: (id: string): Promise<boolean> =>
       ipcRenderer.invoke('omnibox:remove-history', id),
+
+    getKeywordEngines: (): Promise<Array<{ keyword: string; name: string; template: string }>> =>
+      ipcRenderer.invoke('omnibox:get-keyword-engines'),
   },
 
   // Passwords

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -20,7 +20,8 @@ const SECURE_RE = /^https:\/\//i;
 const INSECURE_RE = /^http:\/\//i;
 // New-tab data: URLs and about:blank are internal placeholders; the omnibox
 // renders them as empty so the "Search or enter address" placeholder shows.
-const BLANK_RE = /^(data:|about:blank$)/i;
+// Only match the app's own internal new-tab page, not arbitrary external URLs.
+const BLANK_RE = /^(data:|about:blank$|[a-z][a-z0-9+.-]*:\/\/[^/]*\/newtab\/newtab\.html)/i;
 const NEWTAB_RE = /\/newtab\/newtab\.html/i;
 
 // Subdomains that Chrome elides from display (trivial/redundant prefixes).
@@ -368,6 +369,15 @@ export function URLBar({
   }, [url, closeDropdown]);
 
   const confirmNavigate = useCallback((target: string, suggestion?: OmniboxSuggestion) => {
+    // Keyword mode-enter: fill "<keyword> " into the input to start keyword
+    // search mode instead of navigating to the (empty) search template URL.
+    if (suggestion?.keywordTrigger) {
+      closeDropdown();
+      setInputValue(suggestion.keywordTrigger + ' ');
+      // Keep focus so the user can immediately type their query.
+      requestAnimationFrame(() => inputRef.current?.focus());
+      return;
+    }
     closeDropdown();
     onNavigate(target);
     if (suggestion) {

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -354,6 +354,12 @@ export function URLBar({
   }, [url, inputValue]);
 
   const closeDropdown = useCallback(() => {
+    // Cancel any pending debounced suggestion request so stale results don't
+    // reopen the dropdown after it has been explicitly closed.
+    if (suggestTimerRef.current) {
+      clearTimeout(suggestTimerRef.current);
+      suggestTimerRef.current = null;
+    }
     setDropdownOpen(false);
     setSuggestions([]);
     setSelectedIndex(-1);

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -401,13 +401,17 @@ export function URLBar({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setSelectedIndex((i) => Math.min(i + 1, suggestions.length - 1));
+        if (dropdownOpen && suggestions.length > 0) {
+          e.preventDefault();
+          setSelectedIndex((i) => Math.min(i + 1, suggestions.length - 1));
+        }
         return;
       }
       if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setSelectedIndex((i) => Math.max(i - 1, -1));
+        if (dropdownOpen && suggestions.length > 0) {
+          e.preventDefault();
+          setSelectedIndex((i) => Math.max(i - 1, -1));
+        }
         return;
       }
       if (e.key === 'Enter') {


### PR DESCRIPTION
Reopened after main branch update. Resolves #20.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds search engine keyword mode and Tab-to-search in the omnibox. Type a keyword (e.g., "g") and press Tab to enter that engine, or use "g query" or "@bing cats" to search directly. Resolves #20.

- **New Features**
  - Keyword engines with defaults (Google, Bing, DuckDuckGo, Yahoo, Ecosia, Brave) and store-backed overrides; supports short keys (`g`, `b`, `d`, `y`, `e`, `br`) and `@` names (e.g., `@bing`, `@duckduckgo`, `@yahoo`).
  - Parser supports "keyword query" and "@keyword query"; checks exact `@` key and bare key; falls back to built-ins if the store is unavailable.
  - Omnibox shows a mode-enter hint that fills "<keyword> " and supports Tab-to-search; `keywordTrigger` makes selecting a keyword fill "<keyword> " instead of navigating.
  - IPC `omnibox:get-keyword-engines` (plus preload `getKeywordEngines`) exposes keyword→name/templates to the UI.

- **Bug Fixes**
  - Ignore keyword templates without a `%s`; fixed keyword suggestion URL encoding.
  - Handle `@keyword` in input and added `@` defaults; tightened blank-page regex to only match the app’s new-tab page.
  - Cancel pending debounced suggestion requests when the dropdown closes to prevent stale reopen.
  - Only call `preventDefault` for ArrowUp/ArrowDown when the dropdown is open.

<sup>Written for commit cfc6728796d86d2e06c61c9a851dc7ca4fe54a08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

