### PR TITLE
feat(a11y): Live Caption toggle in Accessibility settings

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1931,6 +1931,14 @@ ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
   return true;
 });
 
+// Issue #104 — Live Caption: toggle caption overlay in the shell window.
+ipcMain.handle('live-caption:toggle', (_e, enabled: boolean) => {
+  if (shellWindow && !shellWindow.isDestroyed()) {
+    shellWindow.webContents.send('live-caption:state-changed', enabled);
+  }
+  return true;
+});
+
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {
   if (!shellWindow || !tabManager) {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1934,7 +1934,7 @@ ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
 // Issue #104 — Live Caption: toggle caption overlay in the shell window.
 ipcMain.handle('live-caption:toggle', (_e, enabled: boolean) => {
   if (shellWindow && !shellWindow.isDestroyed()) {
-    shellWindow.webContents.send('live-caption:state-changed', enabled);
+    shellWindow.webContents.send('live-caption:state-changed', { enabled });
   }
   return true;
 });

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -105,6 +105,8 @@ const CH_SET_ASK_BEFORE_SAVE      = 'settings:set-ask-before-save';
 const CH_GET_FILE_TYPE_ASSOC      = 'settings:get-file-type-associations';
 const CH_SET_FILE_TYPE_ASSOC      = 'settings:set-file-type-association';
 const CH_REMOVE_FILE_TYPE_ASSOC   = 'settings:remove-file-type-association';
+const CH_GET_LIVE_CAPTION         = 'settings:get-live-caption';
+const CH_SET_LIVE_CAPTION         = 'settings:set-live-caption';
 
 // ---------------------------------------------------------------------------
 // Module-level deps (set by registerSettingsHandlers)
@@ -163,6 +165,8 @@ interface Preferences {
     // Random salt (hex) persisted alongside the hash for PBKDF2 verification
     encryptionSalt?: string;
   };
+  liveCaptionEnabled?: boolean;
+  liveCaptionLanguage?: string;
   [key: string]: unknown;
 }
 
@@ -868,6 +872,33 @@ function handleRemoveFileTypeAssociation(_event: Electron.IpcMainInvokeEvent, ex
   mainLogger.info(`${CH_REMOVE_FILE_TYPE_ASSOC}.ok`, { ext: normalized });
 }
 
+// ---------------------------------------------------------------------------
+// Live Caption (a11y) settings handlers
+// ---------------------------------------------------------------------------
+
+function handleGetLiveCaption(): { enabled: boolean; language: string } {
+  mainLogger.info(CH_GET_LIVE_CAPTION);
+  const prefs = readPrefs();
+  const result = {
+    enabled: prefs.liveCaptionEnabled === true,
+    language: typeof prefs.liveCaptionLanguage === 'string' ? prefs.liveCaptionLanguage : 'en-US',
+  };
+  mainLogger.info(`${CH_GET_LIVE_CAPTION}.ok`, result);
+  return result;
+}
+
+function handleSetLiveCaption(
+  _event: Electron.IpcMainInvokeEvent,
+  patch: { enabled?: boolean; language?: string },
+): boolean {
+  if (typeof patch !== 'object' || patch === null) return false;
+  mainLogger.info(CH_SET_LIVE_CAPTION, { patch });
+  if (patch.enabled !== undefined) mergePrefs({ liveCaptionEnabled: Boolean(patch.enabled) });
+  if (typeof patch.language === 'string') mergePrefs({ liveCaptionLanguage: patch.language });
+  mainLogger.info(`${CH_SET_LIVE_CAPTION}.ok`);
+  return true;
+}
+
 function handleCloseWindow(): void {
   mainLogger.info(CH_CLOSE_WINDOW);
   const win = getSettingsWindow();
@@ -928,10 +959,12 @@ export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions):
   ipcMain.handle(CH_GET_FILE_TYPE_ASSOC,      handleGetFileTypeAssociations);
   ipcMain.handle(CH_SET_FILE_TYPE_ASSOC,      handleSetFileTypeAssociation);
   ipcMain.handle(CH_REMOVE_FILE_TYPE_ASSOC,   handleRemoveFileTypeAssociation);
+  ipcMain.handle(CH_GET_LIVE_CAPTION,         handleGetLiveCaption);
+  ipcMain.handle(CH_SET_LIVE_CAPTION,         handleSetLiveCaption);
 
   refreshPrivacyHeaders();
 
-  mainLogger.info('settings.ipc.register.ok', { channelCount: 34 });
+  mainLogger.info('settings.ipc.register.ok', { channelCount: 36 });
 }
 
 export function unregisterSettingsHandlers(): void {
@@ -974,6 +1007,8 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_GET_FILE_TYPE_ASSOC);
   ipcMain.removeHandler(CH_SET_FILE_TYPE_ASSOC);
   ipcMain.removeHandler(CH_REMOVE_FILE_TYPE_ASSOC);
+  ipcMain.removeHandler(CH_GET_LIVE_CAPTION);
+  ipcMain.removeHandler(CH_SET_LIVE_CAPTION);
 
   _accountStore  = null;
   _keychainStore = null;

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -12,7 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app, dialog, ipcMain, session } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, session } from 'electron';
 import { mainLogger } from '../logger';
 import type { AccountStore } from '../identity/AccountStore';
 import type { KeychainStore } from '../identity/KeychainStore';
@@ -896,6 +896,12 @@ function handleSetLiveCaption(
   if (patch.enabled !== undefined) mergePrefs({ liveCaptionEnabled: Boolean(patch.enabled) });
   if (typeof patch.language === 'string') mergePrefs({ liveCaptionLanguage: patch.language });
   mainLogger.info(`${CH_SET_LIVE_CAPTION}.ok`);
+  const current = handleGetLiveCaption();
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('live-caption:state-changed', current);
+    }
+  }
   return true;
 }
 

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -247,6 +247,12 @@ export interface SettingsAPI {
   /** Clear the sync encryption passphrase */
   clearSyncPassphrase: () => Promise<void>;
 
+  /** Get Live Caption preferences (enabled state and language) */
+  getLiveCaption: () => Promise<{ enabled: boolean; language: string }>;
+
+  /** Set Live Caption preferences */
+  setLiveCaption: (patch: { enabled?: boolean; language?: string }) => Promise<boolean>;
+
   /** Get all global content category defaults */
   getContentCategoryDefaults: () => Promise<Record<ContentCategory, CategoryState>>;
 
@@ -503,6 +509,16 @@ const api: SettingsAPI = {
   setGpcEnabled: async (enabled: boolean): Promise<void> => {
     console.debug('[settings-preload] setGpcEnabled', { enabled });
     await ipcRenderer.invoke('settings:set-gpc-enabled', enabled);
+  },
+
+  getLiveCaption: async (): Promise<{ enabled: boolean; language: string }> => {
+    console.debug('[settings-preload] getLiveCaption');
+    return ipcRenderer.invoke('settings:get-live-caption') as Promise<{ enabled: boolean; language: string }>;
+  },
+
+  setLiveCaption: async (patch: { enabled?: boolean; language?: string }): Promise<boolean> => {
+    console.debug('[settings-preload] setLiveCaption', { patch });
+    return ipcRenderer.invoke('settings:set-live-caption', patch) as Promise<boolean>;
   },
 
   getContentCategoryDefaults: async (): Promise<Record<ContentCategory, CategoryState>> => {

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -695,6 +695,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('fullscreen-changed', handler);
       return () => ipcRenderer.removeListener('fullscreen-changed', handler);
     },
+
+    // Issue #104 — Live Caption: receive state changes from main process
+    liveCaptionStateChanged: (cb: (enabled: boolean) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, enabled: boolean) => cb(enabled);
+      ipcRenderer.on('live-caption:state-changed', handler);
+      return () => ipcRenderer.removeListener('live-caption:state-changed', handler);
+    },
   },
 
   // Profiles — current profile info + switch

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -406,6 +406,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('ntp:pick-background-image'),
   },
 
+  // Issue #104 — Live Caption: get current persisted state for initial hydration
+  liveCaption: {
+    getState: (): Promise<{ enabled: boolean; language: string }> =>
+      ipcRenderer.invoke('settings:get-live-caption') as Promise<{ enabled: boolean; language: string }>,
+  },
+
   // Event listeners
   on: {
     tabsState: (

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -697,8 +697,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
 
     // Issue #104 — Live Caption: receive state changes from main process
-    liveCaptionStateChanged: (cb: (enabled: boolean) => void): (() => void) => {
-      const handler = (_e: Electron.IpcRendererEvent, enabled: boolean) => cb(enabled);
+    liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void): (() => void) => {
+      const handler = (_e: Electron.IpcRendererEvent, state: { enabled: boolean; language: string }) => cb(state);
       ipcRenderer.on('live-caption:state-changed', handler);
       return () => ipcRenderer.removeListener('live-caption:state-changed', handler);
     },

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2823,10 +2823,12 @@ function AccessibilityTab(): React.ReactElement {
   }
 
   async function handleLanguageChange(language: string): Promise<void> {
+    const previous = liveCaptionLanguage;
     setLiveCaptionLanguage(language);
     try {
       await window.settingsAPI.setLiveCaption({ language });
     } catch (err) {
+      setLiveCaptionLanguage(previous);
       toast.show({
         variant: 'error',
         title: 'Failed to update language',

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -36,9 +36,10 @@ const TAB_PASSWORDS    = 'passwords'        as const;
 const TAB_ZOOM         = 'site-zoom'        as const;
 const TAB_CONTENT      = 'content'          as const;
 const TAB_PERMISSIONS  = 'permissions'     as const;
-const TAB_ADDRESSES    = 'addresses'        as const;
-const TAB_PAYMENTS     = 'payments'         as const;
-const TAB_DOWNLOADS    = 'downloads'        as const;
+const TAB_ADDRESSES      = 'addresses'        as const;
+const TAB_PAYMENTS       = 'payments'         as const;
+const TAB_DOWNLOADS      = 'downloads'         as const;
+const TAB_ACCESSIBILITY  = 'accessibility'     as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -55,6 +56,7 @@ type TabId =
   | typeof TAB_ADDRESSES
   | typeof TAB_PAYMENTS
   | typeof TAB_DOWNLOADS
+  | typeof TAB_ACCESSIBILITY
   | typeof TAB_DANGER;
 
 const TABS: Array<{ id: TabId; label: string }> = [
@@ -69,10 +71,11 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: TAB_ZOOM,       label: 'Site Zoom' },
   { id: TAB_CONTENT,    label: 'Content' },
   { id: TAB_PERMISSIONS, label: 'Permissions' },
-  { id: TAB_ADDRESSES,   label: 'Addresses' },
-  { id: TAB_PAYMENTS,    label: 'Payments' },
-  { id: TAB_DOWNLOADS,   label: 'Downloads' },
-  { id: TAB_DANGER,     label: 'Danger Zone' },
+  { id: TAB_ADDRESSES,      label: 'Addresses' },
+  { id: TAB_PAYMENTS,       label: 'Payments' },
+  { id: TAB_DOWNLOADS,      label: 'Downloads' },
+  { id: TAB_ACCESSIBILITY,  label: 'Accessibility' },
+  { id: TAB_DANGER,         label: 'Danger Zone' },
 ];
 
 const THEME_ONBOARDING = 'onboarding';
@@ -170,6 +173,8 @@ declare global {
       setDntEnabled: (enabled: boolean) => Promise<void>;
       getGpcEnabled: () => Promise<boolean>;
       setGpcEnabled: (enabled: boolean) => Promise<void>;
+      getLiveCaption: () => Promise<{ enabled: boolean; language: string }>;
+      setLiveCaption: (patch: { enabled?: boolean; language?: string }) => Promise<boolean>;
       getContentCategoryDefaults: () => Promise<Record<string, string>>;
       setContentCategoryDefault: (category: string, state: string) => Promise<void>;
       getContentCategorySite: (origin: string) => Promise<Array<{ origin: string; category: string; state: string; updatedAt: number }>>;
@@ -2770,6 +2775,118 @@ function DownloadsTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Accessibility tab
+// ---------------------------------------------------------------------------
+
+const LIVE_CAPTION_LANGUAGE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'en-US', label: 'English (US)' },
+  { value: 'en-GB', label: 'English (UK)' },
+  { value: 'de-DE', label: 'German' },
+  { value: 'fr-FR', label: 'French' },
+  { value: 'es-ES', label: 'Spanish' },
+  { value: 'ja-JP', label: 'Japanese' },
+];
+
+function AccessibilityTab(): React.ReactElement {
+  const toast = useToast();
+  const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void window.settingsAPI.getLiveCaption().then(({ enabled, language }) => {
+      setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
+    }).catch(() => {
+      // ignore; leave defaults
+    }).finally(() => {
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleLiveCaptionToggle(checked: boolean): Promise<void> {
+    setLiveCaptionEnabled(checked);
+    try {
+      await window.settingsAPI.setLiveCaption({ enabled: checked });
+      toast.show({
+        variant: 'success',
+        title: checked ? 'Live Caption enabled' : 'Live Caption disabled',
+      });
+    } catch (err) {
+      setLiveCaptionEnabled(!checked);
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update setting',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  async function handleLanguageChange(language: string): Promise<void> {
+    setLiveCaptionLanguage(language);
+    try {
+      await window.settingsAPI.setLiveCaption({ language });
+    } catch (err) {
+      toast.show({
+        variant: 'error',
+        title: 'Failed to update language',
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Accessibility</h2>
+      <p className="settings-section-desc">
+        Configure accessibility features to improve your browsing experience.
+      </p>
+
+      <Card variant="default" padding="md" className="settings-card">
+        <div className="settings-toggle-row">
+          <div className="settings-toggle-info">
+            <span className="settings-toggle-label">Live Caption</span>
+            <span className="settings-toggle-desc">
+              Automatically caption speech in audio and video
+            </span>
+          </div>
+          <label className="settings-toggle">
+            <input
+              type="checkbox"
+              checked={liveCaptionEnabled}
+              disabled={loading}
+              onChange={(e) => void handleLiveCaptionToggle(e.target.checked)}
+            />
+            <span className="settings-toggle-track" />
+          </label>
+        </div>
+
+        {liveCaptionEnabled && (
+          <div className="settings-field" style={{ marginTop: 12 }}>
+            <label htmlFor="live-caption-language" className="settings-label">
+              Caption language
+            </label>
+            <select
+              id="live-caption-language"
+              className="settings-input"
+              value={liveCaptionLanguage}
+              disabled={loading}
+              onChange={(e) => void handleLanguageChange(e.target.value)}
+            >
+              {LIVE_CAPTION_LANGUAGE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Inner app (uses useToast — must be inside ToastProvider)
 // ---------------------------------------------------------------------------
 
@@ -2833,10 +2950,11 @@ function SettingsInner(): React.ReactElement {
     [TAB_ZOOM]:       <SiteZoomTab />,
     [TAB_PERMISSIONS]: <PermissionsTab />,
     [TAB_ADDRESSES]:   <AddressesTab />,
-    [TAB_PAYMENTS]:    <PaymentsTab />,
-    [TAB_DOWNLOADS]:   <DownloadsTab />,
-    [TAB_CONTENT]:    <ContentCategoriesTab />,
-    [TAB_DANGER]:     <DangerZoneTab />,
+    [TAB_PAYMENTS]:       <PaymentsTab />,
+    [TAB_DOWNLOADS]:      <DownloadsTab />,
+    [TAB_CONTENT]:        <ContentCategoriesTab />,
+    [TAB_ACCESSIBILITY]:  <AccessibilityTab />,
+    [TAB_DANGER]:         <DangerZoneTab />,
   };
 
   return (

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -2807,7 +2807,8 @@ function AccessibilityTab(): React.ReactElement {
   async function handleLiveCaptionToggle(checked: boolean): Promise<void> {
     setLiveCaptionEnabled(checked);
     try {
-      await window.settingsAPI.setLiveCaption({ enabled: checked });
+      const ok = await window.settingsAPI.setLiveCaption({ enabled: checked });
+      if (!ok) throw new Error('Settings update failed');
       toast.show({
         variant: 'success',
         title: checked ? 'Live Caption enabled' : 'Live Caption disabled',
@@ -2828,7 +2829,8 @@ function AccessibilityTab(): React.ReactElement {
     try {
       await window.settingsAPI.setLiveCaption({ language });
     } catch (err) {
-      setLiveCaptionLanguage(previous);
+      // Only roll back if the user hasn't already selected a different language.
+      setLiveCaptionLanguage((cur) => (cur === language ? previous : cur));
       toast.show({
         variant: 'error',
         title: 'Failed to update language',

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -159,6 +159,7 @@ declare const electronAPI: {
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
     nameWindowDialog: (cb: () => void) => () => void;
+    liveCaptionStateChanged: (cb: (enabled: boolean) => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -201,6 +202,10 @@ export function WindowChrome(): React.ReactElement {
 
   // PiP state
   const [pipActive, setPipActive] = useState(false);
+
+  // Live Caption state
+  const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [captionText, setCaptionText] = useState('');
 
   // Side panel state
   const [sidePanelOpen, setSidePanelOpen] = useState(false);
@@ -361,6 +366,11 @@ export function WindowChrome(): React.ReactElement {
       setIsFullscreen(fs);
     });
 
+    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged((enabled) => {
+      setLiveCaptionEnabled(enabled);
+      if (!enabled) setCaptionText('');
+    });
+
     return () => {
       unsubTabsState();
       unsubTabUpdated();
@@ -378,6 +388,7 @@ export function WindowChrome(): React.ReactElement {
       unsubFocusBar();
       unsubNameWindow();
       unsubFullscreen();
+      unsubLiveCaptionState();
     };
   }, [bookmarksTree?.visibility]);
 
@@ -740,6 +751,12 @@ export function WindowChrome(): React.ReactElement {
             setNameWindowDialogOpen(false);
           }}
         />
+      )}
+
+      {liveCaptionEnabled && (
+        <div className="caption-overlay" aria-live="polite" aria-label="Live captions">
+          <span className="caption-overlay__text">{captionText || '\u00a0'}</span>
+        </div>
       )}
     </div>
   );

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -161,6 +161,9 @@ declare const electronAPI: {
     nameWindowDialog: (cb: () => void) => () => void;
     liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void) => () => void;
   };
+  liveCaption: {
+    getState: () => Promise<{ enabled: boolean; language: string }>;
+  };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
     dismiss: (promptId: string) => Promise<void>;
@@ -203,7 +206,7 @@ export function WindowChrome(): React.ReactElement {
   // PiP state
   const [pipActive, setPipActive] = useState(false);
 
-  // Live Caption state
+  // Live Caption state — hydrated from prefs on mount
   const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
   const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
   const [captionText, setCaptionText] = useState('');
@@ -400,6 +403,16 @@ export function WindowChrome(): React.ReactElement {
   }, [bookmarksTree?.visibility]);
 
   // ---------------------------------------------------------------------------
+  // Live Caption — hydrate from persisted prefs on mount
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    electronAPI.liveCaption.getState().then(({ enabled, language }) => {
+      setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
+    }).catch(() => {});
+  }, []);
+
+  // ---------------------------------------------------------------------------
   // Live Caption — Web Speech API
   // ---------------------------------------------------------------------------
   useEffect(() => {
@@ -422,9 +435,13 @@ export function WindowChrome(): React.ReactElement {
       }
       setCaptionText(text);
     };
-    rec.onerror = () => { /* ignore */ };
+    let fatalError = false;
+    rec.onerror = (ev: any) => {
+      const fatal = ['not-allowed', 'service-not-available', 'audio-capture'];
+      if (fatal.includes(ev.error)) fatalError = true;
+    };
     rec.onend = () => {
-      if (liveCaptionEnabled) rec.start();
+      if (liveCaptionEnabled && !fatalError) rec.start();
     };
     rec.start();
     recognitionRef.current = rec;

--- a/my-app/src/renderer/shell/WindowChrome.tsx
+++ b/my-app/src/renderer/shell/WindowChrome.tsx
@@ -159,7 +159,7 @@ declare const electronAPI: {
     downloadsState: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
     linkHover: (cb: (payload: { url: string }) => void) => () => void;
     nameWindowDialog: (cb: () => void) => () => void;
-    liveCaptionStateChanged: (cb: (enabled: boolean) => void) => () => void;
+    liveCaptionStateChanged: (cb: (state: { enabled: boolean; language: string }) => void) => () => void;
   };
   permissions: {
     respond: (promptId: string, decision: string) => Promise<void>;
@@ -205,7 +205,13 @@ export function WindowChrome(): React.ReactElement {
 
   // Live Caption state
   const [liveCaptionEnabled, setLiveCaptionEnabled] = useState(false);
+  const [liveCaptionLanguage, setLiveCaptionLanguage] = useState('en-US');
   const [captionText, setCaptionText] = useState('');
+  const captionPos = useRef({ x: 0, y: 0 });
+  const captionDragStart = useRef<{ mx: number; my: number; ox: number; oy: number } | null>(null);
+  const captionRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
 
   // Side panel state
   const [sidePanelOpen, setSidePanelOpen] = useState(false);
@@ -366,8 +372,9 @@ export function WindowChrome(): React.ReactElement {
       setIsFullscreen(fs);
     });
 
-    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged((enabled) => {
+    const unsubLiveCaptionState = electronAPI.on.liveCaptionStateChanged(({ enabled, language }) => {
       setLiveCaptionEnabled(enabled);
+      setLiveCaptionLanguage(language);
       if (!enabled) setCaptionText('');
     });
 
@@ -391,6 +398,41 @@ export function WindowChrome(): React.ReactElement {
       unsubLiveCaptionState();
     };
   }, [bookmarksTree?.visibility]);
+
+  // ---------------------------------------------------------------------------
+  // Live Caption — Web Speech API
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    const SR: (new () => any) | undefined = w.SpeechRecognition ?? w.webkitSpeechRecognition;
+    if (!liveCaptionEnabled || !SR) {
+      recognitionRef.current?.stop();
+      recognitionRef.current = null;
+      return;
+    }
+    const rec = new SR();
+    rec.lang = liveCaptionLanguage;
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.onresult = (ev: any) => {
+      let text = '';
+      for (let i = ev.resultIndex; i < ev.results.length; i++) {
+        text += ev.results[i][0].transcript;
+      }
+      setCaptionText(text);
+    };
+    rec.onerror = () => { /* ignore */ };
+    rec.onend = () => {
+      if (liveCaptionEnabled) rec.start();
+    };
+    rec.start();
+    recognitionRef.current = rec;
+    return () => {
+      rec.onend = null;
+      rec.stop();
+    };
+  }, [liveCaptionEnabled, liveCaptionLanguage]);
 
   // ---------------------------------------------------------------------------
   // Download IPC subscriptions
@@ -754,7 +796,43 @@ export function WindowChrome(): React.ReactElement {
       )}
 
       {liveCaptionEnabled && (
-        <div className="caption-overlay" aria-live="polite" aria-label="Live captions">
+        <div
+          ref={captionRef}
+          className="caption-overlay"
+          aria-live="polite"
+          aria-label="Live captions"
+          style={captionPos.current.x || captionPos.current.y ? {
+            bottom: 'auto',
+            top: captionPos.current.y,
+            left: captionPos.current.x,
+            transform: 'none',
+          } : undefined}
+          onMouseDown={(e) => {
+            const el = captionRef.current;
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            captionDragStart.current = { mx: e.clientX, my: e.clientY, ox: rect.left, oy: rect.top };
+            const onMove = (ev: MouseEvent) => {
+              if (!captionDragStart.current) return;
+              const dx = ev.clientX - captionDragStart.current.mx;
+              const dy = ev.clientY - captionDragStart.current.my;
+              captionPos.current = { x: captionDragStart.current.ox + dx, y: captionDragStart.current.oy + dy };
+              if (el) {
+                el.style.bottom = 'auto';
+                el.style.top = captionPos.current.y + 'px';
+                el.style.left = captionPos.current.x + 'px';
+                el.style.transform = 'none';
+              }
+            };
+            const onUp = () => {
+              captionDragStart.current = null;
+              window.removeEventListener('mousemove', onMove);
+              window.removeEventListener('mouseup', onUp);
+            };
+            window.addEventListener('mousemove', onMove);
+            window.addEventListener('mouseup', onUp);
+          }}
+        >
           <span className="caption-overlay__text">{captionText || '\u00a0'}</span>
         </div>
       )}

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2674,3 +2674,29 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* ---------------------------------------------------------------------------
+   Live Caption overlay (issue #104)
+   --------------------------------------------------------------------------- */
+
+.caption-overlay {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 600px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 16px;
+  line-height: 1.5;
+  z-index: 9999;
+  pointer-events: none;
+  user-select: none;
+}
+
+.caption-overlay__text {
+  display: block;
+  text-align: center;
+}

--- a/my-app/src/renderer/shell/components.css
+++ b/my-app/src/renderer/shell/components.css
@@ -2685,6 +2685,7 @@
   left: 50%;
   transform: translateX(-50%);
   max-width: 600px;
+  min-width: 200px;
   background: rgba(0, 0, 0, 0.85);
   color: #fff;
   border-radius: 8px;
@@ -2692,8 +2693,13 @@
   font-size: 16px;
   line-height: 1.5;
   z-index: 9999;
-  pointer-events: none;
+  pointer-events: auto;
   user-select: none;
+  cursor: grab;
+}
+
+.caption-overlay:active {
+  cursor: grabbing;
 }
 
 .caption-overlay__text {


### PR DESCRIPTION
Reopened after main branch update. Resolves #104.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Live Caption controls in Accessibility settings and a draggable caption overlay in the shell. Persists enabled state and language, hydrates on launch, syncs across windows, and starts/stops transcription via the Web Speech API (closes #104).

- **New Features**
  - Accessibility tab: Live Caption toggle and language selector; stored as `liveCaptionEnabled`/`liveCaptionLanguage`.
  - IPC/preload: `settings:get-live-caption`, `settings:set-live-caption`, and `live-caption:toggle`; broadcasts `live-caption:state-changed` with `{ enabled, language }` to all windows; exposed via `settingsAPI.getLiveCaption/setLiveCaption`, `electronAPI.liveCaption.getState`, and `electronAPI.on.liveCaptionStateChanged`.
  - Shell overlay (`WindowChrome`): high-contrast, draggable captions; state hydrated on mount; speech recognition uses the selected language.

- **Bug Fixes**
  - Web Speech: stop retrying on fatal errors (`not-allowed`, `service-not-available`, `audio-capture`).
  - Settings: verify `setLiveCaption` result; roll back language on save failure; avoid stale rollback on rapid changes.

<sup>Written for commit bbba99c770f3b824f90e06d0e3de5929e779a93d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

