### PR TITLE
feat(tabs): drag tab to detach into new window

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -265,6 +265,10 @@ function openShellAndWire(profileId?: string): BrowserWindow {
     rebuildApplicationMenu();
   });
 
+  tabManager.setOnMoveTabToNewWindow((url: string) => {
+    openNewWindow(url);
+  });
+
   setTimeout(async () => {
     if (tabManager) {
       const port = await tabManager.discoverCdpPort();
@@ -421,7 +425,7 @@ function openGuestShell(): BrowserWindow {
 // ---------------------------------------------------------------------------
 // New window (Cmd+N) — fresh window sharing the active profile session
 // ---------------------------------------------------------------------------
-function openNewWindow(): BrowserWindow {
+function openNewWindow(initialUrl?: string): BrowserWindow {
   const pid = activeProfileId;
   const profileDataDir = getProfileDataDir(pid);
   const profilePartition = getProfilePartitionName(pid);
@@ -435,7 +439,11 @@ function openNewWindow(): BrowserWindow {
     const store = bookmarkStore;
     tm.setUrlMatchFn((candidate: string) => store.isUrlBookmarked(candidate) ? candidate : null);
   }
-  tm.restoreSession();
+  if (initialUrl) {
+    tm.createTab(initialUrl);
+  } else {
+    tm.restoreSession();
+  }
   tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
 
   win.webContents.once('did-finish-load', () => {
@@ -1809,6 +1817,18 @@ ipcMain.handle('window:set-name', (e, name: string) => {
       }
     }
   }
+});
+
+// Tab drag-to-detach / move to new window (issue #1)
+ipcMain.handle('tabs:move-to-new-window', (_e, tabId: string) => {
+  if (!tabManager) return false;
+  const { tabs } = tabManager.getState();
+  if (tabs.length <= 1) return false; // Can't detach the last tab
+  const tab = tabs.find((t) => t.id === tabId);
+  if (!tab) return false;
+  tabManager.closeTab(tabId);
+  openNewWindow(tab.url);
+  return true;
 });
 
 // Issue #81 — Three-dot app menu for non-macOS platforms.

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -451,6 +451,9 @@ function openNewWindow(initialUrl?: string): BrowserWindow {
     tm.restoreSession();
   }
   tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
+  tm.setOnMoveTabToNewWindow((url: string) => {
+    openNewWindow(url);
+  });
 
   win.webContents.once('did-finish-load', () => {
     mainLogger.info('main.newWindow.ready', { windowId: win.id });
@@ -471,19 +474,26 @@ function openNewWindow(initialUrl?: string): BrowserWindow {
 // ---------------------------------------------------------------------------
 // Incognito window (Cmd+Shift+N) — isolated session, cleared on last close
 // ---------------------------------------------------------------------------
-function openIncognitoWindow(): BrowserWindow {
+function openIncognitoWindow(initialUrl?: string): BrowserWindow {
   // All incognito windows in a profile share one session partition.
   if (!incognitoPartitionName) {
     incognitoPartitionName = `${INCOGNITO_PARTITION_PREFIX}-${activeProfileId}-${Date.now()}`;
     mainLogger.info('main.openIncognitoWindow.newPartition', { incognitoPartitionName });
   }
   const partition = incognitoPartitionName;
-  mainLogger.info('main.openIncognitoWindow', { partition });
+  mainLogger.info('main.openIncognitoWindow', { partition, initialUrl });
 
   const win = createShellWindow({ titleSuffix: ' (Incognito)', incognito: true });
   const tm = new TabManager(win, { guest: true, partition });
-  tm.restoreSession();
+  if (initialUrl) {
+    tm.createTab(initialUrl);
+  } else {
+    tm.restoreSession();
+  }
   tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
+  tm.setOnMoveTabToNewWindow((url: string) => {
+    openIncognitoWindow(url);
+  });
 
   win.webContents.once('did-finish-load', () => {
     mainLogger.info('main.incognitoWindow.ready', { windowId: win.id });
@@ -504,6 +514,8 @@ function openIncognitoWindow(): BrowserWindow {
       remaining: incognitoWindows.size,
       partition,
     });
+    // Clean up this instance from the TabManager registry.
+    tm.destroy();
     if (incognitoWindows.size === 0 && incognitoPartitionName) {
       mainLogger.info('main.incognitoWindow.clearSession', { partition });
       void clearGuestSession(incognitoPartitionName);
@@ -1834,8 +1846,21 @@ ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
   if (tabs.length <= 1) return false; // Can't detach the last tab
   const tab = tabs.find((t) => t.id === tabId);
   if (!tab) return false;
-  tm.closeTab(tabId);
-  openNewWindow(tab.url);
+  // Force-close so pinned tabs are moved rather than duplicated.
+  tm.closeTab(tabId, true);
+  // Preserve the source window's session type so the detached tab stays in
+  // the same context (incognito → incognito, guest → guest, normal → normal).
+  if (callerWin && incognitoWindows.has(callerWin)) {
+    openIncognitoWindow(tab.url);
+  } else if (tm.isGuest) {
+    // Guest (non-incognito) — open a new guest shell with the URL.
+    // Note: openGuestShell replaces the primary shell; for guest tab-detach
+    // this is the best approximation of session-preserving behaviour today.
+    openGuestShell();
+    tabManager?.createTab(tab.url);
+  } else {
+    openNewWindow(tab.url);
+  }
   return true;
 });
 

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -323,6 +323,10 @@ function openShellAndWire(profileId?: string): BrowserWindow {
     shellWindow?.webContents.send('fullscreen-changed', { isFullscreen: false });
   });
 
+  // Capture before module-level tabManager can be reassigned by a profile switch.
+  const shellTm = tabManager;
+  shellWindow.on('closed', () => shellTm.destroy());
+
   // DEV/TEST: expose tabManager on the Node.js global object so E2E tests can
   // reach it via electronApp.evaluate() calls (which run in the same Node.js
   // process and share the global scope).  The BrowserWindow proxy returned by
@@ -407,11 +411,13 @@ function openGuestShell(): BrowserWindow {
 
   shellWindow.on('resize', () => tabManager?.relayout());
 
+  const guestTm = tabManager;
   shellWindow.on('closed', () => {
     mainLogger.info('main.guestShell.closed', {
       msg: 'Guest window closed — clearing ephemeral session data',
       guestPartitionName,
     });
+    guestTm.destroy();
     if (guestPartitionName) {
       void clearGuestSession(guestPartitionName);
     }

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -1820,13 +1820,15 @@ ipcMain.handle('window:set-name', (e, name: string) => {
 });
 
 // Tab drag-to-detach / move to new window (issue #1)
-ipcMain.handle('tabs:move-to-new-window', (_e, tabId: string) => {
-  if (!tabManager) return false;
-  const { tabs } = tabManager.getState();
+ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
+  const callerWin = BrowserWindow.fromWebContents(e.sender);
+  const tm = (callerWin ? TabManager.instances.get(callerWin.id) : null) ?? tabManager;
+  if (!tm) return false;
+  const { tabs } = tm.getState();
   if (tabs.length <= 1) return false; // Can't detach the last tab
   const tab = tabs.find((t) => t.id === tabId);
   if (!tab) return false;
-  tabManager.closeTab(tabId);
+  tm.closeTab(tabId);
   openNewWindow(tab.url);
   return true;
 });

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -168,6 +168,11 @@ const incognitoWindows = new Set<BrowserWindow>();
 // one session (matches Chrome behaviour). Cleared when the last window closes.
 let incognitoPartitionName: string | null = null;
 
+// Tracks all secondary guest windows opened via tab-detach so we can clear
+// the shared session only when the LAST one closes (the primary guest shell is
+// not included here — it manages its own cleanup in openGuestShell()).
+const secondaryGuestWindows = new Set<BrowserWindow>();
+
 let bookmarkStore: BookmarkStore | null = null;
 let passwordStore: PasswordStore | null = null;
 let autofillStore: AutofillStore | null = null;
@@ -412,17 +417,22 @@ function openGuestShell(): BrowserWindow {
   shellWindow.on('resize', () => tabManager?.relayout());
 
   const guestTm = tabManager;
+  const primaryPartition = guestPartitionName;
   shellWindow.on('closed', () => {
     mainLogger.info('main.guestShell.closed', {
-      msg: 'Guest window closed — clearing ephemeral session data',
-      guestPartitionName,
+      msg: 'Guest shell closed',
+      guestPartitionName: primaryPartition,
+      secondaryGuestWindows: secondaryGuestWindows.size,
     });
     guestTm.destroy();
-    if (guestPartitionName) {
-      void clearGuestSession(guestPartitionName);
-    }
     isGuestSession = false;
     guestPartitionName = null;
+    // Only clear the ephemeral session data when ALL windows sharing this
+    // partition have closed (secondary detached windows may still be open).
+    if (primaryPartition && secondaryGuestWindows.size === 0) {
+      mainLogger.info('main.guestShell.clearSession', { partition: primaryPartition });
+      void clearGuestSession(primaryPartition);
+    }
   });
 
   return shellWindow;
@@ -520,6 +530,55 @@ function openIncognitoWindow(initialUrl?: string): BrowserWindow {
       mainLogger.info('main.incognitoWindow.clearSession', { partition });
       void clearGuestSession(incognitoPartitionName);
       incognitoPartitionName = null;
+    }
+  });
+
+  return win;
+}
+
+// ---------------------------------------------------------------------------
+// Secondary guest window — opened when a tab is detached from a guest shell.
+// Reuses the SOURCE window's existing partition so cookies/session are shared.
+// ---------------------------------------------------------------------------
+function openGuestWindow(partition: string, initialUrl?: string): BrowserWindow {
+  mainLogger.info('main.openGuestWindow', { partition, initialUrl });
+
+  const win = createShellWindow({ titleSuffix: ' (Guest)' });
+  const tm = new TabManager(win, { guest: true, partition });
+
+  if (initialUrl) {
+    tm.createTab(initialUrl);
+  } else {
+    tm.restoreSession();
+  }
+  tm.setOnClosedTabsChanged(() => rebuildApplicationMenu());
+  tm.setOnMoveTabToNewWindow((url: string) => {
+    openGuestWindow(partition, url);
+  });
+
+  win.webContents.once('did-finish-load', () => {
+    mainLogger.info('main.guestWindow.ready', { windowId: win.id });
+    win.webContents.send('window-ready');
+    win.webContents.send('guest-mode', true);
+  });
+
+  win.on('resize', () => tm.relayout());
+
+  secondaryGuestWindows.add(win);
+  mainLogger.info('main.openGuestWindow.tracked', { total: secondaryGuestWindows.size });
+
+  win.on('closed', () => {
+    secondaryGuestWindows.delete(win);
+    mainLogger.info('main.guestWindow.closed', {
+      partition,
+      remaining: secondaryGuestWindows.size,
+    });
+    tm.destroy();
+    // Only clear the partition data when BOTH the primary guest shell AND all
+    // secondary guest windows using this partition are gone.
+    if (secondaryGuestWindows.size === 0 && !isGuestSession) {
+      mainLogger.info('main.guestWindow.clearSession', { partition });
+      void clearGuestSession(partition);
     }
   });
 
@@ -1853,11 +1912,19 @@ ipcMain.handle('tabs:move-to-new-window', (e, tabId: string) => {
   if (callerWin && incognitoWindows.has(callerWin)) {
     openIncognitoWindow(tab.url);
   } else if (tm.isGuest) {
-    // Guest (non-incognito) — open a new guest shell with the URL.
-    // Note: openGuestShell replaces the primary shell; for guest tab-detach
-    // this is the best approximation of session-preserving behaviour today.
-    openGuestShell();
-    tabManager?.createTab(tab.url);
+    // Guest (non-incognito) — reuse the SOURCE window's existing partition so
+    // the detached tab shares the same cookies/session.  We must NOT call
+    // openGuestShell() here because that would (a) create a brand-new unique
+    // partition and (b) overwrite the global guestPartitionName, causing the
+    // wrong partition to be cleared when either guest window is closed.
+    const sourcePartition = tm.getGuestPartition();
+    if (sourcePartition) {
+      openGuestWindow(sourcePartition, tab.url);
+    } else {
+      // Fallback (should not happen for a properly constructed guest TabManager).
+      openGuestShell();
+      tabManager?.createTab(tab.url);
+    }
   } else {
     openNewWindow(tab.url);
   }

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2497,6 +2497,19 @@ export class TabManager {
 
   destroy(): void {
     TabManager.instances.delete(this.win.id);
+
+    // Only unregister process-wide IPC handlers when the last TabManager
+    // instance is being destroyed. With multiple windows open (e.g. from
+    // tab-detach), closing one window must not tear down IPC handlers that
+    // are still needed by the remaining windows.
+    if (TabManager.instances.size > 0) {
+      mainLogger.info('TabManager.destroy.skipIpcRemoval', {
+        remainingInstances: TabManager.instances.size,
+        msg: 'Other windows still open — preserving shared IPC handlers',
+      });
+      return;
+    }
+
     ipcMain.removeHandler('tabs:create');
     ipcMain.removeHandler('tabs:close');
     ipcMain.removeHandler('tabs:activate');

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -159,6 +159,7 @@ export class TabManager {
   private onClosedTabsChanged: (() => void) | null = null;
   private onTabClosed: ((tabId: string) => void) | null = null;
   private onWebContentsCreated: ((wc: import("electron").WebContents) => void) | null = null;
+  private onMoveTabToNewWindow: ((url: string, title: string) => void) | null = null;
   // Extra pixels the renderer added on top of the base chrome (e.g. 32 px
   // for a visible bookmarks bar). The page-hosting WebContentsView is then
   // positioned at CHROME_HEIGHT + chromeOffset.
@@ -215,6 +216,10 @@ export class TabManager {
   /** Called by DeviceManager to attach select-bluetooth-device on new tabs */
   setOnWebContentsCreated(cb: ((wc: import("electron").WebContents) => void) | null): void {
     this.onWebContentsCreated = cb;
+  }
+
+  setOnMoveTabToNewWindow(cb: ((url: string, title: string) => void) | null): void {
+    this.onMoveTabToNewWindow = cb;
   }
 
   setHistoryStore(store: HistoryStore): void {
@@ -2179,6 +2184,20 @@ export class TabManager {
         this.safeSend('bookmark-all-tabs-request', {});
       },
     }));
+
+    if (this.onMoveTabToNewWindow) {
+      menu.append(new MenuItem({ type: 'separator' }));
+      menu.append(new MenuItem({
+        label: 'Move Tab to New Window',
+        enabled: tabCount > 1,
+        click: () => {
+          const tabUrl = view.webContents.getURL();
+          const tabTitle = view.webContents.getTitle();
+          this.closeTab(tabId);
+          this.onMoveTabToNewWindow?.(tabUrl, tabTitle);
+        },
+      }));
+    }
 
     menu.popup({ window: this.win });
   }

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -146,6 +146,8 @@ const SKIP_HISTORY_RE = /^(data:|about:|chrome:|devtools:|view-source:)/i;
 const NEWTAB_URL_RE = /newtab\.html$/;
 
 export class TabManager {
+  static readonly instances = new Map<number, TabManager>();
+
   private win: BrowserWindow;
   private tabs: Map<string, WebContentsView> = new Map();
   private tabOrder: string[] = [];
@@ -188,6 +190,7 @@ export class TabManager {
 
   constructor(win: BrowserWindow, opts?: { dataDir?: string; partition?: string; guest?: boolean }) {
     this.win = win;
+    TabManager.instances.set(win.id, this);
     this.isGuest = opts?.guest ?? false;
     this.partition = opts?.partition ?? null;
     this.sessionStore = new SessionStore(opts?.dataDir);
@@ -2493,6 +2496,7 @@ export class TabManager {
   }
 
   destroy(): void {
+    TabManager.instances.delete(this.win.id);
     ipcMain.removeHandler('tabs:create');
     ipcMain.removeHandler('tabs:close');
     ipcMain.removeHandler('tabs:activate');

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -188,6 +188,11 @@ export class TabManager {
   readonly isGuest: boolean;
   private readonly partition: string | null;
 
+  /** Returns the Electron session partition name used by this TabManager's tabs, or null for the default session. */
+  getGuestPartition(): string | null {
+    return this.partition;
+  }
+
   constructor(win: BrowserWindow, opts?: { dataDir?: string; partition?: string; guest?: boolean }) {
     this.win = win;
     TabManager.instances.set(win.id, this);

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -111,6 +111,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     showForwardHistory: (tabId: string): Promise<void> =>
       ipcRenderer.invoke('tabs:show-forward-history', tabId),
+
+    moveToNewWindow: (tabId: string): Promise<boolean> =>
+      ipcRenderer.invoke('tabs:move-to-new-window', tabId),
   },
 
   // CDP info for agent integration

--- a/my-app/src/renderer/shell/TabStrip.tsx
+++ b/my-app/src/renderer/shell/TabStrip.tsx
@@ -20,6 +20,7 @@ declare const electronAPI: {
     showContextMenu: (tabId: string) => Promise<void>;
     muteTab: (tabId: string) => Promise<void>;
     captureThumbnail: (tabId: string) => Promise<string | null>;
+    moveToNewWindow: (tabId: string) => Promise<boolean>;
   };
 };
 
@@ -464,10 +465,13 @@ export function TabStrip({
     [],
   );
 
+  const droppedRef = useRef(false);
+
   const handleDrop = useCallback(
     (e: React.DragEvent, toIndex: number) => {
       e.preventDefault();
       setDragOverIndex(null);
+      droppedRef.current = true;
       if (dragTabId.current) {
         onMove(dragTabId.current, toIndex);
         dragTabId.current = null;
@@ -476,13 +480,23 @@ export function TabStrip({
     [onMove],
   );
 
-  const handleDragEnd = useCallback(() => {
+  // Detach threshold: if the drag ends more than 80px below the tab strip top, treat it as detach.
+  const DETACH_Y_THRESHOLD = 80;
+
+  const handleDragEnd = useCallback((e: React.DragEvent) => {
+    const tabId = dragTabId.current;
+    const wasDroppedInStrip = droppedRef.current;
     setDragOverIndex(null);
     dragTabId.current = null;
+    droppedRef.current = false;
+
+    if (tabId && !wasDroppedInStrip && e.clientY > DETACH_Y_THRESHOLD) {
+      electronAPI.tabs.moveToNewWindow(tabId).catch(() => {/* ignore */});
+    }
   }, []);
 
   return (
-    <div className="tab-strip" role="presentation" onDragEnd={handleDragEnd}>
+    <div className="tab-strip" role="presentation" onDragEnd={(e) => handleDragEnd(e)}>
       <div
         ref={tabsContainerRef}
         className="tab-strip__tabs"


### PR DESCRIPTION
Implements tab drag-to-detach:
- Drag a tab out of the tab strip to open it in a new window
- Move-to-window context menu action
- TabManager.instances static registry for cross-window operations
- Proper cleanup of TabManager instances on window close

Reopened after main branch update.

Closes #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drag-to-detach tabs into a new window with session/partition preservation and a “Move Tab to New Window” context action. Improves multi-window stability with a per-window `TabManager` registry and safe IPC teardown. Closes #1.

- **New Features**
  - Drag a tab 80px below the strip to open it in a new window; last tab can’t detach; pinned tabs are moved.
  - Context menu: Move Tab to New Window (normal, incognito, guest).
  - IPC: `tabs:move-to-new-window` + preload; `openNewWindow(initialUrl)`, `openIncognitoWindow(initialUrl)`, `openGuestWindow(partition, initialUrl)`; `setOnMoveTabToNewWindow` wired for all window types.

- **Bug Fixes**
  - Resolve move-to-new-window against the caller window via `TabManager.instances`; call `destroy()` on window close and skip IPC removal while other windows exist.
  - Preserve session type on detach; reuse the source guest partition; track secondary guest windows and clear the partition only when the primary and all secondaries close; clean up the registry on incognito close.

<sup>Written for commit 0ae9f3d97e5fc5341b3144e93700b9df240d43ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

