### PR TITLE
feat(settings): custom search engines management

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -45,6 +45,9 @@ import { registerSettingsHandlers, unregisterSettingsHandlers, openClearDataDial
 // Wave1 P3 — Bookmarks
 import { BookmarkStore } from './bookmarks/BookmarkStore';
 import { registerBookmarkHandlers, unregisterBookmarkHandlers } from './bookmarks/ipc';
+// Issue #21 — Search Engines
+import { SearchEngineStore } from './search/SearchEngineStore';
+import { registerSearchEngineHandlers, unregisterSearchEngineHandlers } from './search/ipc';
 // Password Manager
 import { PasswordStore } from './passwords/PasswordStore';
 import { registerPasswordHandlers, unregisterPasswordHandlers } from './passwords/ipc';
@@ -177,6 +180,7 @@ let incognitoPartitionName: string | null = null;
 const secondaryGuestWindows = new Set<BrowserWindow>();
 
 let bookmarkStore: BookmarkStore | null = null;
+let searchEngineStore: SearchEngineStore | null = null;
 let passwordStore: PasswordStore | null = null;
 let autofillStore: AutofillStore | null = null;
 let profileStore: ProfileStore | null = null;
@@ -224,6 +228,11 @@ function openShellAndWire(profileId?: string): BrowserWindow {
     tabManager.setUrlMatchFn((candidate: string) => {
       return store.isUrlBookmarked(candidate) ? candidate : null;
     });
+  }
+
+  // Wire the default search engine URL template into navigation.
+  if (searchEngineStore) {
+    tabManager.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
   }
   if (historyStore) {
     tabManager.setHistoryStore(historyStore);
@@ -379,6 +388,10 @@ function openGuestShell(): BrowserWindow {
   downloadManager?.destroy();
   downloadManager = new DownloadManager(shellWindow);
 
+  if (searchEngineStore) {
+    tabManager.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
+  }
+
   tabManager.restoreSession();
 
   tabManager.setOnClosedTabsChanged(() => {
@@ -457,6 +470,7 @@ function openNewWindow(initialUrl?: string): BrowserWindow {
   // Secondary windows do not share the global tab-group store — each window
   // manages its own tab set and restores its own session IDs, so mixing them
   // into a shared store would silently mis-assign tab memberships.
+  if (searchEngineStore) tm.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
 
   if (historyStore) tm.setHistoryStore(historyStore);
   if (bookmarkStore) {
@@ -504,6 +518,7 @@ function openIncognitoWindow(initialUrl?: string): BrowserWindow {
   const win = createShellWindow({ titleSuffix: ' (Incognito)', incognito: true });
   const tm = new TabManager(win, { guest: true, partition });
   // Incognito windows do not share the persistent group store — privacy isolation.
+  if (searchEngineStore) tm.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
   if (initialUrl) {
     tm.createTab(initialUrl);
   } else {
@@ -528,6 +543,7 @@ function openIncognitoWindow(initialUrl?: string): BrowserWindow {
   const incogWinId = win.id;
   win.on('closed', () => {
     windowDefaultTitles.delete(incogWinId);
+    tm.destroy();
     incognitoWindows.delete(win);
     mainLogger.info('main.incognitoWindow.closed', {
       remaining: incognitoWindows.size,
@@ -599,6 +615,18 @@ function openGuestWindow(partition: string, initialUrl?: string): BrowserWindow 
 // ---------------------------------------------------------------------------
 app.whenReady().then(async () => {
   mainLogger.info('main.appReady');
+
+  // Issue #21 — Search Engines: init store + register IPC before the shell loads.
+  searchEngineStore = new SearchEngineStore();
+  registerSearchEngineHandlers({
+    store: searchEngineStore,
+    onDefaultChanged: (searchUrl) => {
+      // Broadcast to ALL active TabManager instances (primary + extra windows + incognito).
+      for (const tm of TabManager.getAllInstances()) {
+        tm.setSearchUrlTemplate(searchUrl);
+      }
+    },
+  });
 
   // Wave1 P3 — Bookmarks: init store + register IPC before the shell loads.
   // NOTE: BookmarkStore/PasswordStore/HistoryStore currently key off
@@ -880,6 +908,7 @@ app.whenReady().then(async () => {
       tabManager?.flushZoom();
       bookmarkStore?.flushSync();
       historyStore?.flushSync();
+      searchEngineStore?.flushSync();
       shortcutsStore?.flushSync();
       permissionStore?.flushSync();
       deviceStore?.flushSync();
@@ -903,6 +932,7 @@ app.whenReady().then(async () => {
     unregisterBookmarkHandlers();
     unregisterHistoryHandlers();
     shortcutsStore?.flushSync();
+    unregisterSearchEngineHandlers();
     unregisterOmniboxHandlers();
     unregisterChromeHandlers();
     unregisterProfileHandlers();

--- a/my-app/src/main/navigation.ts
+++ b/my-app/src/main/navigation.ts
@@ -27,6 +27,13 @@ const HAS_WHITESPACE_RE = /\s/;
 
 const GOOGLE_SEARCH_BASE = 'https://www.google.com/search?q=';
 
+const buildSearch = (query: string, searchUrl?: string): string => {
+  if (searchUrl && searchUrl.includes('%s')) {
+    return searchUrl.replace('%s', encodeURIComponent(query));
+  }
+  return GOOGLE_SEARCH_BASE + encodeURIComponent(query);
+};
+
 // ---------------------------------------------------------------------------
 // Keyword search engines (Tab-to-search / keyword mode).
 // Maps keyword → %s URL template. Populated from SearchEngineStore at runtime;
@@ -67,9 +74,9 @@ export type UrlMatchFn = (url: string) => string | null;
 // Core heuristic
 // ---------------------------------------------------------------------------
 
-export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn): string {
+export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn, searchUrl?: string): string {
   const trimmed = input.trim();
-  if (!trimmed) return GOOGLE_SEARCH_BASE;
+  if (!trimmed) return searchUrl ? searchUrl.replace('%s', '') : GOOGLE_SEARCH_BASE;
 
   // 1. Explicit scheme → always navigate
   if (EXPLICIT_URL_RE.test(trimmed)) {
@@ -108,7 +115,7 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
   // 3. Whitespace anywhere → search (URLs never contain unencoded spaces)
   if (HAS_WHITESPACE_RE.test(trimmed)) {
     mainLogger.info('navigation.parse.searchWithSpaces', { input: trimmed });
-    return GOOGLE_SEARCH_BASE + encodeURIComponent(trimmed);
+    return buildSearch(trimmed, searchUrl);
   }
 
   // 4. localhost / IP / IPv6
@@ -143,7 +150,7 @@ export function parseNavigationInput(input: string, findMatchingUrl?: UrlMatchFn
 
   // 8. Single word, no dots → search
   mainLogger.info('navigation.parse.search', { input: trimmed });
-  return GOOGLE_SEARCH_BASE + encodeURIComponent(trimmed);
+  return buildSearch(trimmed, searchUrl);
 }
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/main/search/SearchEngineStore.ts
+++ b/my-app/src/main/search/SearchEngineStore.ts
@@ -1,0 +1,251 @@
+/**
+ * SearchEngineStore — persistent store for search engines.
+ *
+ * Follows the BookmarkStore pattern: debounced atomic writes to
+ * userData/search-engines.json (300 ms).
+ *
+ * Built-in engines are always available and non-removable. Custom engines
+ * are user-added and stored in the JSON file. The default engine can be
+ * any built-in or custom engine.
+ */
+
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import { v4 as uuidv4 } from 'uuid';
+import { mainLogger } from '../logger';
+
+const SEARCH_ENGINES_FILE_NAME = 'search-engines.json';
+const DEBOUNCE_MS = 300;
+const DEFAULT_ENGINE_ID = 'google';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SearchEngine {
+  id: string;
+  name: string;
+  keyword: string;
+  searchUrl: string;
+  isBuiltIn: boolean;
+}
+
+export interface PersistedSearchEngines {
+  version: 1;
+  defaultEngineId: string;
+  custom: SearchEngine[];
+}
+
+// ---------------------------------------------------------------------------
+// Built-in engines
+// ---------------------------------------------------------------------------
+
+const BUILT_IN_ENGINES: SearchEngine[] = [
+  {
+    id: 'google',
+    name: 'Google',
+    keyword: 'g',
+    searchUrl: 'https://www.google.com/search?q=%s',
+    isBuiltIn: true,
+  },
+  {
+    id: 'bing',
+    name: 'Bing',
+    keyword: 'b',
+    searchUrl: 'https://www.bing.com/search?q=%s',
+    isBuiltIn: true,
+  },
+  {
+    id: 'duckduckgo',
+    name: 'DuckDuckGo',
+    keyword: 'd',
+    searchUrl: 'https://duckduckgo.com/?q=%s',
+    isBuiltIn: true,
+  },
+  {
+    id: 'yahoo',
+    name: 'Yahoo',
+    keyword: 'y',
+    searchUrl: 'https://search.yahoo.com/search?p=%s',
+    isBuiltIn: true,
+  },
+  {
+    id: 'ecosia',
+    name: 'Ecosia',
+    keyword: 'e',
+    searchUrl: 'https://www.ecosia.org/search?q=%s',
+    isBuiltIn: true,
+  },
+  {
+    id: 'brave',
+    name: 'Brave Search',
+    keyword: 'br',
+    searchUrl: 'https://search.brave.com/search?q=%s',
+    isBuiltIn: true,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getStorePath(): string {
+  return path.join(app.getPath('userData'), SEARCH_ENGINES_FILE_NAME);
+}
+
+function makeEmpty(): PersistedSearchEngines {
+  return {
+    version: 1,
+    defaultEngineId: DEFAULT_ENGINE_ID,
+    custom: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store class
+// ---------------------------------------------------------------------------
+
+export class SearchEngineStore {
+  private state: PersistedSearchEngines;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+
+  constructor() {
+    this.state = this.load();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private load(): PersistedSearchEngines {
+    try {
+      const raw = fs.readFileSync(getStorePath(), 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedSearchEngines;
+      if (parsed.version !== 1 || !Array.isArray(parsed.custom)) {
+        mainLogger.warn('SearchEngineStore.load.invalid', { msg: 'Resetting search engines' });
+        return makeEmpty();
+      }
+      mainLogger.info('SearchEngineStore.load.ok', {
+        defaultEngineId: parsed.defaultEngineId,
+        customCount: parsed.custom.length,
+      });
+      return parsed;
+    } catch {
+      mainLogger.info('SearchEngineStore.load.fresh', {
+        msg: 'No search-engines.json — starting fresh',
+      });
+      return makeEmpty();
+    }
+  }
+
+  private schedulePersist(): void {
+    this.dirty = true;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.flushSync(), DEBOUNCE_MS);
+  }
+
+  flushSync(): void {
+    if (!this.dirty) return;
+    try {
+      fs.writeFileSync(getStorePath(), JSON.stringify(this.state, null, 2), 'utf-8');
+      this.dirty = false;
+      mainLogger.info('SearchEngineStore.flushSync.ok', { path: getStorePath() });
+    } catch (err) {
+      mainLogger.error('SearchEngineStore.flushSync.failed', {
+        error: (err as Error).message,
+      });
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  /** Returns built-in engines followed by custom engines. */
+  listAll(): SearchEngine[] {
+    return [
+      ...BUILT_IN_ENGINES,
+      ...this.state.custom,
+    ];
+  }
+
+  getDefault(): SearchEngine {
+    const id = this.state.defaultEngineId;
+    const all = this.listAll();
+    return all.find((e) => e.id === id) ?? BUILT_IN_ENGINES[0];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  setDefault(id: string): void {
+    const all = this.listAll();
+    const engine = all.find((e) => e.id === id);
+    if (!engine) {
+      throw new Error(`Unknown search engine id: ${id}`);
+    }
+    this.state.defaultEngineId = id;
+    this.schedulePersist();
+    mainLogger.info('SearchEngineStore.setDefault', { id });
+  }
+
+  addCustom(input: { name: string; keyword: string; searchUrl: string }): SearchEngine {
+    const engine: SearchEngine = {
+      id: uuidv4(),
+      name: input.name.trim(),
+      keyword: input.keyword.trim(),
+      searchUrl: input.searchUrl.trim(),
+      isBuiltIn: false,
+    };
+    this.state.custom.push(engine);
+    this.schedulePersist();
+    mainLogger.info('SearchEngineStore.addCustom', { id: engine.id, name: engine.name });
+    return engine;
+  }
+
+  updateCustom(
+    id: string,
+    input: Partial<{ name: string; keyword: string; searchUrl: string }>,
+  ): boolean {
+    const engine = this.state.custom.find((e) => e.id === id);
+    if (!engine) return false;
+    if (input.name !== undefined) engine.name = input.name.trim();
+    if (input.keyword !== undefined) engine.keyword = input.keyword.trim();
+    if (input.searchUrl !== undefined) engine.searchUrl = input.searchUrl.trim();
+    this.schedulePersist();
+    mainLogger.info('SearchEngineStore.updateCustom', { id });
+    return true;
+  }
+
+  removeCustom(id: string): boolean {
+    const index = this.state.custom.findIndex((e) => e.id === id);
+    if (index === -1) return false;
+    this.state.custom.splice(index, 1);
+    // If the removed engine was the default, fall back to Google.
+    if (this.state.defaultEngineId === id) {
+      this.state.defaultEngineId = DEFAULT_ENGINE_ID;
+    }
+    this.schedulePersist();
+    mainLogger.info('SearchEngineStore.removeCustom', { id });
+    return true;
+  }
+
+  /**
+   * Build a search URL for the given query using the default engine.
+   * The engine's `searchUrl` must contain `%s` as a placeholder.
+   */
+  buildSearchUrl(query: string): string {
+    const engine = this.getDefault();
+    if (!engine.searchUrl.includes('%s')) {
+      return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+    }
+    return engine.searchUrl.replace('%s', encodeURIComponent(query));
+  }
+}

--- a/my-app/src/main/search/ipc.ts
+++ b/my-app/src/main/search/ipc.ts
@@ -1,0 +1,95 @@
+/**
+ * ipc.ts — search engine IPC bindings.
+ * Registers `search-engines:*` handlers.
+ */
+
+import { ipcMain } from 'electron';
+import { SearchEngineStore } from './SearchEngineStore';
+import { assertString } from '../ipc-validators';
+import { mainLogger } from '../logger';
+
+const CHANNELS = [
+  'search-engines:list',
+  'search-engines:get-default',
+  'search-engines:set-default',
+  'search-engines:add-custom',
+  'search-engines:update-custom',
+  'search-engines:remove-custom',
+] as const;
+
+export interface SearchEnginesIpcOptions {
+  store: SearchEngineStore;
+  /** Called after the default engine changes so TabManager can pick up the new URL template. */
+  onDefaultChanged?: (searchUrl: string) => void;
+}
+
+export function registerSearchEngineHandlers(opts: SearchEnginesIpcOptions): void {
+  const { store, onDefaultChanged } = opts;
+
+  ipcMain.handle('search-engines:list', () => store.listAll());
+
+  ipcMain.handle('search-engines:get-default', () => store.getDefault());
+
+  ipcMain.handle('search-engines:set-default', (_e, id: unknown) => {
+    const engineId = assertString(id, 'id', 256);
+    store.setDefault(engineId);
+    if (onDefaultChanged) {
+      onDefaultChanged(store.getDefault().searchUrl);
+    }
+    mainLogger.info('search-engines:set-default', { id: engineId });
+  });
+
+  ipcMain.handle(
+    'search-engines:add-custom',
+    (
+      _e,
+      payload: { name: string; keyword: string; searchUrl: string },
+    ) => {
+      const name = assertString(payload?.name, 'name', 512);
+      const keyword = assertString(payload?.keyword, 'keyword', 64);
+      const searchUrl = assertString(payload?.searchUrl, 'searchUrl', 2048);
+      return store.addCustom({ name, keyword, searchUrl });
+    },
+  );
+
+  ipcMain.handle(
+    'search-engines:update-custom',
+    (
+      _e,
+      payload: { id: string; name?: string; keyword?: string; searchUrl?: string },
+    ) => {
+      const id = assertString(payload?.id, 'id', 256);
+      const isDefault = store.getDefault().id === id;
+      const input: Partial<{ name: string; keyword: string; searchUrl: string }> = {};
+      if (payload?.name !== undefined) input.name = assertString(payload.name, 'name', 512);
+      if (payload?.keyword !== undefined) input.keyword = assertString(payload.keyword, 'keyword', 64);
+      if (payload?.searchUrl !== undefined) input.searchUrl = assertString(payload.searchUrl, 'searchUrl', 2048);
+      const result = store.updateCustom(id, input);
+      // If the updated engine is (or was) the default, propagate the new template.
+      if (result && isDefault && onDefaultChanged) {
+        onDefaultChanged(store.getDefault().searchUrl);
+        mainLogger.info('search-engines:update-custom.defaultChanged', { id });
+      }
+      return result;
+    },
+  );
+
+  ipcMain.handle('search-engines:remove-custom', (_e, id: unknown) => {
+    const engineId = assertString(id, 'id', 256);
+    const wasDefault = store.getDefault().id === engineId;
+    const result = store.removeCustom(engineId);
+    // If the removed engine was the default, the store falls back to Google
+    // internally. Notify active TabManagers of the new default URL.
+    if (result && wasDefault && onDefaultChanged) {
+      onDefaultChanged(store.getDefault().searchUrl);
+      mainLogger.info('search-engines:remove-custom.defaultChanged', { fallback: store.getDefault().id });
+    }
+    return result;
+  });
+}
+
+export function unregisterSearchEngineHandlers(): void {
+  for (const channel of CHANNELS) {
+    ipcMain.removeHandler(channel);
+  }
+}

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -147,7 +147,15 @@ const SKIP_HISTORY_RE = /^(data:|about:|chrome:|devtools:|view-source:)/i;
 const NEWTAB_URL_RE = /newtab\.html$/;
 
 export class TabManager {
+  // ---------------------------------------------------------------------------
+  // Static instance registry — lets callers look up by window id and broadcast
+  // to all active windows.
+  // ---------------------------------------------------------------------------
   static readonly instances = new Map<number, TabManager>();
+
+  static getAllInstances(): TabManager[] {
+    return Array.from(TabManager.instances.values());
+  }
 
   private win: BrowserWindow;
   private tabs: Map<string, WebContentsView> = new Map();
@@ -184,6 +192,7 @@ export class TabManager {
   private zoomStore: ZoomStore;
   private mutedSitesStore: MutedSitesStore;
   private urlMatchFn: UrlMatchFn | null = null;
+  private searchUrlTemplate: string | null = null;
   private historyStore: HistoryStore | null = null;
   private passwordStore: PasswordStore | null = null;
   private tabGroupStore: TabGroupStore | null = null;
@@ -289,6 +298,12 @@ export class TabManager {
 
   setUrlMatchFn(fn: UrlMatchFn | null): void {
     this.urlMatchFn = fn;
+  }
+
+  /** Update the search URL template (e.g. 'https://www.google.com/search?q=%s'). */
+  setSearchUrlTemplate(url: string | null): void {
+    this.searchUrlTemplate = url;
+    mainLogger.info('TabManager.setSearchUrlTemplate', { url: url ?? '(reset to default)' });
   }
 
   private isFullscreen = false;
@@ -778,7 +793,7 @@ export class TabManager {
   // ---------------------------------------------------------------------------
 
   navigate(tabId: string, input: string): void {
-    const url = parseNavigationInput(input, this.urlMatchFn ?? undefined);
+    const url = parseNavigationInput(input, this.urlMatchFn ?? undefined, this.searchUrlTemplate ?? undefined);
     const chromeMatch = CHROME_URL_RE.exec(url);
     if (chromeMatch) {
       const page = chromeMatch[1].toLowerCase();

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -15,6 +15,9 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
+import type { SearchEngine } from '../main/search/SearchEngineStore';
+
+export type { SearchEngine };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -299,6 +302,14 @@ export interface SettingsAPI {
   updateCard: (payload: { id: string; nameOnCard?: string; cardNumber?: string; expiryMonth?: string; expiryYear?: string; nickname?: string }) => Promise<boolean>;
   deleteCard: (id: string) => Promise<boolean>;
   deleteAllAutofill: () => Promise<void>;
+
+  // Search engines — issue #21
+  listSearchEngines: () => Promise<SearchEngine[]>;
+  getDefaultSearchEngine: () => Promise<SearchEngine>;
+  setDefaultSearchEngine: (id: string) => Promise<void>;
+  addCustomSearchEngine: (p: { name: string; keyword: string; searchUrl: string }) => Promise<SearchEngine>;
+  updateCustomSearchEngine: (id: string, p: Partial<{ name: string; keyword: string; searchUrl: string }>) => Promise<boolean>;
+  removeCustomSearchEngine: (id: string) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------
@@ -667,6 +678,37 @@ const api: SettingsAPI = {
 
   clearSyncPassphrase: (): Promise<void> =>
     ipcRenderer.invoke('settings:clear-sync-passphrase') as Promise<void>,
+
+  // Search engines — issue #21
+  listSearchEngines: async (): Promise<SearchEngine[]> => {
+    console.debug('[settings-preload] listSearchEngines');
+    return ipcRenderer.invoke('search-engines:list');
+  },
+
+  getDefaultSearchEngine: async (): Promise<SearchEngine> => {
+    console.debug('[settings-preload] getDefaultSearchEngine');
+    return ipcRenderer.invoke('search-engines:get-default');
+  },
+
+  setDefaultSearchEngine: async (id: string): Promise<void> => {
+    console.debug('[settings-preload] setDefaultSearchEngine', { id });
+    await ipcRenderer.invoke('search-engines:set-default', id);
+  },
+
+  addCustomSearchEngine: async (p: { name: string; keyword: string; searchUrl: string }): Promise<SearchEngine> => {
+    console.debug('[settings-preload] addCustomSearchEngine', { name: p.name });
+    return ipcRenderer.invoke('search-engines:add-custom', p);
+  },
+
+  updateCustomSearchEngine: async (id: string, p: Partial<{ name: string; keyword: string; searchUrl: string }>): Promise<boolean> => {
+    console.debug('[settings-preload] updateCustomSearchEngine', { id });
+    return ipcRenderer.invoke('search-engines:update-custom', { id, ...p });
+  },
+
+  removeCustomSearchEngine: async (id: string): Promise<boolean> => {
+    console.debug('[settings-preload] removeCustomSearchEngine', { id });
+    return ipcRenderer.invoke('search-engines:remove-custom', id);
+  },
 
 };
 

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -19,6 +19,7 @@ import type { DevicePickerRequest } from '../main/devices/DeviceManager';
 import type { GrantedDevice, DeviceApiType } from '../main/devices/DeviceStore';
 import type { OmniboxSuggestion } from '../main/omnibox/providers';
 import type { TabGroup } from '../main/tabs/TabGroupStore';
+import type { SearchEngine } from '../main/search/SearchEngineStore';
 
 // ---------------------------------------------------------------------------
 // Type re-exports for renderer consumption
@@ -42,6 +43,7 @@ export type {
   DeviceApiType,
   OmniboxSuggestion,
   TabGroup,
+  SearchEngine,
 };
 
 // ---------------------------------------------------------------------------
@@ -806,5 +808,29 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('tab-groups:updated', handler);
       return () => ipcRenderer.removeListener('tab-groups:updated', handler);
     },
+  },
+
+  // Search engines — issue #21
+  searchEngines: {
+    list: (): Promise<SearchEngine[]> =>
+      ipcRenderer.invoke('search-engines:list'),
+
+    getDefault: (): Promise<SearchEngine> =>
+      ipcRenderer.invoke('search-engines:get-default'),
+
+    setDefault: (id: string): Promise<void> =>
+      ipcRenderer.invoke('search-engines:set-default', id),
+
+    addCustom: (p: { name: string; keyword: string; searchUrl: string }): Promise<SearchEngine> =>
+      ipcRenderer.invoke('search-engines:add-custom', p),
+
+    updateCustom: (
+      id: string,
+      p: Partial<{ name: string; keyword: string; searchUrl: string }>,
+    ): Promise<boolean> =>
+      ipcRenderer.invoke('search-engines:update-custom', { id, ...p }),
+
+    removeCustom: (id: string): Promise<boolean> =>
+      ipcRenderer.invoke('search-engines:remove-custom', id),
   },
 });

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -24,22 +24,23 @@ import { ClearDataDialog } from './ClearDataDialog';
 // Constants
 // ---------------------------------------------------------------------------
 
-const TAB_API_KEY      = 'api-key'          as const;
-const TAB_AGENT        = 'agent'            as const;
-const TAB_APPEARANCE   = 'appearance'       as const;
-const TAB_SCOPES       = 'scopes'           as const;
-const TAB_DANGER       = 'danger'           as const;
-const TAB_PROFILES     = 'profiles'         as const;
-const TAB_SYNC         = 'sync'             as const;
-const TAB_PRIVACY      = 'privacy'          as const;
-const TAB_PASSWORDS    = 'passwords'        as const;
-const TAB_ZOOM         = 'site-zoom'        as const;
-const TAB_CONTENT      = 'content'          as const;
-const TAB_PERMISSIONS  = 'permissions'     as const;
+const TAB_API_KEY        = 'api-key'          as const;
+const TAB_AGENT          = 'agent'            as const;
+const TAB_APPEARANCE     = 'appearance'       as const;
+const TAB_SCOPES         = 'scopes'           as const;
+const TAB_DANGER         = 'danger'           as const;
+const TAB_PROFILES       = 'profiles'         as const;
+const TAB_SYNC           = 'sync'             as const;
+const TAB_PRIVACY        = 'privacy'          as const;
+const TAB_PASSWORDS      = 'passwords'        as const;
+const TAB_ZOOM           = 'site-zoom'        as const;
+const TAB_CONTENT        = 'content'          as const;
+const TAB_PERMISSIONS    = 'permissions'      as const;
 const TAB_ADDRESSES      = 'addresses'        as const;
 const TAB_PAYMENTS       = 'payments'         as const;
-const TAB_DOWNLOADS      = 'downloads'         as const;
-const TAB_ACCESSIBILITY  = 'accessibility'     as const;
+const TAB_DOWNLOADS      = 'downloads'        as const;
+const TAB_ACCESSIBILITY  = 'accessibility'    as const;
+const TAB_SEARCH_ENGINES = 'search-engines'   as const;
 
 type TabId =
   | typeof TAB_API_KEY
@@ -57,24 +58,26 @@ type TabId =
   | typeof TAB_PAYMENTS
   | typeof TAB_DOWNLOADS
   | typeof TAB_ACCESSIBILITY
+  | typeof TAB_SEARCH_ENGINES
   | typeof TAB_DANGER;
 
 const TABS: Array<{ id: TabId; label: string }> = [
-  { id: TAB_API_KEY,    label: 'API Key' },
-  { id: TAB_AGENT,      label: 'Agent' },
-  { id: TAB_APPEARANCE, label: 'Appearance' },
-  { id: TAB_SCOPES,     label: 'Google Scopes' },
-  { id: TAB_PASSWORDS,  label: 'Passwords' },
-  { id: TAB_PROFILES,   label: 'Profiles' },
-  { id: TAB_SYNC,       label: 'Sync' },
-  { id: TAB_PRIVACY,    label: 'Privacy and security' },
-  { id: TAB_ZOOM,       label: 'Site Zoom' },
-  { id: TAB_CONTENT,    label: 'Content' },
-  { id: TAB_PERMISSIONS, label: 'Permissions' },
+  { id: TAB_API_KEY,        label: 'API Key' },
+  { id: TAB_AGENT,          label: 'Agent' },
+  { id: TAB_APPEARANCE,     label: 'Appearance' },
+  { id: TAB_SCOPES,         label: 'Google Scopes' },
+  { id: TAB_PASSWORDS,      label: 'Passwords' },
+  { id: TAB_PROFILES,       label: 'Profiles' },
+  { id: TAB_SYNC,           label: 'Sync' },
+  { id: TAB_PRIVACY,        label: 'Privacy and security' },
+  { id: TAB_ZOOM,           label: 'Site Zoom' },
+  { id: TAB_CONTENT,        label: 'Content' },
+  { id: TAB_PERMISSIONS,    label: 'Permissions' },
   { id: TAB_ADDRESSES,      label: 'Addresses' },
   { id: TAB_PAYMENTS,       label: 'Payments' },
   { id: TAB_DOWNLOADS,      label: 'Downloads' },
   { id: TAB_ACCESSIBILITY,  label: 'Accessibility' },
+  { id: TAB_SEARCH_ENGINES, label: 'Search Engines' },
   { id: TAB_DANGER,         label: 'Danger Zone' },
 ];
 
@@ -96,6 +99,14 @@ const PAGE_ZOOM_OPTIONS = [
 // ---------------------------------------------------------------------------
 // Types (mirror preload shape)
 // ---------------------------------------------------------------------------
+
+interface SearchEngineEntry {
+  id: string;
+  name: string;
+  keyword: string;
+  searchUrl: string;
+  isBuiltIn: boolean;
+}
 
 interface OAuthScopeStatus {
   scope: string;
@@ -217,6 +228,12 @@ declare global {
       getFileTypeAssociations: () => Promise<Record<string, boolean>>;
       setFileTypeAssociation: (ext: string, enabled: boolean) => Promise<void>;
       removeFileTypeAssociation: (ext: string) => Promise<void>;
+      listSearchEngines: () => Promise<SearchEngineEntry[]>;
+      getDefaultSearchEngine: () => Promise<SearchEngineEntry>;
+      setDefaultSearchEngine: (id: string) => Promise<void>;
+      addCustomSearchEngine: (p: { name: string; keyword: string; searchUrl: string }) => Promise<SearchEngineEntry>;
+      updateCustomSearchEngine: (id: string, p: Partial<{ name: string; keyword: string; searchUrl: string }>) => Promise<boolean>;
+      removeCustomSearchEngine: (id: string) => Promise<boolean>;
     };
   }
 }
@@ -2002,6 +2019,219 @@ function PermissionsTab(): React.ReactElement {
 }
 
 // ---------------------------------------------------------------------------
+// Search Engines tab
+// ---------------------------------------------------------------------------
+
+function SearchEnginesTab(): React.ReactElement {
+  const toast = useToast();
+  const [engines, setEngines] = useState<SearchEngineEntry[]>([]);
+  const [defaultId, setDefaultId] = useState<string>('google');
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addName, setAddName] = useState('');
+  const [addKeyword, setAddKeyword] = useState('');
+  const [addSearchUrl, setAddSearchUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [all, def] = await Promise.all([
+        window.settingsAPI.listSearchEngines(),
+        window.settingsAPI.getDefaultSearchEngine(),
+      ]);
+      setEngines(all);
+      setDefaultId(def.id);
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to load search engines', message: (err as Error).message });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleSetDefault(id: string): Promise<void> {
+    try {
+      await window.settingsAPI.setDefaultSearchEngine(id);
+      setDefaultId(id);
+      toast.show({ variant: 'success', title: 'Default search engine updated' });
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to set default', message: (err as Error).message });
+    }
+  }
+
+  async function handleDelete(id: string): Promise<void> {
+    try {
+      await window.settingsAPI.removeCustomSearchEngine(id);
+      toast.show({ variant: 'success', title: 'Search engine removed' });
+      void load();
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to remove', message: (err as Error).message });
+    }
+  }
+
+  async function handleAdd(): Promise<void> {
+    if (!addName.trim() || !addSearchUrl.trim()) {
+      toast.show({ variant: 'error', title: 'Name and search URL are required' });
+      return;
+    }
+    if (!addSearchUrl.includes('%s')) {
+      toast.show({ variant: 'error', title: 'Search URL must contain %s as the query placeholder' });
+      return;
+    }
+    if (!/^https?:\/\//i.test(addSearchUrl.trim())) {
+      toast.show({ variant: 'error', title: 'Search URL must start with http:// or https://' });
+      return;
+    }
+    setSaving(true);
+    try {
+      await window.settingsAPI.addCustomSearchEngine({
+        name: addName.trim(),
+        keyword: addKeyword.trim(),
+        searchUrl: addSearchUrl.trim(),
+      });
+      setAddName('');
+      setAddKeyword('');
+      setAddSearchUrl('');
+      setShowAddForm(false);
+      toast.show({ variant: 'success', title: 'Custom search engine added' });
+      void load();
+    } catch (err) {
+      toast.show({ variant: 'error', title: 'Failed to add', message: (err as Error).message });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="settings-section">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Search Engines</h2>
+      <p className="settings-section-desc">
+        Choose which search engine is used when you type a search query in the address bar.
+      </p>
+
+      <Card variant="default" padding="md" className="settings-card">
+        {engines.map((engine) => (
+          <div
+            key={engine.id}
+            className="settings-scope-row"
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0' }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <input
+                type="radio"
+                name="default-search-engine"
+                id={`se-${engine.id}`}
+                checked={defaultId === engine.id}
+                onChange={() => void handleSetDefault(engine.id)}
+              />
+              <label htmlFor={`se-${engine.id}`} style={{ cursor: 'pointer' }}>
+                <span style={{ fontWeight: 500 }}>{engine.name}</span>
+                {engine.keyword && (
+                  <span className="settings-label" style={{ marginLeft: 8 }}>
+                    @{engine.keyword}
+                  </span>
+                )}
+              </label>
+            </div>
+            {!engine.isBuiltIn && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => void handleDelete(engine.id)}
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+        ))}
+      </Card>
+
+      {!showAddForm && (
+        <div style={{ marginTop: 16 }}>
+          <Button variant="secondary" size="sm" onClick={() => setShowAddForm(true)}>
+            Add custom engine
+          </Button>
+        </div>
+      )}
+
+      {showAddForm && (
+        <Card variant="outline" padding="md" className="settings-card" style={{ marginTop: 16 }}>
+          <h3 className="settings-label" style={{ marginBottom: 12 }}>Add custom search engine</h3>
+
+          <div className="settings-field">
+            <label htmlFor="se-add-name" className="settings-label">Name</label>
+            <input
+              id="se-add-name"
+              className="settings-input"
+              type="text"
+              value={addName}
+              onChange={(e) => setAddName(e.target.value)}
+              placeholder="My Search Engine"
+            />
+          </div>
+
+          <div className="settings-field" style={{ marginTop: 8 }}>
+            <label htmlFor="se-add-keyword" className="settings-label">Keyword (optional)</label>
+            <input
+              id="se-add-keyword"
+              className="settings-input"
+              type="text"
+              value={addKeyword}
+              onChange={(e) => setAddKeyword(e.target.value)}
+              placeholder="ms"
+            />
+          </div>
+
+          <div className="settings-field" style={{ marginTop: 8 }}>
+            <label htmlFor="se-add-url" className="settings-label">
+              Search URL (use %s for query placeholder)
+            </label>
+            <input
+              id="se-add-url"
+              className="settings-input"
+              type="text"
+              value={addSearchUrl}
+              onChange={(e) => setAddSearchUrl(e.target.value)}
+              placeholder="https://example.com/search?q=%s"
+            />
+          </div>
+
+          <div className="settings-row-actions" style={{ marginTop: 12 }}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => { setShowAddForm(false); setAddName(''); setAddKeyword(''); setAddSearchUrl(''); }}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleAdd()}
+              loading={saving}
+            >
+              Add
+            </Button>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Danger Zone tab
 // ---------------------------------------------------------------------------
 
@@ -2943,21 +3173,22 @@ function SettingsInner(): React.ReactElement {
   }
 
   const content: Record<TabId, React.ReactElement> = {
-    [TAB_API_KEY]:    <ApiKeyTab />,
-    [TAB_AGENT]:      <AgentTab />,
-    [TAB_APPEARANCE]: <AppearanceTab />,
-    [TAB_SCOPES]:     <GoogleScopesTab />,
-    [TAB_PASSWORDS]:  <PasswordsTab />,
-    [TAB_PROFILES]:   <ProfilesTab />,
-    [TAB_SYNC]:       <SyncTab />,
-    [TAB_PRIVACY]:    <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
-    [TAB_ZOOM]:       <SiteZoomTab />,
-    [TAB_PERMISSIONS]: <PermissionsTab />,
-    [TAB_ADDRESSES]:   <AddressesTab />,
+    [TAB_API_KEY]:        <ApiKeyTab />,
+    [TAB_AGENT]:          <AgentTab />,
+    [TAB_APPEARANCE]:     <AppearanceTab />,
+    [TAB_SCOPES]:         <GoogleScopesTab />,
+    [TAB_PASSWORDS]:      <PasswordsTab />,
+    [TAB_PROFILES]:       <ProfilesTab />,
+    [TAB_SYNC]:           <SyncTab />,
+    [TAB_PRIVACY]:        <PrivacyTab openDialog={clearDataOpen} onDialogChange={setClearDataOpen} />,
+    [TAB_ZOOM]:           <SiteZoomTab />,
+    [TAB_PERMISSIONS]:    <PermissionsTab />,
+    [TAB_ADDRESSES]:      <AddressesTab />,
     [TAB_PAYMENTS]:       <PaymentsTab />,
     [TAB_DOWNLOADS]:      <DownloadsTab />,
     [TAB_CONTENT]:        <ContentCategoriesTab />,
     [TAB_ACCESSIBILITY]:  <AccessibilityTab />,
+    [TAB_SEARCH_ENGINES]: <SearchEnginesTab />,
     [TAB_DANGER]:         <DangerZoneTab />,
   };
 


### PR DESCRIPTION
Implements custom search engines settings:
- Add/edit/delete custom search engines
- Set default search engine
- Search engines persist via SearchEngineStore
- Integrates with navigation to use engine templates

Reopened after main branch update.

Closes #21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add custom search engine management and wire the chosen default into navigation so address bar searches use your provider across all windows, including guest and incognito. Adds a Settings tab, persistent storage, and IPC APIs. Closes #21.

- New Features
  - Settings > Search Engines: view built-ins, set default, and add/remove custom engines (URL must include `%s`, keyword optional; update supported via API).
  - `SearchEngineStore` with JSON persistence and built-ins; `search-engines:*` IPC and preload APIs (`settingsAPI`, `electronAPI.searchEngines`); navigation builds search URLs from the selected engine and syncs the template across all windows (normal, guest, incognito, extra).

- Bug Fixes
  - Guard `%s` and empty input to prevent lost queries; validate `http/https` in the add-engine UI; fallback to Google if a template is invalid or the default is removed.
  - Broadcast default/template changes on set/update/remove; flush store on shutdown; unregister `search-engines:*` handlers on app quit; clean up `TabManager` instances.

<sup>Written for commit 12ffdd1340654ee5d96f7e9665a3dc8bf7b99e56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

