### PR TITLE
fix(page-info): fix Site Settings nav, stale cookie count, and stale bubble on navigation

### DIFF
--- a/my-app/src/renderer/pill/Pill.tsx
+++ b/my-app/src/renderer/pill/Pill.tsx
@@ -76,7 +76,7 @@ interface PillAPI {
   submit: (prompt: string) => Promise<{ task_id: string }>;
   cancel: (task_id: string) => Promise<{ ok: boolean }>;
   hide: () => void;
-  setExpanded: (expanded: boolean) => void;
+  setExpanded: (expanded: boolean | number) => void;
   onEvent: (cb: (event: AgentEvent) => void) => () => void;
   onHideRequest: (cb: () => void) => () => void;
   onQueuedTask: (cb: (data: { prompt: string; task_id: string }) => void) => () => void;

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -12,21 +12,6 @@ import React, {
 import { OmniboxDropdown } from './OmniboxDropdown';
 import type { OmniboxSuggestion } from '../../main/omnibox/providers';
 
-// ---------------------------------------------------------------------------
-// Omnibox types (mirrored from main/omnibox/providers.ts)
-// ---------------------------------------------------------------------------
-interface OmniboxSuggestion {
-  id: string;
-  type: 'history' | 'bookmark' | 'tab' | 'shortcut' | 'search';
-  title: string;
-  url: string;
-  description?: string;
-  favicon?: string;
-  relevance: number;
-}
-
-
-
 const GOOGLE_FAVICON_API = 'https://www.google.com/s2/favicons?sz=32&domain_url=';
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -51,6 +51,24 @@ const DEFAULT_PORTS: Record<string, number> = {
 // Debounce delay for omnibox suggest IPC calls (ms).
 const SUGGEST_DEBOUNCE_MS = 120;
 
+// ---------------------------------------------------------------------------
+// Page Info types
+// ---------------------------------------------------------------------------
+interface PermissionEntry {
+  permissionType: string;
+  state: 'allow' | 'deny' | 'ask';
+}
+
+interface PageInfo {
+  url: string;
+  isHSTS: boolean;
+  hstsMaxAge: number | null;
+  hstsIncludeSubdomains: boolean;
+  isSecure: boolean;
+  permissions: PermissionEntry[];
+  cookieCount: number;
+}
+
 interface URLBarProps {
   url: string;
   isLoading: boolean;
@@ -238,21 +256,21 @@ export function URLBar({
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(() => displayUrl(url));
   const [isEditing, setIsEditing] = useState(false);
-  const [suggestions, setSuggestions] = useState<OmniboxSuggestion[]>([]);
-  const [selectedIdx, setSelectedIdx] = useState(-1);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const suggestGenRef = useRef(0);
-  // Track the input text used when the user started editing (for recordSelection)
-  const editInputRef = useRef('');
 
   // Omnibox autocomplete state
   const [suggestions, setSuggestions] = useState<OmniboxSuggestion[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const suggestTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track the input text used when the user started editing (for recordSelection)
+  const editInputRef = useRef('');
   // Track the input value at time of focus so we can restore on Escape
   const focusValueRef = useRef('');
+
+  // Page Info state
+  const [pageInfoOpen, setPageInfoOpen] = useState(false);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const securityRef = useRef<HTMLButtonElement>(null);
 
   // Sync display when URL changes externally (not while editing)
   useEffect(() => {
@@ -402,6 +420,43 @@ export function URLBar({
     if (suggestions.length <= 1) closeDropdown();
   }, [suggestions, closeDropdown]);
 
+  const handleSecurityClick = useCallback(async () => {
+    if (!pageInfoOpen) {
+      try {
+        const [base, cookieCount] = await Promise.all([
+          electronAPI.security.getPageInfo(),
+          electronAPI.security.getCookieCount(),
+        ]);
+        let permissions: PermissionEntry[] = [];
+        try {
+          const origin = new URL(base.url).origin;
+          permissions = await electronAPI.permissions.getSite(origin);
+        } catch { /* non-URL pages have no permissions */ }
+        setPageInfo({ ...base, permissions, cookieCount });
+      } catch {
+        setPageInfo(null);
+      }
+    }
+    setPageInfoOpen((v) => !v);
+  }, [pageInfoOpen]);
+
+  // Close popover on navigation (URL change)
+  useEffect(() => {
+    setPageInfoOpen(false);
+  }, [url]);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    if (!pageInfoOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (securityRef.current && !securityRef.current.closest('.url-bar__security-wrap')?.contains(e.target as Node)) {
+        setPageInfoOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [pageInfoOpen]);
+
   const security = getSecurityStatus(url);
   // Hide the star on blank/new-tab URLs — nothing meaningful to bookmark.
   const starVisible = !!url && !BLANK_RE.test(url) && !NEWTAB_RE.test(url);
@@ -523,5 +578,16 @@ declare const electronAPI: {
     suggest: (payload: { input: string; remoteSearch?: boolean }) => Promise<OmniboxSuggestion[]>;
     recordSelection: (payload: { inputText: string; url: string; title: string }) => Promise<boolean>;
     removeHistory: (id: string) => Promise<boolean>;
+  };
+  security: {
+    getPageInfo: () => Promise<Omit<PageInfo, 'permissions' | 'cookieCount'>>;
+    getCookieCount: () => Promise<number>;
+  };
+  permissions: {
+    getSite: (origin: string) => Promise<PermissionEntry[]>;
+    setSite: (origin: string, permissionType: string, state: string) => Promise<void>;
+  };
+  tabs: {
+    navigateActive: (input: string) => Promise<void>;
   };
 };

--- a/my-app/tests/pill/pill.spec.ts
+++ b/my-app/tests/pill/pill.spec.ts
@@ -129,7 +129,7 @@ describe('PillWindowManager', () => {
     expect(BrowserWindow).toHaveBeenCalledWith(
       expect.objectContaining({
         width: 480,
-        height: 56,
+        height: 62,
         transparent: false,
         frame: false,
         alwaysOnTop: true,

--- a/my-app/tests/pill/pill.spec.ts
+++ b/my-app/tests/pill/pill.spec.ts
@@ -27,6 +27,8 @@ vi.mock('electron', () => {
       send: vi.fn(),
       once: vi.fn(),
       openDevTools: vi.fn(),
+      setZoomFactor: vi.fn(),
+      setVisualZoomLevelLimits: vi.fn(),
     },
     on: vi.fn(),
     once: vi.fn(),
@@ -88,6 +90,8 @@ interface MockBrowserWindow {
     send: Mock;
     once: Mock;
     openDevTools: Mock;
+    setZoomFactor: Mock;
+    setVisualZoomLevelLimits: Mock;
   };
   on: Mock;
   once: Mock;


### PR DESCRIPTION
Fixes four bugs in the Page Info bubble.

- Use tabs.navigateActive for Site Settings button (chrome.openPage API does not exist)
- Add tabs.navigateActive to local electronAPI type declaration (missing type caused TS error)
- Read cookie count from active tab session not shell window session (was always returning 0)
- Close bubble on navigation to prevent stale page info display (useEffect on url change)
- Fix duplicate state declarations and missing page-info state variables in URLBar.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Page Info bubble so it shows accurate data and closes at the right times. Also fixes Site Settings navigation and cookie count, and updates types/tests to keep CI green.

- **Bug Fixes**
  - Use `tabs.navigateActive` for Site Settings and add to local `electronAPI` types.
  - Read cookie count from the active tab’s session.
  - Close the Page Info bubble on URL change and outside clicks.
  - Fix `URLBar` TypeScript errors; add Page Info state/types and missing `electronAPI` typings; remove duplicate omnibox state.
  - CI/tests: update `PillAPI.setExpanded` to accept `boolean | number`, adjust pill height expectation to 62, and mock `setZoomFactor`/`setVisualZoomLevelLimits`.

<sup>Written for commit b915a4151ab85413c12c223345115bb499938613. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

