### PR TITLE
fix(pill): unbreak main typecheck + vitest

### DIFF
--- a/my-app/src/renderer/pill/Pill.tsx
+++ b/my-app/src/renderer/pill/Pill.tsx
@@ -76,7 +76,9 @@ interface PillAPI {
   submit: (prompt: string) => Promise<{ task_id: string }>;
   cancel: (task_id: string) => Promise<{ ok: boolean }>;
   hide: () => void;
-  setExpanded: (expanded: boolean) => void;
+  // `boolean` collapses/expands to default height; `number` expands to that
+  // exact pixel height (used for the palette's visible-rows layout).
+  setExpanded: (expanded: boolean | number) => void;
   onEvent: (cb: (event: AgentEvent) => void) => () => void;
   onHideRequest: (cb: () => void) => () => void;
   onQueuedTask: (cb: (data: { prompt: string; task_id: string }) => void) => () => void;

--- a/my-app/tests/pill/pill.spec.ts
+++ b/my-app/tests/pill/pill.spec.ts
@@ -26,7 +26,10 @@ vi.mock('electron', () => {
     webContents: {
       send: vi.fn(),
       once: vi.fn(),
+      on: vi.fn(),
       openDevTools: vi.fn(),
+      setZoomFactor: vi.fn(),
+      setVisualZoomLevelLimits: vi.fn(),
     },
     on: vi.fn(),
     once: vi.fn(),
@@ -125,7 +128,7 @@ describe('PillWindowManager', () => {
     expect(BrowserWindow).toHaveBeenCalledWith(
       expect.objectContaining({
         width: 480,
-        height: 56,
+        height: 62,
         transparent: false,
         frame: false,
         alwaysOnTop: true,


### PR DESCRIPTION
## Summary

Main CI is still failing after 4fc9350 fixed URLBar. Two residual breakages remain:

- **Pill.tsx:174** — \`setExpanded\` declared as \`(expanded: boolean)\` but code passes a number. Preload signature is \`boolean | number\`. Widen the renderer type.
- **pill.spec.ts** — mock missing \`webContents.setZoomFactor\` / \`setVisualZoomLevelLimits\` / \`webContents.on\` (added in ab8ee1e for the zoom-lock); expected height 56 but pill is now 62.

## Validation

- \`npm run typecheck\`: 0 errors (was 1)
- \`npm run test\`: 424/424 (was 423/424)
- \`npm run lint\`: 0 errors

## Risk

Zero runtime change — type widening only, plus test expectation correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing typecheck and Vitest on `main` by aligning the `Pill` API and test mocks with current behavior. No runtime changes.

- **Bug Fixes**
  - Renderer: `Pill.setExpanded` now accepts `boolean | number` to match preload and numeric pixel heights.
  - Tests: added mocks for `webContents.on`, `setZoomFactor`, `setVisualZoomLevelLimits`; updated expected height from 56 to 62.

<sup>Written for commit f88e1aea796b42d1409da5d30cf032e67b4a6c5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

