### PR TITLE
fix(share): resolve tab/shell refs lazily so share IPC works after startup

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -660,7 +660,13 @@ app.whenReady().then(async () => {
   // Issue #26 — Chrome internal pages
 
   // Issue #98 — Share menu
-  registerShareHandlers(tabManager!, shellWindow!);
+  // Use lazy getters so the handlers resolve the live shell/tab refs at call
+  // time. The refs don't exist yet — openShellAndWire() is what creates them.
+  // See issue #205 for background on the previous null-binding bug.
+  registerShareHandlers({
+    getTabManager: () => tabManager,
+    getShellWindow: () => shellWindow,
+  });
   // Issue #5 — Tab groups
   registerTabGroupHandlers(tabGroupStore, () => shellWindow);
   registerChromeHandlers(

--- a/my-app/src/main/share/ipc.ts
+++ b/my-app/src/main/share/ipc.ts
@@ -2,6 +2,12 @@
  * Share IPC handlers — main-process side of the share surface.
  *
  * Handles: copy link, email page, save page as, QR code data generation.
+ *
+ * The handlers resolve their dependencies (tab manager, shell window) lazily
+ * through getter functions supplied at registration time. This lets the caller
+ * wire the handlers up during `app.whenReady()` — before the shell window
+ * and tab manager actually exist — without leaving the handlers bound to
+ * stale `null` references. See issue #205 for background.
  */
 
 import { ipcMain, clipboard, shell, dialog, type BrowserWindow } from 'electron';
@@ -9,19 +15,23 @@ import { mainLogger } from '../logger';
 import type { TabManager } from '../tabs/TabManager';
 
 // ---------------------------------------------------------------------------
-// State refs set by register/unregister
+// Dependency getters — populated at registration time
 // ---------------------------------------------------------------------------
-let tabManagerRef: TabManager | null = null;
-let shellWindowRef: BrowserWindow | null = null;
+type TabManagerGetter = () => TabManager | null;
+type ShellWindowGetter = () => BrowserWindow | null;
+
+let getTabManager: TabManagerGetter = () => null;
+let getShellWindow: ShellWindowGetter = () => null;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 function getActivePageInfo(): { url: string; title: string } | null {
-  if (!tabManagerRef) return null;
-  const url = tabManagerRef.getActiveTabUrl();
+  const tabManager = getTabManager();
+  if (!tabManager) return null;
+  const url = tabManager.getActiveTabUrl();
   if (!url) return null;
-  const wc = tabManagerRef.getActiveWebContents();
+  const wc = tabManager.getActiveWebContents();
   const title = wc?.getTitle() ?? '';
   return { url, title };
 }
@@ -57,8 +67,10 @@ async function handleEmailPage(): Promise<boolean> {
 
 async function handleSavePageAs(): Promise<boolean> {
   const info = getActivePageInfo();
-  const wc = tabManagerRef?.getActiveWebContents();
-  if (!info || !wc || !shellWindowRef) {
+  const tabManager = getTabManager();
+  const shellWindow = getShellWindow();
+  const wc = tabManager?.getActiveWebContents();
+  if (!info || !wc || !shellWindow) {
     mainLogger.warn('share.savePageAs', { msg: 'missing page info, webContents, or shellWindow' });
     return false;
   }
@@ -66,7 +78,7 @@ async function handleSavePageAs(): Promise<boolean> {
   const sanitizedTitle = (info.title || 'page').replace(/[/\\?%*:|"<>]/g, '-').slice(0, 100);
   mainLogger.info('share.savePageAs', { url: info.url, title: sanitizedTitle });
 
-  const result = await dialog.showSaveDialog(shellWindowRef, {
+  const result = await dialog.showSaveDialog(shellWindow, {
     defaultPath: sanitizedTitle,
     filters: [
       { name: 'Webpage, Complete', extensions: ['html'] },
@@ -101,9 +113,14 @@ function handleGetPageInfo(): { url: string; title: string } | null {
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerShareHandlers(tabManager: TabManager, shellWindow: BrowserWindow): void {
-  tabManagerRef = tabManager;
-  shellWindowRef = shellWindow;
+export interface ShareHandlerDeps {
+  getTabManager: TabManagerGetter;
+  getShellWindow: ShellWindowGetter;
+}
+
+export function registerShareHandlers(deps: ShareHandlerDeps): void {
+  getTabManager = deps.getTabManager;
+  getShellWindow = deps.getShellWindow;
   mainLogger.info('share.register', { msg: 'Registering share IPC handlers' });
 
   ipcMain.handle('share:copy-link', () => handleCopyLink());
@@ -114,8 +131,8 @@ export function registerShareHandlers(tabManager: TabManager, shellWindow: Brows
 
 export function unregisterShareHandlers(): void {
   mainLogger.info('share.unregister', { msg: 'Unregistering share IPC handlers' });
-  tabManagerRef = null;
-  shellWindowRef = null;
+  getTabManager = () => null;
+  getShellWindow = () => null;
 
   ipcMain.removeHandler('share:copy-link');
   ipcMain.removeHandler('share:email-page');

--- a/my-app/tests/unit/share/ipc.spec.ts
+++ b/my-app/tests/unit/share/ipc.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Share IPC handler regression tests — issue #205.
+ *
+ * The share handlers used to capture `tabManager` / `shellWindow` by value at
+ * registration time. Because `registerShareHandlers` runs during
+ * `app.whenReady()`, BEFORE `openShellAndWire()` creates the shell/tab refs,
+ * every share IPC call silently resolved to `null`.
+ *
+ * These tests pin down the new lazy-getter contract: the handlers must read
+ * the *current* refs at invocation time, so registering before shell startup
+ * is safe.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Electron mock — captures ipcMain.handle callbacks so we can invoke them
+// directly from the test and observe the handler's return value.
+// ---------------------------------------------------------------------------
+
+type Handler = (...args: unknown[]) => unknown;
+const handlers = new Map<string, Handler>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  shell: {
+    openExternal: vi.fn(async () => undefined),
+  },
+  dialog: {
+    showSaveDialog: vi.fn(async () => ({ canceled: true, filePath: undefined })),
+  },
+}));
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  registerShareHandlers,
+  unregisterShareHandlers,
+} from '../../../src/main/share/ipc';
+import type { TabManager } from '../../../src/main/tabs/TabManager';
+import type { BrowserWindow } from 'electron';
+
+// ---------------------------------------------------------------------------
+// Fake TabManager / WebContents / BrowserWindow
+// ---------------------------------------------------------------------------
+
+interface FakeWebContents {
+  getTitle: () => string;
+  savePage: (path: string, kind: string) => Promise<void>;
+}
+
+function makeFakeTabManager(url: string | null, title: string): TabManager {
+  const wc: FakeWebContents | null = url
+    ? {
+        getTitle: () => title,
+        savePage: vi.fn(async () => undefined),
+      }
+    : null;
+  return {
+    getActiveTabUrl: () => url,
+    getActiveWebContents: () => wc,
+  } as unknown as TabManager;
+}
+
+function makeFakeShellWindow(): BrowserWindow {
+  return {} as unknown as BrowserWindow;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('share IPC — lazy ref resolution (issue #205)', () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  afterEach(() => {
+    unregisterShareHandlers();
+    vi.clearAllMocks();
+  });
+
+  it('returns null from share:get-page-info when registered before shell startup', async () => {
+    // Simulate the real app-ready flow: register BEFORE the shell is created.
+    let tabManager: TabManager | null = null;
+    let shellWindow: BrowserWindow | null = null;
+
+    registerShareHandlers({
+      getTabManager: () => tabManager,
+      getShellWindow: () => shellWindow,
+    });
+
+    const handler = handlers.get('share:get-page-info')!;
+    expect(handler).toBeDefined();
+
+    // Before shell startup — no refs — handler must degrade gracefully.
+    expect(await handler()).toBeNull();
+
+    // Simulate openShellAndWire() finishing.
+    tabManager = makeFakeTabManager('https://example.com/hello', 'Example Page');
+    shellWindow = makeFakeShellWindow();
+
+    // Same handler — now returns the live active tab info.
+    expect(await handler()).toEqual({
+      url: 'https://example.com/hello',
+      title: 'Example Page',
+    });
+  });
+
+  it('share:get-page-info tracks tab changes without re-registration', async () => {
+    let tabManager: TabManager | null = makeFakeTabManager('https://first.test/', 'First');
+    const shellWindow: BrowserWindow = makeFakeShellWindow();
+
+    registerShareHandlers({
+      getTabManager: () => tabManager,
+      getShellWindow: () => shellWindow,
+    });
+
+    const handler = handlers.get('share:get-page-info')!;
+    expect(await handler()).toEqual({
+      url: 'https://first.test/',
+      title: 'First',
+    });
+
+    // Swap the tab manager (e.g. after profile switch / guest shell open).
+    tabManager = makeFakeTabManager('https://second.test/path', 'Second');
+    expect(await handler()).toEqual({
+      url: 'https://second.test/path',
+      title: 'Second',
+    });
+  });
+
+  it('share:copy-link copies the active tab URL when the tab manager is live', async () => {
+    const { clipboard } = await import('electron');
+    const tabManager = makeFakeTabManager('https://copy.example/', 'Copy Me');
+    const shellWindow = makeFakeShellWindow();
+
+    registerShareHandlers({
+      getTabManager: () => tabManager,
+      getShellWindow: () => shellWindow,
+    });
+
+    const handler = handlers.get('share:copy-link')!;
+    const ok = await handler();
+
+    expect(ok).toBe(true);
+    expect(clipboard.writeText).toHaveBeenCalledWith('https://copy.example/');
+  });
+
+  it('share:copy-link returns false when no tab manager is available', async () => {
+    registerShareHandlers({
+      getTabManager: () => null,
+      getShellWindow: () => null,
+    });
+
+    const handler = handlers.get('share:copy-link')!;
+    expect(await handler()).toBe(false);
+  });
+
+  it('unregisterShareHandlers clears all four channels', () => {
+    registerShareHandlers({
+      getTabManager: () => null,
+      getShellWindow: () => null,
+    });
+
+    expect(handlers.size).toBe(4);
+    unregisterShareHandlers();
+    expect(handlers.size).toBe(0);
+  });
+});

--- a/my-app/vitest.config.ts
+++ b/my-app/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       'tests/unit/extensions/**/*.spec.tsx',
       'tests/unit/zoom/**/*.spec.ts',
       'tests/unit/shell/**/*.spec.tsx',
+      'tests/unit/share/**/*.spec.ts',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],
     // Renderer .spec.tsx files declare jsdom via the per-file


### PR DESCRIPTION
Fixes #205.

## Summary
- `registerShareHandlers` was called during `app.whenReady()` *before* `openShellAndWire()` created the shell window and `TabManager`, so the module-level refs inside `src/main/share/ipc.ts` were captured as `null` and never refreshed. Every share action (Copy link, Email page, Save page as, QR page info) silently failed or returned `null`.
- Reworked `registerShareHandlers` to accept `getTabManager` / `getShellWindow` getter functions that are resolved lazily on each IPC invocation. The call site in `src/main/index.ts` now passes `() => tabManager` / `() => shellWindow`, so the handlers always see the live refs regardless of registration order and survive profile/guest shell swaps.
- Added `tests/unit/share/ipc.spec.ts` as a regression pin: it verifies `share:get-page-info` returns `null` before shell startup, then returns the live active-tab URL/title after the refs are populated, plus coverage for tab-manager swaps, `share:copy-link`, and unregister cleanup.

## Test plan
- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck` (clean)
- [x] `npm test` — 429 tests pass across 31 files, including the new 5 tests in `tests/unit/share/ipc.spec.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup bug where share actions captured `null` refs and returned nothing. Share IPC now resolves the TabManager and shell window lazily so actions work after startup and across shell/profile swaps. Fixes #205.

- **Bug Fixes**
  - `registerShareHandlers` now accepts `getTabManager`/`getShellWindow` getters and resolves them on each IPC call.
  - Updated `src/main/index.ts` to pass getters during `app.whenReady()` so handlers don’t bind `null`.
  - Added `tests/unit/share/ipc.spec.ts` and included it in `vitest.config.ts` to pin null-before/live-after behavior and cleanup.

<sup>Written for commit bbd223cb7368bd1c9df5b361b4683038b203cd30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

