### PR TITLE
fix(identity): register missing sign-out IPC handlers

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -32,6 +32,8 @@ import { KeychainStore } from './identity/KeychainStore';
 import { registerProtocol, initOAuthHandler } from './oauth';
 import { createOnboardingWindow } from './identity/onboardingWindow';
 import { registerOnboardingHandlers, unregisterOnboardingHandlers } from './identity/onboardingHandlers';
+import { performSignOut, turnOffSync } from './identity/SignOutController';
+import type { SignOutMode } from './identity/SignOutController';
 import { mainLogger } from './logger';
 // daemon imports removed — Docker-per-task architecture replaces the persistent daemon
 import { getApiKey } from './agentApiKey';
@@ -2183,6 +2185,26 @@ ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) 
 
   const menu = Menu.buildFromTemplate(template);
   menu.popup({ window: shellWindow, x: Math.round(bounds.x), y: Math.round(bounds.y) });
+});
+
+// ---------------------------------------------------------------------------
+// IPC: identity — sign-out dialog handlers (closes #215)
+// ---------------------------------------------------------------------------
+
+ipcMain.handle('identity:sign-out', async (_event, mode: SignOutMode) => {
+  mainLogger.info('main.identity:sign-out', { mode });
+  return performSignOut(mode, accountStore, keychainStore);
+});
+
+ipcMain.handle('identity:turn-off-sync', async () => {
+  mainLogger.info('main.identity:turn-off-sync');
+  return turnOffSync(accountStore);
+});
+
+ipcMain.handle('identity:get-account-info', () => {
+  const account = accountStore.load();
+  if (!account) return null;
+  return { email: account.email, agentName: account.agent_name };
 });
 
 ipcMain.handle('shell:get-cdp-info', async () => {


### PR DESCRIPTION
## Summary
Registers the missing main-process IPC handlers for the sign-out dialog:
- `identity:sign-out` → calls `SignOutController.performSignOut()`
- `identity:turn-off-sync` → calls `SignOutController.turnOffSync()`
- `identity:get-account-info` → reads current account from `AccountStore`

Closes #215

## Test plan
- [ ] Open the sign-out dialog and click "Sign out" — account is cleared
- [ ] Open the sign-out dialog and click "Turn off sync" — succeeds without error
- [ ] Sign-out dialog shows current account info correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers missing main-process IPC handlers for the sign-out dialog so sign out and turn off sync work, and the dialog shows current account info. Closes #215.

- **Bug Fixes**
  - `identity:sign-out` → calls `performSignOut(mode, accountStore, keychainStore)`
  - `identity:turn-off-sync` → calls `turnOffSync(accountStore)`
  - `identity:get-account-info` → returns `{ email, agentName }` from `AccountStore`

<sup>Written for commit ca1548b6abeec2027fa472ff55b8d0cf31aad8c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

