### PR TITLE
fix(downloads): preserve interrupted download status instead of collapsing to paused/cancelled

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -205,7 +205,7 @@ export class DownloadManager {
         dlItem.savePath = item.getSavePath() || dlItem.savePath;
 
         if (state === 'interrupted') {
-          dlItem.status = 'paused';
+          dlItem.status = 'interrupted';
           mainLogger.info('DownloadManager.interrupted', { id, received, total });
         } else {
           dlItem.status = 'in-progress';
@@ -247,6 +247,9 @@ export class DownloadManager {
               });
             }
           }
+        } else if (state === 'interrupted') {
+          dlItem.status = 'interrupted';
+          mainLogger.info('DownloadManager.interrupted', { id, state });
         } else {
           dlItem.status = 'cancelled';
           mainLogger.info('DownloadManager.cancelled', { id, state });

--- a/my-app/src/renderer/shell/DownloadBubble.tsx
+++ b/my-app/src/renderer/shell/DownloadBubble.tsx
@@ -57,7 +57,7 @@ export function DownloadBubble({
   }, [onClose]);
 
   const hasCompleted = downloads.some(
-    (d) => d.status === 'completed' || d.status === 'cancelled',
+    (d) => d.status === 'completed' || d.status === 'cancelled' || d.status === 'interrupted',
   );
 
   return (
@@ -152,6 +152,11 @@ function DownloadRow({
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M5 5l6 6m0-6l-6 6" stroke="var(--color-status-danger)" strokeWidth="1.5" strokeLinecap="round" />
           </svg>
+        ) : dl.status === 'interrupted' ? (
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M8 4v5" stroke="var(--color-status-warning, #f59e0b)" strokeWidth="1.5" strokeLinecap="round" />
+            <circle cx="8" cy="12" r="1" fill="var(--color-status-warning, #f59e0b)" />
+          </svg>
         ) : (
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <path d="M8 3v7m0 0l-2.5-2.5M8 10l2.5-2.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
@@ -203,6 +208,9 @@ function DownloadRow({
 
         {dl.status === 'cancelled' && (
           <span className="download-row__cancelled-label">Cancelled</span>
+        )}
+        {dl.status === 'interrupted' && (
+          <span className="download-row__cancelled-label">Interrupted</span>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
Fixes download status reporting for interrupted downloads:
- During progress: `state='interrupted'` now sets `status='interrupted'` (was incorrectly `'paused'`)
- On completion: terminal `state='interrupted'` now sets `status='interrupted'` (was incorrectly `'cancelled'`)

This preserves the cause of the download failure and enables correct UI display and future retry logic.

Closes #203

## Test plan
- [ ] Start a download and interrupt the network — download shows as "interrupted" not "paused"
- [ ] After interruption completes — download shows as "interrupted" not "cancelled"
- [ ] User-paused downloads still show as "paused"
- [ ] User-cancelled downloads still show as "cancelled"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves interrupted downloads as "interrupted" during progress and after they stop, instead of collapsing to "paused" or "cancelled". Fixes wrong UI labels and improves future retry logic. Closes #203.

- **Bug Fixes**
  - `DownloadManager`: map `state==='interrupted'` to `status='interrupted'` in both progress and terminal handlers.
  - `DownloadBubble`: treat interrupted as a completed outcome; add warning icon and "Interrupted" label.

<sup>Written for commit 798bfc2046d6d95f6a824bfdfb42d6c481cff429. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

