### PR TITLE
fix(share): resolve tabManager/shellWindow lazily to prevent null-ref IPC failures

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -689,7 +689,7 @@ app.whenReady().then(async () => {
   // Issue #26 — Chrome internal pages
 
   // Issue #98 — Share menu
-  registerShareHandlers(tabManager!, shellWindow!);
+  registerShareHandlers(() => tabManager, () => shellWindow);
   // Issue #5 — Tab groups
   registerTabGroupHandlers(tabGroupStore, () => shellWindow);
   registerChromeHandlers(

--- a/my-app/src/main/share/ipc.ts
+++ b/my-app/src/main/share/ipc.ts
@@ -9,19 +9,23 @@ import { mainLogger } from '../logger';
 import type { TabManager } from '../tabs/TabManager';
 
 // ---------------------------------------------------------------------------
-// State refs set by register/unregister
+// Lazy getter types — resolved at invocation time, not registration time.
 // ---------------------------------------------------------------------------
-let tabManagerRef: TabManager | null = null;
-let shellWindowRef: BrowserWindow | null = null;
+type GetTabManager = () => TabManager | null;
+type GetShellWindow = () => BrowserWindow | null;
+
+let getTabManager: GetTabManager = () => null;
+let getShellWindow: GetShellWindow = () => null;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 function getActivePageInfo(): { url: string; title: string } | null {
-  if (!tabManagerRef) return null;
-  const url = tabManagerRef.getActiveTabUrl();
+  const tabManager = getTabManager();
+  if (!tabManager) return null;
+  const url = tabManager.getActiveTabUrl();
   if (!url) return null;
-  const wc = tabManagerRef.getActiveWebContents();
+  const wc = tabManager.getActiveWebContents();
   const title = wc?.getTitle() ?? '';
   return { url, title };
 }
@@ -57,8 +61,10 @@ async function handleEmailPage(): Promise<boolean> {
 
 async function handleSavePageAs(): Promise<boolean> {
   const info = getActivePageInfo();
-  const wc = tabManagerRef?.getActiveWebContents();
-  if (!info || !wc || !shellWindowRef) {
+  const tabManager = getTabManager();
+  const shellWindow = getShellWindow();
+  const wc = tabManager?.getActiveWebContents();
+  if (!info || !wc || !shellWindow) {
     mainLogger.warn('share.savePageAs', { msg: 'missing page info, webContents, or shellWindow' });
     return false;
   }
@@ -66,7 +72,7 @@ async function handleSavePageAs(): Promise<boolean> {
   const sanitizedTitle = (info.title || 'page').replace(/[/\\?%*:|"<>]/g, '-').slice(0, 100);
   mainLogger.info('share.savePageAs', { url: info.url, title: sanitizedTitle });
 
-  const result = await dialog.showSaveDialog(shellWindowRef, {
+  const result = await dialog.showSaveDialog(shellWindow, {
     defaultPath: sanitizedTitle,
     filters: [
       { name: 'Webpage, Complete', extensions: ['html'] },
@@ -101,9 +107,12 @@ function handleGetPageInfo(): { url: string; title: string } | null {
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerShareHandlers(tabManager: TabManager, shellWindow: BrowserWindow): void {
-  tabManagerRef = tabManager;
-  shellWindowRef = shellWindow;
+export function registerShareHandlers(
+  getTabManagerFn: () => TabManager | null,
+  getShellWindowFn: () => BrowserWindow | null,
+): void {
+  getTabManager = getTabManagerFn;
+  getShellWindow = getShellWindowFn;
   mainLogger.info('share.register', { msg: 'Registering share IPC handlers' });
 
   ipcMain.handle('share:copy-link', () => handleCopyLink());
@@ -114,8 +123,8 @@ export function registerShareHandlers(tabManager: TabManager, shellWindow: Brows
 
 export function unregisterShareHandlers(): void {
   mainLogger.info('share.unregister', { msg: 'Unregistering share IPC handlers' });
-  tabManagerRef = null;
-  shellWindowRef = null;
+  getTabManager = () => null;
+  getShellWindow = () => null;
 
   ipcMain.removeHandler('share:copy-link');
   ipcMain.removeHandler('share:email-page');


### PR DESCRIPTION
## Summary
Share IPC handlers were registered during app.whenReady() before shellWindow and tabManager were created, causing all share actions to fail with null refs.

Fix: changed registerShareHandlers to accept getter functions instead of direct refs. Handlers now call getTabManager() and getShellWindow() at invocation time, correctly resolving the live instances.

Closes #205

## Test plan
- [ ] Open Share menu → Copy link copies the current page URL
- [ ] Open Share menu → Email this page works
- [ ] Share actions don't fail with null ref errors in the console

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes share menu IPC failures by lazily resolving `tabManager` and `shellWindow` at handler invocation time. Ensures Copy Link, Email Page, and Save As work during startup and beyond (closes #205).

- **Bug Fixes**
  - Changed `registerShareHandlers` to accept `getTabManager` and `getShellWindow` getters.
  - Updated share handlers to call getters on demand and guard missing state.
  - Updated `index.ts` to pass `() => tabManager` and `() => shellWindow` instead of non-null refs.

<sup>Written for commit 79014982522f01123faca064fcea2930360f910c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

