### PR TITLE
fix(permissions): instantiate ProtocolHandlerStore and wire protocol-handler IPC

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -69,6 +69,7 @@ import { PermissionStore } from './permissions/PermissionStore';
 import { PermissionManager } from './permissions/PermissionManager';
 import { registerPermissionHandlers, unregisterPermissionHandlers } from './permissions/ipc';
 import { PermissionAutoRevoker } from './permissions/PermissionAutoRevoker';
+import { ProtocolHandlerStore } from './permissions/ProtocolHandlerStore';
 // Issue #54 — Content category toggles
 import { ContentCategoryStore } from './content-categories/ContentCategoryStore';
 import { registerContentCategoryHandlers, unregisterContentCategoryHandlers } from './content-categories/ipc';
@@ -187,6 +188,7 @@ let profileStore: ProfileStore | null = null;
 let permissionStore: PermissionStore | null = null;
 let permissionManager: PermissionManager | null = null;
 let permissionAutoRevoker: PermissionAutoRevoker | null = null;
+let protocolHandlerStore: ProtocolHandlerStore | null = null;
 let contentCategoryStore: ContentCategoryStore | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
@@ -258,6 +260,7 @@ function openShellAndWire(profileId?: string): BrowserWindow {
       manager: permissionManager,
       getShellWindow: () => shellWindow,
       autoRevoker: permissionAutoRevoker ?? undefined,
+      protocolHandlerStore: protocolHandlerStore ?? undefined,
     });
   }
 
@@ -636,6 +639,7 @@ app.whenReady().then(async () => {
   // only PermissionStore accepts a data dir today.
   bookmarkStore = new BookmarkStore();
   permissionStore = new PermissionStore(getProfileDataDir(activeProfileId));
+  protocolHandlerStore = new ProtocolHandlerStore(getProfileDataDir(activeProfileId));
   deviceStore = new DeviceStore(getProfileDataDir(activeProfileId));
   contentCategoryStore = new ContentCategoryStore();
   registerContentCategoryHandlers({ store: contentCategoryStore });
@@ -912,6 +916,7 @@ app.whenReady().then(async () => {
       searchEngineStore?.flushSync();
       shortcutsStore?.flushSync();
       permissionStore?.flushSync();
+      protocolHandlerStore?.flushSync();
       deviceStore?.flushSync();
       contentCategoryStore?.flushSync();
       autofillStore?.flushSync();


### PR DESCRIPTION
## Summary
The \`ProtocolHandlerStore\` was never instantiated in \`main/index.ts\`, causing all \`protocol-handlers:*\` IPC channels to be dead.

Fix: create a \`ProtocolHandlerStore\` instance and pass it to \`registerPermissionHandlers()\`.

Closes #223

## Test plan
- [ ] \`protocol-handlers:get-all\` returns an array (empty on fresh profile)
- [ ] \`protocol-handlers:register\` persists a handler entry
- [ ] No undefined/null errors when the protocol handlers API is invoked

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instantiates `ProtocolHandlerStore` in the main process and wires it into permission IPC so `protocol-handlers:*` channels work again (closes #223). Also flushes the store on shutdown.

- **Bug Fixes**
  - Create `ProtocolHandlerStore` with profile data dir and pass it to `registerPermissionHandlers`.
  - Call `protocolHandlerStore.flushSync()` on app shutdown.

<sup>Written for commit b0e5af953c83bdf7899a156db0892783a6b9eeb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

