### PR TITLE
fix(startup): honor --user-data-dir and --remote-debugging-port CLI flags

### DIFF
--- a/my-app/src/main/chrome/ipc.ts
+++ b/my-app/src/main/chrome/ipc.ts
@@ -6,6 +6,7 @@
 import { app, ipcMain } from 'electron';
 import http from 'node:http';
 import { mainLogger } from '../logger';
+import { getAnnouncedCdpPort, DEFAULT_CDP_PORT } from '../startup/cli';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,9 +33,26 @@ export interface NetworkTarget {
 // Network targets persistence (in-memory for session lifetime)
 // ---------------------------------------------------------------------------
 
-const networkTargets: NetworkTarget[] = [
-  { host: 'localhost', port: 9222 },
-];
+// Populated lazily on first access so the CLI-supplied
+// `--remote-debugging-port` (announced from index.ts after this module is
+// imported) is picked up. When `--remote-debugging-port=0` was passed we
+// fall back to the compile-time default so the UI has a sensible starting
+// row that the user can edit.
+let networkTargets: NetworkTarget[] | null = null;
+
+function ensureNetworkTargets(): NetworkTarget[] {
+  if (networkTargets === null) {
+    const announced = getAnnouncedCdpPort();
+    const port = announced > 0 ? announced : DEFAULT_CDP_PORT;
+    networkTargets = [{ host: 'localhost', port }];
+  }
+  return networkTargets;
+}
+
+/** Test-only hook: reset the lazy cache so each spec starts clean. */
+export function __resetNetworkTargetsForTests(): void {
+  networkTargets = null;
+}
 
 // ---------------------------------------------------------------------------
 // HTTP helper: fetch JSON from a remote debugging endpoint
@@ -174,40 +192,43 @@ export function registerChromeHandlers(
   });
 
   ipcMain.handle('chrome:inspect-targets', async () => {
-    mainLogger.debug('chrome.ipc.inspectTargets', { targetCount: networkTargets.length });
+    const targets_ = ensureNetworkTargets();
+    mainLogger.debug('chrome.ipc.inspectTargets', { targetCount: targets_.length });
     const results = await Promise.all(
-      networkTargets.map((t) => discoverTargets(t.host, t.port)),
+      targets_.map((t) => discoverTargets(t.host, t.port)),
     );
     const targets = results.flat();
     mainLogger.info('chrome.ipc.inspectTargets.result', { found: targets.length });
-    return { targets, networkTargets: [...networkTargets] };
+    return { targets, networkTargets: [...targets_] };
   });
 
   ipcMain.handle('chrome:inspect-get-network-targets', () => {
     mainLogger.debug('chrome.ipc.inspectGetNetworkTargets');
-    return [...networkTargets];
+    return [...ensureNetworkTargets()];
   });
 
   ipcMain.handle('chrome:inspect-add-target', (_event, host: string, port: number) => {
     mainLogger.info('chrome.ipc.inspectAddTarget', { host, port });
-    const already = networkTargets.some((t) => t.host === host && t.port === port);
+    const targets_ = ensureNetworkTargets();
+    const already = targets_.some((t) => t.host === host && t.port === port);
     if (!already) {
-      networkTargets.push({ host, port });
-      mainLogger.info('chrome.ipc.inspectAddTarget.added', { host, port, total: networkTargets.length });
+      targets_.push({ host, port });
+      mainLogger.info('chrome.ipc.inspectAddTarget.added', { host, port, total: targets_.length });
     } else {
       mainLogger.debug('chrome.ipc.inspectAddTarget.duplicate', { host, port });
     }
-    return [...networkTargets];
+    return [...targets_];
   });
 
   ipcMain.handle('chrome:inspect-remove-target', (_event, host: string, port: number) => {
     mainLogger.info('chrome.ipc.inspectRemoveTarget', { host, port });
-    const idx = networkTargets.findIndex((t) => t.host === host && t.port === port);
+    const targets_ = ensureNetworkTargets();
+    const idx = targets_.findIndex((t) => t.host === host && t.port === port);
     if (idx !== -1) {
-      networkTargets.splice(idx, 1);
-      mainLogger.info('chrome.ipc.inspectRemoveTarget.removed', { host, port, remaining: networkTargets.length });
+      targets_.splice(idx, 1);
+      mainLogger.info('chrome.ipc.inspectRemoveTarget.removed', { host, port, remaining: targets_.length });
     }
-    return [...networkTargets];
+    return [...targets_];
   });
 }
 

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -33,6 +33,11 @@ import { registerProtocol, initOAuthHandler } from './oauth';
 import { createOnboardingWindow } from './identity/onboardingWindow';
 import { registerOnboardingHandlers, unregisterOnboardingHandlers } from './identity/onboardingHandlers';
 import { mainLogger } from './logger';
+import {
+  resolveUserDataDir,
+  resolveCdpPort,
+  setAnnouncedCdpPort,
+} from './startup/cli';
 // daemon imports removed — Docker-per-task architecture replaces the persistent daemon
 import { getApiKey } from './agentApiKey';
 import { assertString } from './ipc-validators';
@@ -119,27 +124,39 @@ process.on('unhandledRejection', (reason, promise) => {
 });
 
 // ---------------------------------------------------------------------------
-// Dev-only: isolated userData override.
-// AGB_USER_DATA_DIR lets dev scripts (`start:fresh`, `start:onboarding`) run
-// the app against a throwaway profile without touching the real account.json,
-// keychain entries, or session store. MUST be applied before any
-// `app.getPath('userData')` call — including AccountStore/KeychainStore
-// construction at module-top-level below.
+// Isolated userData override.
+//
+// Precedence:
+//   1. `--user-data-dir=<path>` CLI flag (recommended — Playwright launchers,
+//      multi-instance tests)
+//   2. `AGB_USER_DATA_DIR` env var (dev-time `start:fresh` / `start:onboarding`
+//      scripts)
+//   3. Electron's platform default
+//
+// MUST be applied before any `app.getPath('userData')` call — including
+// AccountStore/KeychainStore construction at module-top-level below.
 // ---------------------------------------------------------------------------
-const USER_DATA_OVERRIDE = process.env.AGB_USER_DATA_DIR;
-if (USER_DATA_OVERRIDE) {
-  app.setPath('userData', USER_DATA_OVERRIDE);
+const resolvedUserData = resolveUserDataDir(process.argv, process.env);
+if (resolvedUserData.value) {
+  app.setPath('userData', resolvedUserData.value);
 }
 
 // ---------------------------------------------------------------------------
 // Remote debugging: MUST be called before app.whenReady()
 // ---------------------------------------------------------------------------
-// Fixed port so Docker agent containers can connect via ws://host.docker.internal:9222
-app.commandLine.appendSwitch('remote-debugging-port', '9222');
+// Respect `--remote-debugging-port=<N>` passed by launchers (test harnesses,
+// multi-instance dev). When none is given, default to 9222 so Docker agent
+// containers can keep reaching `host.docker.internal:9222`.
+const resolvedCdp = resolveCdpPort(process.argv);
+app.commandLine.appendSwitch('remote-debugging-port', String(resolvedCdp.port));
+setAnnouncedCdpPort(resolvedCdp.port);
 mainLogger.info('main.startup', {
-  msg: 'Remote debugging port set to 9222',
+  msg: `Remote debugging port set to ${resolvedCdp.port}`,
+  cdpPort: resolvedCdp.port,
+  cdpPortSource: resolvedCdp.source,
   settingsStandalone: process.env.SETTINGS_STANDALONE === '1',
-  userDataOverride: USER_DATA_OVERRIDE ?? null,
+  userDataOverride: resolvedUserData.value,
+  userDataSource: resolvedUserData.source,
   forceOnboarding: process.env.AGB_FORCE_ONBOARDING === '1',
 });
 

--- a/my-app/src/main/startup/cli.ts
+++ b/my-app/src/main/startup/cli.ts
@@ -1,0 +1,138 @@
+/**
+ * Startup CLI-flag parsing helpers.
+ *
+ * Two flags are honored before any store is constructed:
+ *
+ *   --user-data-dir=<path>    Override userData directory
+ *   --remote-debugging-port=<port>  Pick the CDP port exposed by Electron/Chromium
+ *
+ * Precedence (highest → lowest):
+ *   1. CLI flag (`--user-data-dir=…`, `--remote-debugging-port=…`)
+ *   2. Env var (`AGB_USER_DATA_DIR`)
+ *   3. Default (userData: Electron's platform default; CDP port: 9222 so
+ *      the Docker agent containers can reach `host.docker.internal:9222`)
+ *
+ * Kept as a standalone module so it can be unit-tested without booting Electron.
+ */
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a `--<flag>=<value>` or `--<flag> <value>` pair from an argv array.
+ * Returns `null` when the flag is absent or the value is empty.
+ */
+export function extractFlagValue(argv: readonly string[], flag: string): string | null {
+  const prefix = `--${flag}=`;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (arg.startsWith(prefix)) {
+      const v = arg.slice(prefix.length);
+      return v.length > 0 ? v : null;
+    }
+    if (arg === `--${flag}`) {
+      const next = argv[i + 1];
+      if (next !== undefined && next.length > 0 && !next.startsWith('-')) {
+        return next;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// --user-data-dir
+// ---------------------------------------------------------------------------
+
+export interface ResolvedUserDataDir {
+  value: string | null;
+  /** One of 'cli' | 'env' | null — null means caller should leave default. */
+  source: 'cli' | 'env' | null;
+}
+
+/**
+ * Resolve the userData override with explicit precedence.
+ *
+ * - `--user-data-dir=<path>` on argv wins.
+ * - Otherwise `AGB_USER_DATA_DIR` env var (dev fallback for start:fresh scripts).
+ * - Otherwise returns `{ value: null, source: null }` so the caller preserves
+ *   Electron's platform default.
+ */
+export function resolveUserDataDir(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv,
+): ResolvedUserDataDir {
+  const cli = extractFlagValue(argv, 'user-data-dir');
+  if (cli) return { value: cli, source: 'cli' };
+  const envVal = env.AGB_USER_DATA_DIR;
+  if (envVal && envVal.length > 0) return { value: envVal, source: 'env' };
+  return { value: null, source: null };
+}
+
+// ---------------------------------------------------------------------------
+// --remote-debugging-port
+// ---------------------------------------------------------------------------
+
+/** Default CDP port kept for Docker agent containers that hardcode 9222. */
+export const DEFAULT_CDP_PORT = 9222;
+
+export interface ResolvedCdpPort {
+  /**
+   * Port Electron will advertise via `remote-debugging-port`. `0` means
+   * Chromium will pick a free port at runtime — the real value has to be
+   * discovered from stdout / `/json/version` after launch.
+   */
+  port: number;
+  /** Whether the caller supplied a port (so we should NOT pick the default). */
+  source: 'cli' | 'default';
+}
+
+/**
+ * Resolve the CDP remote-debugging port.
+ *
+ * - `--remote-debugging-port=<N>` on argv wins. `0` (OS-assigned) is honored.
+ * - Otherwise returns `DEFAULT_CDP_PORT` (9222) so the Docker agent
+ *   containers that hardcode `host.docker.internal:9222` keep working.
+ *
+ * An invalid or negative port in argv is rejected (falls back to default)
+ * rather than silently crashing Electron at launch.
+ */
+export function resolveCdpPort(argv: readonly string[]): ResolvedCdpPort {
+  const raw = extractFlagValue(argv, 'remote-debugging-port');
+  if (raw === null) {
+    return { port: DEFAULT_CDP_PORT, source: 'default' };
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0 || n > 65535 || String(n) !== raw) {
+    return { port: DEFAULT_CDP_PORT, source: 'default' };
+  }
+  return { port: n, source: 'cli' };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level shared CDP port
+// ---------------------------------------------------------------------------
+//
+// TabManager and src/main/chrome/ipc.ts both need the CDP port that was
+// announced to Electron. They live in separate modules that can't easily
+// import from index.ts without creating a cycle, so we stash the resolved
+// port here and expose a getter.
+//
+// index.ts calls setAnnouncedCdpPort() immediately after appending the
+// --remote-debugging-port switch; consumers call getAnnouncedCdpPort() at
+// use-time. When `port === 0` (OS-assigned) consumers must fall back to
+// runtime discovery via `/json/version`.
+// ---------------------------------------------------------------------------
+
+let announcedCdpPort: number = DEFAULT_CDP_PORT;
+
+export function setAnnouncedCdpPort(port: number): void {
+  announcedCdpPort = port;
+}
+
+export function getAnnouncedCdpPort(): number {
+  return announcedCdpPort;
+}

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -67,6 +67,7 @@ import {
   CERT_ERROR_BACK_PREFIX,
 } from '../errors/NetworkErrorController';
 import type { TabGroupStore } from './TabGroupStore';
+import { getAnnouncedCdpPort } from '../startup/cli';
 
 // Forge VitePlugin globals for the new-tab page (injected at build time)
 declare const NEWTAB_VITE_DEV_SERVER_URL: string | undefined;
@@ -337,19 +338,36 @@ export class TabManager {
   // ---------------------------------------------------------------------------
 
   async discoverCdpPort(): Promise<number | null> {
-    // CDP port is fixed at 9222 (set in main/index.ts via --remote-debugging-port).
-    // Just verify it's responding.
-    const port = 9222;
-    try {
-      const res = await fetch(`http://localhost:${port}/json/version`, { signal: AbortSignal.timeout(2000) });
-      if (res.ok) {
-        this.cdpPort = port;
-        mainLogger.info('TabManager.discoverCdpPort.ok', { cdpPort: port });
-        return port;
-      }
-    } catch { /* not ready */ }
-    mainLogger.warn('TabManager.discoverCdpPort.notFound', { port });
+    // The port was announced via `--remote-debugging-port` in index.ts.
+    // If the caller passed `--remote-debugging-port=0`, Chromium chose a port
+    // at runtime; in that case `getAnnouncedCdpPort()` returns 0 and we fall
+    // back to scanning a small range of common debug ports (9222-9322) via
+    // `/json/version` so the test harness still works.
+    const announced = getAnnouncedCdpPort();
+    const candidates = announced > 0 ? [announced] : this.candidateCdpPorts();
+    for (const port of candidates) {
+      try {
+        const res = await fetch(`http://localhost:${port}/json/version`, { signal: AbortSignal.timeout(2000) });
+        if (res.ok) {
+          this.cdpPort = port;
+          mainLogger.info('TabManager.discoverCdpPort.ok', { cdpPort: port, announced });
+          return port;
+        }
+      } catch { /* not ready — keep trying */ }
+    }
+    mainLogger.warn('TabManager.discoverCdpPort.notFound', { announced, candidates });
     return null;
+  }
+
+  /**
+   * When Chromium picks an OS-assigned port (announced === 0), scan a small
+   * window of likely ports. The CDP endpoint only binds on a single port, so
+   * the first /json/version hit wins.
+   */
+  private candidateCdpPorts(): number[] {
+    const ports: number[] = [];
+    for (let p = 9222; p <= 9322; p++) ports.push(p);
+    return ports;
   }
   async getActiveTabTargetId(): Promise<string | null> {
     if (!this.activeTabId || !this.cdpPort) return null;

--- a/my-app/tests/unit/startup/cli.test.ts
+++ b/my-app/tests/unit/startup/cli.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for startup CLI flag parsing.
+ *
+ * Covers the two issues bundled together:
+ *   #206 — --user-data-dir=<path> must override AGB_USER_DATA_DIR env var
+ *   #207 — --remote-debugging-port=<N> must be honored instead of the
+ *          hardcoded 9222
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  extractFlagValue,
+  resolveUserDataDir,
+  resolveCdpPort,
+  DEFAULT_CDP_PORT,
+  setAnnouncedCdpPort,
+  getAnnouncedCdpPort,
+} from '../../../src/main/startup/cli';
+
+// ---------------------------------------------------------------------------
+// extractFlagValue
+// ---------------------------------------------------------------------------
+
+describe('extractFlagValue', () => {
+  it('returns value for --flag=value form', () => {
+    expect(extractFlagValue(['--foo=bar'], 'foo')).toBe('bar');
+  });
+
+  it('returns value for --flag value form (two args)', () => {
+    expect(extractFlagValue(['--foo', 'bar'], 'foo')).toBe('bar');
+  });
+
+  it('returns null when flag is absent', () => {
+    expect(extractFlagValue(['--other=1'], 'foo')).toBeNull();
+  });
+
+  it('returns null when --flag= has empty value', () => {
+    expect(extractFlagValue(['--foo='], 'foo')).toBeNull();
+  });
+
+  it('ignores flags with a matching prefix but different name', () => {
+    expect(extractFlagValue(['--foobar=baz'], 'foo')).toBeNull();
+  });
+
+  it('picks the first occurrence when repeated', () => {
+    expect(extractFlagValue(['--foo=a', '--foo=b'], 'foo')).toBe('a');
+  });
+
+  it('does not treat the next flag-like arg as a value', () => {
+    expect(extractFlagValue(['--foo', '--bar'], 'foo')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveUserDataDir — Issue #206
+// ---------------------------------------------------------------------------
+
+describe('resolveUserDataDir (#206)', () => {
+  it('honors --user-data-dir CLI flag', () => {
+    const r = resolveUserDataDir(['--user-data-dir=/tmp/cli-dir'], {});
+    expect(r.value).toBe('/tmp/cli-dir');
+    expect(r.source).toBe('cli');
+  });
+
+  it('honors AGB_USER_DATA_DIR env var when CLI flag absent', () => {
+    const r = resolveUserDataDir([], { AGB_USER_DATA_DIR: '/tmp/env-dir' });
+    expect(r.value).toBe('/tmp/env-dir');
+    expect(r.source).toBe('env');
+  });
+
+  it('CLI flag wins over env var (documented precedence)', () => {
+    const r = resolveUserDataDir(
+      ['--user-data-dir=/tmp/cli-dir'],
+      { AGB_USER_DATA_DIR: '/tmp/env-dir' },
+    );
+    expect(r.value).toBe('/tmp/cli-dir');
+    expect(r.source).toBe('cli');
+  });
+
+  it('returns null source when neither CLI nor env is set', () => {
+    const r = resolveUserDataDir([], {});
+    expect(r.value).toBeNull();
+    expect(r.source).toBeNull();
+  });
+
+  it('ignores an empty AGB_USER_DATA_DIR value', () => {
+    const r = resolveUserDataDir([], { AGB_USER_DATA_DIR: '' });
+    expect(r.value).toBeNull();
+    expect(r.source).toBeNull();
+  });
+
+  it('handles the exact launcher-shaped argv (Playwright electron.launch)', () => {
+    // Shape matches tests/setup/electron-launcher.ts line ~109
+    const argv = [
+      '/path/to/electron',
+      '/path/to/main.js',
+      '--user-data-dir=/tmp/agb-test-abc',
+      '--no-sandbox',
+      '--disable-gpu',
+      '--remote-debugging-port=0',
+    ];
+    const r = resolveUserDataDir(argv, {});
+    expect(r.value).toBe('/tmp/agb-test-abc');
+    expect(r.source).toBe('cli');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCdpPort — Issue #207
+// ---------------------------------------------------------------------------
+
+describe('resolveCdpPort (#207)', () => {
+  it('defaults to 9222 so Docker agents keep working', () => {
+    const r = resolveCdpPort([]);
+    expect(r.port).toBe(DEFAULT_CDP_PORT);
+    expect(r.port).toBe(9222);
+    expect(r.source).toBe('default');
+  });
+
+  it('honors --remote-debugging-port=9225', () => {
+    const r = resolveCdpPort(['--remote-debugging-port=9225']);
+    expect(r.port).toBe(9225);
+    expect(r.source).toBe('cli');
+  });
+
+  it('honors --remote-debugging-port=0 (OS-assigned)', () => {
+    const r = resolveCdpPort(['--remote-debugging-port=0']);
+    expect(r.port).toBe(0);
+    expect(r.source).toBe('cli');
+  });
+
+  it('honors two-arg form --remote-debugging-port 9226', () => {
+    const r = resolveCdpPort(['--remote-debugging-port', '9226']);
+    expect(r.port).toBe(9226);
+    expect(r.source).toBe('cli');
+  });
+
+  it('falls back to default for malformed port value', () => {
+    const r = resolveCdpPort(['--remote-debugging-port=not-a-number']);
+    expect(r.port).toBe(DEFAULT_CDP_PORT);
+    expect(r.source).toBe('default');
+  });
+
+  it('falls back to default for out-of-range port value', () => {
+    const r = resolveCdpPort(['--remote-debugging-port=99999']);
+    expect(r.port).toBe(DEFAULT_CDP_PORT);
+    expect(r.source).toBe('default');
+  });
+
+  it('falls back to default for negative port value', () => {
+    const r = resolveCdpPort(['--remote-debugging-port=-1']);
+    expect(r.port).toBe(DEFAULT_CDP_PORT);
+    expect(r.source).toBe('default');
+  });
+
+  it('handles exact multi-instance test argv (non-9222 startup)', () => {
+    // tests/e2e/multi-instance.spec.ts:233 uses 9225/9226
+    const argv = [
+      '/electron',
+      '/main.js',
+      '--user-data-dir=/tmp/inst-a',
+      '--no-sandbox',
+      '--disable-gpu',
+      '--remote-debugging-port=9225',
+    ];
+    const r = resolveCdpPort(argv);
+    expect(r.port).toBe(9225);
+    expect(r.source).toBe('cli');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Announced CDP port module-level store
+// ---------------------------------------------------------------------------
+
+describe('announced CDP port', () => {
+  beforeEach(() => {
+    setAnnouncedCdpPort(DEFAULT_CDP_PORT);
+  });
+
+  it('defaults to 9222', () => {
+    expect(getAnnouncedCdpPort()).toBe(9222);
+  });
+
+  it('returns whatever was last set', () => {
+    setAnnouncedCdpPort(9225);
+    expect(getAnnouncedCdpPort()).toBe(9225);
+  });
+
+  it('preserves 0 so consumers know to fall back to discovery', () => {
+    setAnnouncedCdpPort(0);
+    expect(getAnnouncedCdpPort()).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #206
Fixes #207

## Summary

### #206 — `--user-data-dir` CLI flag ignored
`src/main/index.ts` only honored `AGB_USER_DATA_DIR`, but every Playwright launcher passes `--user-data-dir=<path>` on argv. The flag now resolves before any store is constructed (same timing as the env var), with documented precedence **CLI > env > Electron default**.

### #207 — CDP port hardcoded to 9222
`remote-debugging-port` was unconditionally `9222`, and both `TabManager.discoverCdpPort` and `chrome/ipc.ts` hardcoded the same value. Launchers that pass `--remote-debugging-port=0` / `9225` / `9226` silently lost the port.

The fix adds `src/main/startup/cli.ts` with:
- `resolveUserDataDir(argv, env)` — CLI > env precedence
- `resolveCdpPort(argv)` — respects caller-supplied port (including `0` for OS-assigned), falls back to `9222` so Docker agents keep working
- `setAnnouncedCdpPort` / `getAnnouncedCdpPort` — module-level getter shared by `TabManager` and `chrome/ipc.ts`

When the port is `0` (OS-assigned), `TabManager.discoverCdpPort` now scans `9222-9322` via `/json/version` to find the real port.

## Test plan
- [x] 24 new unit tests in `tests/unit/startup/cli.test.ts` cover CLI > env precedence, `--remote-debugging-port=9225/9226/0`, malformed values, and the exact argv shapes used by `tests/setup/electron-launcher.ts` and `tests/e2e/multi-instance.spec.ts`.
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 new warnings (0 errors)
- [x] `npm test` — 448 passed (was 424 + 24 new)
- [ ] Manual: launch with `--user-data-dir=/tmp/foo --remote-debugging-port=9225`; confirm `/json/version` responds on 9225 and userData is `/tmp/foo`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `--user-data-dir` and `--remote-debugging-port` CLI flags with clear precedence and discovery to fix ignored profile dir and hardcoded CDP port. Fixes #206 and #207.

- **Bug Fixes**
  - `--user-data-dir` now applies before any store is created with precedence: CLI > `AGB_USER_DATA_DIR` > Electron default.
  - `--remote-debugging-port` is parsed by a new `src/main/startup/cli.ts`; honors specific ports and `0` (OS-assigned), otherwise defaults to `9222`, and exposes a shared getter for other modules.
  - `TabManager.discoverCdpPort` uses the announced port; when `0`, scans `9222–9322` via `/json/version` to find the real port.
  - `chrome/ipc` lazily seeds inspect targets from the announced port so the UI starts with the correct CDP endpoint.

<sup>Written for commit 0a8e337f14a5231474b75b70f184196f30d6ffb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

