### PR TITLE
fix(identity+privacy): sign-out 'clear' and clear-browsing-data actually remove app-local data

### DIFF
--- a/my-app/src/main/bookmarks/BookmarkStore.ts
+++ b/my-app/src/main/bookmarks/BookmarkStore.ts
@@ -311,6 +311,26 @@ export class BookmarkStore {
     return state;
   }
 
+  /**
+   * Remove every bookmark and folder under both roots, leaving the two
+   * top-level folders ("Bookmarks bar" + "Other bookmarks") empty.
+   *
+   * Used by sign-out "Clear data" and the privacy "Clear browsing data"
+   * path. The root folders themselves are never deleted — their ids are
+   * load-bearing.
+   */
+  deleteAll(): void {
+    const barCount = this.state.roots[0].children?.length ?? 0;
+    const otherCount = this.state.roots[1].children?.length ?? 0;
+    this.state.roots[0].children = [];
+    this.state.roots[1].children = [];
+    this.schedulePersist();
+    mainLogger.info('BookmarkStore.deleteAll', {
+      barCleared: barCount,
+      otherCleared: otherCount,
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Import / Export — Netscape HTML bookmark format
   // ---------------------------------------------------------------------------

--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -459,7 +459,13 @@ export class DownloadManager {
     this.broadcastState();
   }
 
-  private clearAll(): void {
+  /**
+   * Wipe the app-local download history (in-memory list only — does NOT
+   * touch files already saved to disk). Exposed publicly so callers like
+   * `ClearDataController` ("Clear browsing data" → downloads) and
+   * `SignOutController` ("Clear data" mode) can invoke it directly.
+   */
+  clearAll(): void {
     for (const [id, eItem] of this.electronItems) {
       eItem.cancel();
       this.clearThrottle(id);

--- a/my-app/src/main/identity/SignOutController.ts
+++ b/my-app/src/main/identity/SignOutController.ts
@@ -52,6 +52,21 @@ export interface SignOutResult {
   errors: string[];
 }
 
+/**
+ * App-local stores that hold copies of data the user might consider "synced".
+ * When the user picks "Clear data" at sign-out we wipe these in addition to
+ * the Electron session storage / cache / auth caches — otherwise the user's
+ * bookmarks, history, passwords and autofill entries stay on disk and the
+ * dialog copy ("Remove local copies of synced data") lies to them.
+ * Tracked as #216.
+ */
+export interface AppLocalStores {
+  bookmarkStore?: { deleteAll(): void };
+  historyStore?: { clearAll(): void };
+  passwordStore?: { deleteAllPasswords(): void };
+  autofillStore?: { deleteAll(): void };
+}
+
 // ---------------------------------------------------------------------------
 // Sign-out implementation
 // ---------------------------------------------------------------------------
@@ -60,9 +75,11 @@ export async function performSignOut(
   mode: SignOutMode,
   accountStore: AccountStore,
   keychainStore: KeychainStore,
+  stores?: AppLocalStores,
 ): Promise<SignOutResult> {
   mainLogger.info('SignOutController.performSignOut.start', {
     mode,
+    hasStores: !!stores,
   });
 
   const result: SignOutResult = {
@@ -84,9 +101,13 @@ export async function performSignOut(
   // 1. Revoke OAuth tokens from keychain
   result.tokenRevoked = await revokeTokens(email, keychainStore);
 
-  // 2. If "clear" mode, wipe synced data (history, cookies, passwords, etc.)
+  // 2. If "clear" mode, wipe synced data (session storage + app-local stores).
+  //    Each app-local wipe is independent: one failure must not prevent the
+  //    others from running, and must not block the sign-out itself. See #216.
   if (mode === 'clear') {
-    result.dataCleared = await clearSyncedData();
+    const sessionCleared = await clearSyncedData();
+    const localCleared = clearLocalStores(stores, result.errors);
+    result.dataCleared = sessionCleared && localCleared;
   } else {
     mainLogger.info('SignOutController.performSignOut.keepLocalData', {
       msg: 'Retaining local copies of synced data per user choice',
@@ -111,6 +132,26 @@ export async function performSignOut(
 // ---------------------------------------------------------------------------
 // Turn off sync (distinct from sign-out)
 // ---------------------------------------------------------------------------
+
+/**
+ * Return the currently signed-in identity as `{ email, agentName }`, or
+ * `null` when no `account.json` exists. Used by the sign-out dialog to
+ * show "Signed in as <email>" and by anywhere that wants a redacted view
+ * of account.json without directly touching the file. Issue #215.
+ */
+export function getAccountInfo(
+  accountStore: AccountStore,
+): { email: string; agentName: string } | null {
+  const data = accountStore.load();
+  if (!data) {
+    mainLogger.debug('SignOutController.getAccountInfo.noAccount');
+    return null;
+  }
+  return {
+    email:     data.email ?? '',
+    agentName: data.agent_name ?? '',
+  };
+}
 
 export async function turnOffSync(
   accountStore: AccountStore,
@@ -197,6 +238,53 @@ async function revokeTokens(
 
   mainLogger.info('SignOutController.revokeTokens.complete', { revoked });
   return revoked;
+}
+
+/**
+ * Wipe app-local copies of synced data (bookmarks, history, saved
+ * passwords, autofill). Returns true iff every provided store was cleared
+ * without throwing. Missing stores are silently skipped so the controller
+ * stays usable from backward-compatible call sites and unit tests.
+ *
+ * Implementation fixes Issue #216: before this, signing out with
+ * "Clear data" only wiped Electron session caches, leaving bookmarks.json /
+ * history.json / passwords.json / autofill.json on disk.
+ */
+function clearLocalStores(stores: AppLocalStores | undefined, errors: string[]): boolean {
+  if (!stores) {
+    mainLogger.info('SignOutController.clearLocalStores.skipped', {
+      msg: 'No app-local stores provided',
+    });
+    return true;
+  }
+
+  let allOk = true;
+
+  const attempts: Array<[keyof AppLocalStores, string, () => void]> = [
+    ['bookmarkStore',  'bookmarks',  () => stores.bookmarkStore?.deleteAll()],
+    ['historyStore',   'history',    () => stores.historyStore?.clearAll()],
+    ['passwordStore',  'passwords',  () => stores.passwordStore?.deleteAllPasswords()],
+    ['autofillStore',  'autofill',   () => stores.autofillStore?.deleteAll()],
+  ];
+
+  for (const [key, label, fn] of attempts) {
+    if (!stores[key]) continue;
+    try {
+      fn();
+      mainLogger.info('SignOutController.clearLocalStores.ok', { store: label });
+    } catch (err) {
+      allOk = false;
+      const msg = `${label}: ${(err as Error).message}`;
+      errors.push(msg);
+      mainLogger.error('SignOutController.clearLocalStores.failed', {
+        store: label,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  mainLogger.info('SignOutController.clearLocalStores.complete', { allOk });
+  return allOk;
 }
 
 async function clearSyncedData(): Promise<boolean> {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -49,6 +49,9 @@ import { getEngine, setEngine, type EngineId } from './hl/engine';
 // Track 5 — Settings
 import { openSettingsWindow, closeSettingsWindow, getSettingsWindow } from './settings/SettingsWindow';
 import { registerSettingsHandlers, unregisterSettingsHandlers, openClearDataDialogFromMenu } from './settings/ipc';
+// Issue #200 — ClearDataController needs the password store + download manager
+// wired in so the passwords/downloads checkboxes actually wipe app-local data.
+import { setPrivacyStoreDeps } from './privacy/ClearDataController';
 // Wave1 P3 — Bookmarks
 import { BookmarkStore } from './bookmarks/BookmarkStore';
 import { registerBookmarkHandlers, unregisterBookmarkHandlers } from './bookmarks/ipc';
@@ -242,6 +245,10 @@ function openShellAndWire(profileId?: string): BrowserWindow {
   tabManager.setTabGroupStore(tabGroupStore);
   downloadManager?.destroy();
   downloadManager = new DownloadManager(shellWindow);
+  // Issue #200: keep ClearDataController's downloadManager pointer fresh so
+  // "Clear browsing data → Download history" wipes the current instance's
+  // in-memory list, not a stale one from a previous shell.
+  setPrivacyStoreDeps({ downloadManager });
 
   // Wire bookmark-aware URL matching into the navigation heuristic.
   if (bookmarkStore) {
@@ -410,6 +417,8 @@ function openGuestShell(): BrowserWindow {
   });
   downloadManager?.destroy();
   downloadManager = new DownloadManager(shellWindow);
+  // Issue #200: same reason as openShellAndWire — keep the privacy dep live.
+  setPrivacyStoreDeps({ downloadManager });
 
   if (searchEngineStore) {
     tabManager.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
@@ -831,6 +840,15 @@ app.whenReady().then(async () => {
 
   // Track 5 — Settings IPC handlers
   registerSettingsHandlers({ accountStore, keychainStore });
+
+  // Issue #200 — let ClearDataController reach the password store + download
+  // manager so the "Passwords" / "Download history" checkboxes actually wipe
+  // app-local data. `downloadManager` is null here (constructed inside
+  // openShellAndWire below) — we re-apply the dep inside the shell factory.
+  setPrivacyStoreDeps({
+    passwordStore: passwordStore,
+    downloadManager: downloadManager,
+  });
 
   // Issue #84 — NTP Customization store + IPC
   const ntpStore = new NtpCustomizationStore();
@@ -2221,7 +2239,15 @@ ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) 
 
 ipcMain.handle('identity:sign-out', async (_event, mode: SignOutMode) => {
   mainLogger.info('main.identity:sign-out', { mode });
-  return performSignOut(mode, accountStore, keychainStore);
+  // Issue #216 — pass app-local stores so "Clear data" actually wipes
+  // bookmarks.json / history.json / passwords.json / autofill.json instead
+  // of only the Electron session caches.
+  return performSignOut(mode, accountStore, keychainStore, {
+    bookmarkStore: bookmarkStore ?? undefined,
+    historyStore:  historyStore  ?? undefined,
+    passwordStore: passwordStore ?? undefined,
+    autofillStore: autofillStore ?? undefined,
+  });
 });
 
 ipcMain.handle('identity:turn-off-sync', async () => {

--- a/my-app/src/main/privacy/ClearDataController.ts
+++ b/my-app/src/main/privacy/ClearDataController.ts
@@ -6,13 +6,22 @@
  * call — that would cause checking "history" alone to also wipe cookies and
  * cache. Each clear is independent; failures are captured per-type.
  *
- * Stubs (downloads, autofill, hostedApp) return `note: 'no-op'` until those
- * app-local stores exist.
+ * Issue #200 fix: `passwords` and `downloads` used to be no-ops despite
+ * being exposed as working checkboxes. They now delete app-local stores:
+ *   - passwords → `PasswordStore.deleteAllPasswords()` + `session.clearAuthCache`
+ *   - downloads → `DownloadManager.clearAll()` (history list only — the
+ *                  downloaded files on disk are not touched)
+ *
+ * The `hostedApp` checkbox used to map to a silent no-op. It has been
+ * removed from the renderer AND from the public DataType union so no
+ * caller can request it and get a false-positive "cleared" receipt.
  */
 
 import { session } from 'electron';
 import { mainLogger } from '../logger';
 import { clearAutofillData } from '../autofill/ipc';
+import type { PasswordStore } from '../passwords/PasswordStore';
+import type { DownloadManager } from '../downloads/DownloadManager';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,7 +35,6 @@ export const DATA_TYPES = [
   'passwords',
   'autofill',
   'siteSettings',
-  'hostedApp',
 ] as const;
 
 export type DataType = typeof DATA_TYPES[number];
@@ -56,11 +64,38 @@ const SITE_SETTINGS_STORAGES = ['indexdb', 'localstorage', 'websql', 'servicewor
 const CACHE_STORAGES         = ['cachestorage', 'shadercache'] as const;
 const COOKIE_STORAGES        = ['cookies'] as const;
 
-const NOTE_NOOP_DOWNLOADS = 'downloads store not yet implemented; no-op';
-const NOTE_NOOP_HOSTEDAPP = 'hosted-app data store not yet implemented; no-op';
 const NOTE_RANGE_IGNORED_CACHE     = 'time range ignored — clearCache wipes all cache';
 const NOTE_RANGE_IGNORED_HISTORY   = 'time range ignored — clearHistory wipes all history';
-const NOTE_RANGE_IGNORED_PASSWORDS = 'time range ignored — clearAuthCache wipes all auth';
+const NOTE_RANGE_IGNORED_PASSWORDS = 'time range ignored — auth + saved passwords wiped wholesale';
+const NOTE_FILES_KEPT_DOWNLOADS    = 'download history cleared; downloaded files on disk are kept';
+
+// ---------------------------------------------------------------------------
+// Store dependencies — injected by main/index.ts at app.whenReady() time.
+//
+// These are module-level rather than passed to `clearBrowsingData()` because
+// the existing settings IPC handler already sits between the renderer and the
+// controller; threading the stores through every call site would churn more
+// surface than the bug warrants. Tests call `setPrivacyStoreDeps(...)`
+// directly to inject stubs.
+// ---------------------------------------------------------------------------
+
+interface PrivacyStoreDeps {
+  passwordStore:   PasswordStore    | null;
+  downloadManager: DownloadManager  | null;
+}
+
+let _deps: PrivacyStoreDeps = {
+  passwordStore:   null,
+  downloadManager: null,
+};
+
+export function setPrivacyStoreDeps(deps: Partial<PrivacyStoreDeps>): void {
+  _deps = { ..._deps, ...deps };
+  mainLogger.info('privacy.setPrivacyStoreDeps', {
+    hasPasswordStore:   !!_deps.passwordStore,
+    hasDownloadManager: !!_deps.downloadManager,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Per-type clear implementations
@@ -95,8 +130,27 @@ async function clearCacheAll(): Promise<{ note?: string }> {
 }
 
 async function clearPasswords(): Promise<{ note?: string }> {
+  if (!_deps.passwordStore) {
+    // Surface rather than silently succeed — the "Passwords" checkbox must
+    // not appear to work if the store is not wired.
+    throw new Error('PasswordStore not initialised — cannot clear saved passwords');
+  }
+  // Delete the on-disk credentials + never-save list, then also flush the
+  // browser's cached HTTP auth credentials for origins that used basic /
+  // digest auth.
+  _deps.passwordStore.deleteAllPasswords();
   await session.defaultSession.clearAuthCache();
   return { note: NOTE_RANGE_IGNORED_PASSWORDS };
+}
+
+function clearDownloadHistory(): { note?: string } {
+  if (!_deps.downloadManager) {
+    throw new Error('DownloadManager not initialised — cannot clear download history');
+  }
+  // NOTE: this wipes the in-memory download list only. Files already saved
+  // to disk are deliberately left alone — Chrome behaves the same way.
+  _deps.downloadManager.clearAll();
+  return { note: NOTE_FILES_KEPT_DOWNLOADS };
 }
 
 async function clearSiteSettings(startTimeMs?: number): Promise<{ note?: string }> {
@@ -141,7 +195,7 @@ export async function clearBrowsingData(req: ClearDataRequest): Promise<ClearDat
           outcome = await clearCacheAll();
           break;
         case 'downloads':
-          outcome = { note: NOTE_NOOP_DOWNLOADS };
+          outcome = clearDownloadHistory();
           break;
         case 'passwords':
           outcome = await clearPasswords();
@@ -152,9 +206,6 @@ export async function clearBrowsingData(req: ClearDataRequest): Promise<ClearDat
           break;
         case 'siteSettings':
           outcome = await clearSiteSettings(startTimeMs);
-          break;
-        case 'hostedApp':
-          outcome = { note: NOTE_NOOP_HOSTEDAPP };
           break;
         default: {
           const _exhaustive: never = type;

--- a/my-app/src/preload/settings.ts
+++ b/my-app/src/preload/settings.ts
@@ -34,6 +34,8 @@ export interface OAuthScopeStatus {
   granted: boolean;
 }
 
+// Issue #200: `hostedApp` was removed after its checkbox was wired to a
+// silent no-op in the main process (see src/main/privacy/ClearDataController).
 export type ClearDataType =
   | 'history'
   | 'cookies'
@@ -41,8 +43,7 @@ export type ClearDataType =
   | 'downloads'
   | 'passwords'
   | 'autofill'
-  | 'siteSettings'
-  | 'hostedApp';
+  | 'siteSettings';
 
 export interface ClearDataResult {
   cleared: ClearDataType[];

--- a/my-app/src/renderer/settings/ClearDataDialog.tsx
+++ b/my-app/src/renderer/settings/ClearDataDialog.tsx
@@ -15,6 +15,9 @@ import { Button, Modal } from '../components/base';
 // Types
 // ---------------------------------------------------------------------------
 
+// NOTE: the former `hostedApp` entry was removed — it mapped to a silent
+// no-op in the main process and presented a false-positive "cleared" state
+// to the user. See Issue #200.
 type ClearDataType =
   | 'history'
   | 'cookies'
@@ -22,8 +25,7 @@ type ClearDataType =
   | 'downloads'
   | 'passwords'
   | 'autofill'
-  | 'siteSettings'
-  | 'hostedApp';
+  | 'siteSettings';
 
 interface ClearDataResult {
   cleared: ClearDataType[];
@@ -76,7 +78,6 @@ const ADVANCED_EXTRA_CHECKBOXES: CheckboxDef[] = [
   { type: 'passwords',    label: 'Passwords and other sign-in data', description: 'Clears saved passwords and auth cache.' },
   { type: 'autofill',     label: 'Autofill form data',            description: 'Clears saved form entries.' },
   { type: 'siteSettings', label: 'Site settings',                 description: 'Clears permissions, IndexedDB, service workers, localStorage.' },
-  { type: 'hostedApp',    label: 'Hosted app data',               description: 'Clears data stored by installed hosted apps.' },
 ];
 
 const DEFAULT_BASIC_SELECTED: Record<ClearDataType, boolean> = {
@@ -87,7 +88,6 @@ const DEFAULT_BASIC_SELECTED: Record<ClearDataType, boolean> = {
   passwords: false,
   autofill: false,
   siteSettings: false,
-  hostedApp: false,
 };
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -128,9 +128,11 @@ interface PasswordListEntry {
   updatedAt: number;
 }
 
+// Issue #200: `hostedApp` was removed after its checkbox was wired to a
+// silent no-op in the main process.
 type ClearDataTypeId =
   | 'history' | 'cookies' | 'cache' | 'downloads'
-  | 'passwords' | 'autofill' | 'siteSettings' | 'hostedApp';
+  | 'passwords' | 'autofill' | 'siteSettings';
 
 interface ClearBrowsingDataResult {
   cleared: ClearDataTypeId[];

--- a/my-app/tests/unit/identity/SignOutController.spec.ts
+++ b/my-app/tests/unit/identity/SignOutController.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * SignOutController unit tests — Issue #216.
+ *
+ * Verifies that `performSignOut('clear')` deletes app-local copies of synced
+ * data — bookmarks, history, passwords, autofill — in addition to session
+ * storage / cache / auth. `performSignOut('keep')` must NOT wipe these stores.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — fs (so `deleteAccountFile` is a no-op), logger, keytar
+// ---------------------------------------------------------------------------
+
+const { loggerSpy } = vi.hoisted(() => ({
+  loggerSpy: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: loggerSpy,
+}));
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    unlinkSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => false),
+  unlinkSync: vi.fn(),
+}));
+
+// keytar is optional: stub findCredentials to return empty so the revoke path
+// doesn't hit the real native module.
+vi.mock('keytar', () => ({
+  findCredentials: vi.fn(async () => []),
+  deletePassword: vi.fn(async () => true),
+}));
+
+import { performSignOut } from '../../../src/main/identity/SignOutController';
+
+// ---------------------------------------------------------------------------
+// Fake stores — only implement the surfaces SignOutController actually needs
+// ---------------------------------------------------------------------------
+
+interface FakeAccountStore {
+  load: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+}
+
+interface FakeKeychainStore {
+  deleteToken: ReturnType<typeof vi.fn>;
+}
+
+interface Deletable {
+  deleteAll: ReturnType<typeof vi.fn>;
+}
+
+interface AppLocalStores {
+  bookmarkStore: Deletable;
+  historyStore: { clearAll: ReturnType<typeof vi.fn> };
+  passwordStore: { deleteAllPasswords: ReturnType<typeof vi.fn> };
+  autofillStore: Deletable;
+}
+
+function makeAccountStore(email: string): FakeAccountStore {
+  return {
+    load: vi.fn(() => ({ agent_name: 'Atlas', email, created_at: '2024-01-01' })),
+    save: vi.fn(),
+  };
+}
+
+function makeKeychainStore(): FakeKeychainStore {
+  return {
+    deleteToken: vi.fn(async () => undefined),
+  };
+}
+
+function makeStores(): AppLocalStores {
+  return {
+    bookmarkStore: { deleteAll: vi.fn() },
+    historyStore: { clearAll: vi.fn() },
+    passwordStore: { deleteAllPasswords: vi.fn() },
+    autofillStore: { deleteAll: vi.fn() },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignOutController.performSignOut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clear mode wipes app-local bookmark/history/password/autofill stores", async () => {
+    const stores = makeStores();
+    const result = await performSignOut(
+      'clear',
+      makeAccountStore('user@example.com') as never,
+      makeKeychainStore() as never,
+      stores as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('clear');
+    expect(result.dataCleared).toBe(true);
+
+    expect(stores.bookmarkStore.deleteAll).toHaveBeenCalledTimes(1);
+    expect(stores.historyStore.clearAll).toHaveBeenCalledTimes(1);
+    expect(stores.passwordStore.deleteAllPasswords).toHaveBeenCalledTimes(1);
+    expect(stores.autofillStore.deleteAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("keep mode does NOT touch the app-local stores", async () => {
+    const stores = makeStores();
+    const result = await performSignOut(
+      'keep',
+      makeAccountStore('user@example.com') as never,
+      makeKeychainStore() as never,
+      stores as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('keep');
+    expect(result.dataCleared).toBe(false);
+
+    expect(stores.bookmarkStore.deleteAll).not.toHaveBeenCalled();
+    expect(stores.historyStore.clearAll).not.toHaveBeenCalled();
+    expect(stores.passwordStore.deleteAllPasswords).not.toHaveBeenCalled();
+    expect(stores.autofillStore.deleteAll).not.toHaveBeenCalled();
+  });
+
+  it("clear mode still succeeds when stores are not provided (backward compat)", async () => {
+    // Older callers may not pass the stores bag. The controller should not
+    // throw — it degrades to clearing only session storage.
+    const result = await performSignOut(
+      'clear',
+      makeAccountStore('user@example.com') as never,
+      makeKeychainStore() as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('clear');
+  });
+
+  it("clear mode tolerates a failing individual store without aborting the sign-out", async () => {
+    const stores = makeStores();
+    stores.bookmarkStore.deleteAll.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    const result = await performSignOut(
+      'clear',
+      makeAccountStore('user@example.com') as never,
+      makeKeychainStore() as never,
+      stores as never,
+    );
+
+    // Other stores must still have been asked to delete; the sign-out still
+    // completes so the user is signed out.
+    expect(stores.historyStore.clearAll).toHaveBeenCalledTimes(1);
+    expect(stores.passwordStore.deleteAllPasswords).toHaveBeenCalledTimes(1);
+    expect(stores.autofillStore.deleteAll).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it("revokes OAuth tokens via keychainStore.deleteToken", async () => {
+    const keychain = makeKeychainStore();
+    await performSignOut(
+      'keep',
+      makeAccountStore('user@example.com') as never,
+      keychain as never,
+    );
+    expect(keychain.deleteToken).toHaveBeenCalledWith('user@example.com');
+  });
+});

--- a/my-app/tests/unit/privacy/ClearDataController.spec.ts
+++ b/my-app/tests/unit/privacy/ClearDataController.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * ClearDataController unit tests — Issue #200.
+ *
+ * Before this fix:
+ *   - `passwords` mapped to `session.clearAuthCache()` only, leaving every
+ *     saved credential on disk.
+ *   - `downloads` was a no-op.
+ *   - `hostedApp` was a no-op shown to the user as a working checkbox.
+ *
+ * After the fix:
+ *   - `passwords` → `PasswordStore.deleteAllPasswords()` + `clearAuthCache`.
+ *   - `downloads` → wipe the app-local download history list.
+ *   - `hostedApp` is removed from the DataType union / UI.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  sessionMock,
+  autofillMock,
+  passwordStoreStub,
+  downloadManagerStub,
+  loggerSpy,
+} = vi.hoisted(() => {
+  const sessionMock = {
+    defaultSession: {
+      clearStorageData: vi.fn(async () => undefined),
+      clearCache: vi.fn(async () => undefined),
+      clearAuthCache: vi.fn(async () => undefined),
+      clearHistory: vi.fn(async () => undefined),
+    },
+  };
+  const autofillMock = { clearAutofillData: vi.fn() };
+  const passwordStoreStub = {
+    deleteAllPasswords: vi.fn(),
+  };
+  const downloadManagerStub = {
+    clearAll: vi.fn(),
+  };
+  const loggerSpy = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    sessionMock,
+    autofillMock,
+    passwordStoreStub,
+    downloadManagerStub,
+    loggerSpy,
+  };
+});
+
+vi.mock('electron', () => ({
+  session: sessionMock,
+  app: { getPath: () => '/tmp/test' },
+}));
+
+vi.mock('../../../src/main/autofill/ipc', () => autofillMock);
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: loggerSpy,
+}));
+
+import {
+  clearBrowsingData,
+  setPrivacyStoreDeps,
+  DATA_TYPES,
+} from '../../../src/main/privacy/ClearDataController';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClearDataController — store wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPrivacyStoreDeps({
+      passwordStore: passwordStoreStub as never,
+      downloadManager: downloadManagerStub as never,
+    });
+  });
+
+  describe('passwords', () => {
+    it("calls PasswordStore.deleteAllPasswords() — not just clearAuthCache", async () => {
+      const result = await clearBrowsingData({ types: ['passwords'], timeRangeMs: 0 });
+
+      expect(passwordStoreStub.deleteAllPasswords).toHaveBeenCalledTimes(1);
+      expect(sessionMock.defaultSession.clearAuthCache).toHaveBeenCalledTimes(1);
+      expect(result.cleared).toContain('passwords');
+      expect(result.errors).not.toHaveProperty('passwords');
+    });
+
+    it("surfaces an error (not a silent no-op) if the password store is missing", async () => {
+      setPrivacyStoreDeps({ passwordStore: null, downloadManager: downloadManagerStub as never });
+      const result = await clearBrowsingData({ types: ['passwords'], timeRangeMs: 0 });
+      expect(result.errors.passwords).toBeDefined();
+    });
+  });
+
+  describe('downloads', () => {
+    it("calls DownloadManager.clearAll() to wipe the app-local download history", async () => {
+      const result = await clearBrowsingData({ types: ['downloads'], timeRangeMs: 0 });
+
+      expect(downloadManagerStub.clearAll).toHaveBeenCalledTimes(1);
+      expect(result.cleared).toContain('downloads');
+      expect(result.errors).not.toHaveProperty('downloads');
+    });
+
+    it("surfaces an error when the download manager is not yet initialised", async () => {
+      setPrivacyStoreDeps({ passwordStore: passwordStoreStub as never, downloadManager: null });
+      const result = await clearBrowsingData({ types: ['downloads'], timeRangeMs: 0 });
+      expect(result.errors.downloads).toBeDefined();
+    });
+  });
+
+  describe('hostedApp', () => {
+    it("is removed from the public DataType list so the renderer cannot request it", () => {
+      expect((DATA_TYPES as readonly string[])).not.toContain('hostedApp');
+    });
+  });
+
+  describe("autofill (sanity check)", () => {
+    it("calls clearAutofillData()", async () => {
+      const result = await clearBrowsingData({ types: ['autofill'], timeRangeMs: 0 });
+      expect(autofillMock.clearAutofillData).toHaveBeenCalledTimes(1);
+      expect(result.cleared).toContain('autofill');
+    });
+  });
+
+  describe("multiple types", () => {
+    it("runs each selected wipe independently", async () => {
+      const result = await clearBrowsingData({
+        types: ['passwords', 'downloads', 'autofill'],
+        timeRangeMs: 0,
+      });
+      expect(passwordStoreStub.deleteAllPasswords).toHaveBeenCalledTimes(1);
+      expect(downloadManagerStub.clearAll).toHaveBeenCalledTimes(1);
+      expect(autofillMock.clearAutofillData).toHaveBeenCalledTimes(1);
+      expect(result.cleared).toEqual(expect.arrayContaining(['passwords', 'downloads', 'autofill']));
+    });
+  });
+});

--- a/my-app/vitest.config.ts
+++ b/my-app/vitest.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
       'tests/unit/zoom/**/*.spec.ts',
       'tests/unit/shell/**/*.spec.tsx',
       'tests/unit/share/**/*.spec.ts',
+      // Sign-out store wiring + ClearDataController wiring
+      // (Issues #216 / #200 — sign-out 'clear' and clear-data actually remove data)
+      'tests/unit/identity/SignOutController.spec.ts',
+      'tests/unit/privacy/**/*.spec.ts',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],
     // Renderer .spec.tsx files declare jsdom via the per-file


### PR DESCRIPTION
Fixes #216, #200.

Two closely-related bugs where the UI promised to delete user data and silently didn't. Bundled into one PR because they share surface (SignOutController, ClearDataController, and the app-local stores they need to wipe). The #215 companion bug (sign-out IPC handlers not registered) already landed on main in #239 — this branch was rebased to drop that duplicate work and now threads the new `AppLocalStores` bag through the inline `identity:sign-out` handler that #239 added.

## Summary

- **Issue #216 (P1) — Sign-out "Clear data" left app-local stores on disk.**  
  `SignOutController.clearSyncedData()` only wiped Electron session storage + cache + auth. `bookmarks.json`, `history.json`, `passwords.json`, and `autofill.json` all survived the "Remove local copies of synced data" path — the dialog copy was lying.  
  **Fix:** `performSignOut` now takes an optional `AppLocalStores` bag and, in `"clear"` mode, calls `bookmarkStore.deleteAll() / historyStore.clearAll() / passwordStore.deleteAllPasswords() / autofillStore.deleteAll()`. Each wipe is independent — one failure pushes to `result.errors` but does NOT abort the sign-out. Added `BookmarkStore.deleteAll()` to match the other stores' APIs. The existing `ipcMain.handle('identity:sign-out', ...)` in `main/index.ts` (registered by #239) now threads this bag through.

- **Issue #200 (P0) — ClearDataController had three silent no-ops.**  
  `passwords` mapped to `clearAuthCache()` only (saved credentials stayed). `downloads` and `hostedApp` were flat no-ops even though the checkboxes looked functional.  
  **Fix:**  
  - `passwords` → `PasswordStore.deleteAllPasswords()` (credentials + never-save list) + `session.clearAuthCache()`.  
  - `downloads` → new public `DownloadManager.clearAll()` (in-memory log only; downloaded files on disk kept, Chrome parity).  
  - `hostedApp` → removed from the renderer dialog, the preload type, and the public `DATA_TYPES` union so no caller can request it and get a false-positive receipt.  
  Stores are injected via a new `setPrivacyStoreDeps(...)` on `ClearDataController` rather than threaded through every call site, and are re-applied whenever a fresh `DownloadManager` is constructed in `openShellAndWire` / `openGuestShell`.

## Test plan

- [x] `npm run lint` — clean (0 errors)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 34 files / 465 tests pass, including new tests:
  - `tests/unit/identity/SignOutController.spec.ts` — clear mode calls every store, keep mode calls none, backward-compat when no stores, failure isolation, token revoke
  - `tests/unit/privacy/ClearDataController.spec.ts` — passwords store wired + error path, downloads wired + error path, hostedApp gone, autofill sanity, multi-type run

### Manual verification (suggested)
- [ ] Sign in, add a bookmark / visit a page / save a password / save an address.
- [ ] Open the account menu → Sign out → "Clear data". Confirm `account.json`, `bookmarks.json`, `history.json`, `passwords.json`, `autofill.json` are wiped under `userData`.
- [ ] Sign in again, repeat, but pick "Keep local data" and confirm those four files survive.
- [ ] Settings → Clear browsing data → Advanced → check "Passwords and other sign-in data" only → confirm `passwords.json` is emptied but other stores are untouched.
- [ ] Settings → Clear browsing data → Advanced → check "Download history" only → confirm the downloads bubble list is empty and previously-downloaded files still exist on disk.
- [ ] Confirm the "Hosted app data" checkbox is gone from the Advanced tab.
