### PR TITLE
fix(extensions): register MV3 IPC handlers at startup

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -83,6 +83,7 @@ import { registerContentCategoryHandlers, unregisterContentCategoryHandlers } fr
 // Issue #71 — Extensions
 import { ExtensionManager } from './extensions/ExtensionManager';
 import { registerExtensionsHandlers, unregisterExtensionsHandlers } from './extensions/ipc';
+import { registerMV3Handlers, unregisterMV3Handlers } from './extensions/mv3';
 import { openExtensionsWindow } from './extensions/ExtensionsWindow';
 // Issue #40 — History
 import { HistoryStore } from './history/HistoryStore';
@@ -854,6 +855,7 @@ app.whenReady().then(async () => {
 // Issue #71 — Extensions: init manager + register IPC
   extensionManager = new ExtensionManager();
   registerExtensionsHandlers(extensionManager);
+  registerMV3Handlers(extensionManager);
   void extensionManager.loadAllEnabled();
 
   // Issue #95 — Settings zoom override IPC (needs tabManager access)
@@ -973,6 +975,7 @@ app.whenReady().then(async () => {
     unregisterPipHandlers();
     unregisterTabGroupHandlers();
     unregisterExtensionsHandlers();
+    unregisterMV3Handlers();
     unregisterAutofillHandlers();
     // ExtensionManager currently has no dispose()/destroy() hook; its
     // internal MV3 runtime tears itself down via its own lifecycle. If a


### PR DESCRIPTION
## Summary

- `registerMV3Handlers(extensionManager)` was defined and exported from `src/main/extensions/mv3/ipc.ts` but was never called, making the entire MV3 IPC surface (`mv3:*` channels) dead at runtime.
- Added the call immediately after `registerExtensionsHandlers(extensionManager)` in `app.whenReady()`.
- Added the corresponding `unregisterMV3Handlers()` call in the `will-quit` handler, alongside the other unregister calls.
- Added the import for both `registerMV3Handlers` and `unregisterMV3Handlers` from `./extensions/mv3`.

Closes #235.

## Test plan

- [ ] `npm run typecheck` passes with no errors (verified locally).
- [ ] On app startup, the 16 `mv3:*` IPC channels (`mv3:get-info`, `mv3:list`, `mv3:validate`, `mv3:worker-state`, `mv3:worker-wake`, `mv3:worker-stop`, `mv3:action-state`, `mv3:action-set-badge`, `mv3:action-set-title`, `mv3:action-set-popup`, `mv3:dnr-get-rules`, `mv3:dnr-update-dynamic`, `mv3:dnr-update-session`, `mv3:active-tab-grant`, `mv3:active-tab-check`, `mv3:active-tab-revoke`) are now registered and respond to renderer invocations.
- [ ] On app quit, all `mv3:*` handlers are cleanly removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the MV3 IPC surface by registering its handlers at startup and cleaning them up on quit. This fixes dead `mv3:*` channels so MV3 extensions respond as expected.

- **Bug Fixes**
  - Register `registerMV3Handlers(extensionManager)` right after `registerExtensionsHandlers(...)` in `app.whenReady()`.
  - Add `unregisterMV3Handlers()` to the `will-quit` cleanup sequence.

<sup>Written for commit 1b519d12ec99b173e50991f74f5ef5299f6de7ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

