### PR TITLE
fix(devtools): emit devtools:tab-changed on active-tab switch and reattach in renderer

### DIFF
--- a/my-app/src/main/devtools/ipc.ts
+++ b/my-app/src/main/devtools/ipc.ts
@@ -7,6 +7,7 @@ import { ipcMain, BrowserWindow } from 'electron';
 import { mainLogger } from '../logger';
 import { DevToolsBridge } from './DevToolsBridge';
 import { TabManager } from '../tabs/TabManager';
+import { getDevToolsWindow } from './DevToolsWindow';
 
 let bridge: DevToolsBridge | null = null;
 
@@ -66,13 +67,25 @@ export function registerDevToolsHandlers(tabManager: TabManager): void {
     const tab = state.tabs.find((t) => t.id === state.activeTabId);
     return tab ?? null;
   });
+
+  tabManager.setOnActiveTabChanged((tabId: string) => {
+    const win = getDevToolsWindow();
+    if (!win) return;
+    const state = tabManager.getState();
+    const tab = state.tabs.find((t) => t.id === tabId);
+    mainLogger.info('devtools:tab-changed', { tabId, url: tab?.url });
+    win.webContents.send('devtools:tab-changed', tabId);
+  });
 }
 
-export function unregisterDevToolsHandlers(): void {
+export function unregisterDevToolsHandlers(tabManager?: TabManager): void {
   mainLogger.info('devtools.ipc.unregister');
   if (bridge) {
     bridge.detach();
     bridge = null;
+  }
+  if (tabManager) {
+    tabManager.setOnActiveTabChanged(null);
   }
   ipcMain.removeHandler('devtools:attach');
   ipcMain.removeHandler('devtools:detach');

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -172,6 +172,7 @@ export class TabManager {
   private onTabClosed: ((tabId: string) => void) | null = null;
   private onWebContentsCreated: ((wc: import("electron").WebContents) => void) | null = null;
   private onMoveTabToNewWindow: ((url: string, title: string) => void) | null = null;
+  private onActiveTabChanged: ((tabId: string) => void) | null = null;
   // Extra pixels the renderer added on top of the base chrome (e.g. 32 px
   // for a visible bookmarks bar). The page-hosting WebContentsView is then
   // positioned at CHROME_HEIGHT + chromeOffset.
@@ -244,6 +245,10 @@ export class TabManager {
 
   setOnMoveTabToNewWindow(cb: ((url: string, title: string) => void) | null): void {
     this.onMoveTabToNewWindow = cb;
+  }
+
+  setOnActiveTabChanged(cb: ((tabId: string) => void) | null): void {
+    this.onActiveTabChanged = cb;
   }
 
   setHistoryStore(store: HistoryStore): void {
@@ -712,6 +717,7 @@ export class TabManager {
     this.win.webContents.send('tab-activated', tabId);
     this.broadcastState();
     this.broadcastZoom();
+    this.onActiveTabChanged?.(tabId);
   }
 
   moveTab(tabId: string, toIndex: number): void {

--- a/my-app/src/renderer/devtools/DevToolsApp.tsx
+++ b/my-app/src/renderer/devtools/DevToolsApp.tsx
@@ -138,6 +138,16 @@ export function DevToolsApp(): React.ReactElement {
     };
   }, [connect]);
 
+  useEffect(() => {
+    const unsubscribe = devtoolsAPI.onTabChanged((_tabId: string) => {
+      console.log('[DevToolsApp] active tab changed, reattaching...', _tabId);
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+      void devtoolsAPI.detach().then(() => connect());
+    });
+    return unsubscribe;
+  }, [connect]);
+
   const isAttached = connectionState === 'connected';
 
   const renderPanel = (): React.ReactElement | null => {


### PR DESCRIPTION
## Summary

Fixes #236 — the custom DevTools window was permanently attached to the tab that was active at connect-time and never followed the user to a different tab.

- **`TabManager.ts`**: Added `onActiveTabChanged` callback field + `setOnActiveTabChanged()` setter (same pattern as `onTabClosed` / `onClosedTabsChanged`). `activateTab()` now fires this callback with the new `tabId` at the end of every tab switch.
- **`src/main/devtools/ipc.ts`**: `registerDevToolsHandlers` registers an `onActiveTabChanged` listener on the `TabManager`. When it fires, the handler looks up the open DevTools `BrowserWindow` via the existing `getDevToolsWindow()` helper and sends `devtools:tab-changed` with the new `tabId`. `unregisterDevToolsHandlers` now accepts an optional `tabManager` parameter so the callback is properly cleaned up.
- **`DevToolsApp.tsx`**: Added a `useEffect` that subscribes to `devtoolsAPI.onTabChanged`. On each event it cleans up the current CDP event listener, calls `devtoolsAPI.detach()`, then calls `connect()` to reattach to the newly-active tab — exactly the same flow as the initial connect.

## Test plan

- [ ] Open the custom DevTools window while on Tab A; verify it attaches and CDP events flow
- [ ] Switch to Tab B; verify the DevTools window automatically detaches from Tab A and reattaches to Tab B (title/URL in the header updates)
- [ ] Switch back to Tab A; verify it follows again
- [ ] Open DevTools, close the DevTools window, re-open it — normal flow still works
- [ ] `npm run typecheck` passes with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the custom DevTools follow the active tab by emitting `devtools:tab-changed` on tab switches and reattaching in the renderer. Fixes #236 where DevTools stayed bound to the first tab.

- **Bug Fixes**
  - TabManager: added `onActiveTabChanged` callback + `setOnActiveTabChanged`; invoked at the end of `activateTab()`.
  - Main IPC: on active tab change, finds the DevTools window and sends `devtools:tab-changed`; `unregisterDevToolsHandlers` accepts `tabManager` to remove the listener.
  - Renderer: `DevToolsApp` listens for tab changes, cleans up, calls `detach()`, then `connect()` to attach to the new active tab.

<sup>Written for commit 519deaca5ff898b68403c8b1240bfa0413889e55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

