### PR TITLE
fix(identity): add sync_enabled to AccountData type and gate sync on the flag

### DIFF
--- a/my-app/src/main/identity/AccountStore.ts
+++ b/my-app/src/main/identity/AccountStore.ts
@@ -6,7 +6,7 @@
  *
  * File location: ${app.getPath('userData')}/account.json
  *
- * Shape: { agent_name, email, created_at, onboarding_completed_at? }
+ * Shape: { agent_name, email, created_at, onboarding_completed_at?, sync_enabled? }
  *
  * D2 logging: save/load/isComplete transitions logged at debug level.
  * PII policy: email is logged for debugging; no passwords or tokens.
@@ -33,6 +33,32 @@ export interface AccountData {
   created_at?: string;
   /** ISO 8601 — set when the user completes onboarding */
   onboarding_completed_at?: string;
+  /**
+   * When false, background sync with the user's Google account is disabled.
+   * Defaults to true (sync on) if absent, matching Chrome's behaviour.
+   * Set to false by SignOutController.turnOffSync().
+   * Gate any sync-related behaviour on `getSyncEnabled(account)`.
+   */
+  sync_enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns whether sync is enabled for the given account.
+ *
+ * Treats `undefined` as true so that existing accounts that predate the
+ * sync_enabled field behave as if sync is on (Chrome parity: sync is on by
+ * default once the user signs in).
+ *
+ * Usage:
+ *   const account = accountStore.load();
+ *   if (getSyncEnabled(account)) { ... }
+ */
+export function getSyncEnabled(account: AccountData | null | undefined): boolean {
+  return account?.sync_enabled !== false;
 }
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/main/identity/SignOutController.ts
+++ b/my-app/src/main/identity/SignOutController.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import { app, session } from 'electron';
 import { mainLogger } from '../logger';
 import type { AccountStore } from './AccountStore';
+import { getSyncEnabled } from './AccountStore';
 import type { KeychainStore } from './KeychainStore';
 
 // ---------------------------------------------------------------------------
@@ -123,12 +124,16 @@ export async function turnOffSync(
     return { success: false };
   }
 
-  // Mark sync as disabled in account data while keeping the Google association
-  const updated = { ...account, sync_enabled: false } as typeof account & { sync_enabled: boolean };
-  accountStore.save(updated);
+  // Mark sync as disabled in account data while keeping the Google association.
+  // sync_enabled is now a first-class field on AccountData (no cast needed).
+  accountStore.save({ ...account, sync_enabled: false });
 
+  // Verify the flag was persisted correctly.
+  const saved = accountStore.load();
+  const stillEnabled = getSyncEnabled(saved);
   mainLogger.info('SignOutController.turnOffSync.complete', {
     email: account.email,
+    syncEnabled: stillEnabled, // should be false
   });
 
   return { success: true };

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -26,7 +26,7 @@ import { registerHotkeys, unregisterHotkeys } from './hotkeys';
 import { makeRequest, PROTOCOL_VERSION } from '../shared/types';
 import type { AgentEvent } from '../shared/types';
 // Track C — Onboarding gate
-import { AccountStore } from './identity/AccountStore';
+import { AccountStore, getSyncEnabled } from './identity/AccountStore';
 import { OAuthClient } from './identity/OAuthClient';
 import { KeychainStore } from './identity/KeychainStore';
 import { registerProtocol, initOAuthHandler } from './oauth';
@@ -2232,7 +2232,11 @@ ipcMain.handle('identity:turn-off-sync', async () => {
 ipcMain.handle('identity:get-account-info', () => {
   const account = accountStore.load();
   if (!account) return null;
-  return { email: account.email, agentName: account.agent_name };
+  return {
+    email: account.email,
+    agentName: account.agent_name,
+    syncEnabled: getSyncEnabled(account),
+  };
 });
 
 ipcMain.handle('shell:get-cdp-info', async () => {

--- a/my-app/src/preload/shell.ts
+++ b/my-app/src/preload/shell.ts
@@ -746,7 +746,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     turnOffSync: (): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('identity:turn-off-sync'),
 
-    getAccountInfo: (): Promise<{ email: string; agentName: string } | null> =>
+    getAccountInfo: (): Promise<{ email: string; agentName: string; syncEnabled: boolean } | null> =>
       ipcRenderer.invoke('identity:get-account-info'),
   },
 

--- a/my-app/src/renderer/shell/SignOutDialog.tsx
+++ b/my-app/src/renderer/shell/SignOutDialog.tsx
@@ -25,7 +25,7 @@ declare const electronAPI: {
       errors: string[];
     }>;
     turnOffSync: () => Promise<{ success: boolean }>;
-    getAccountInfo: () => Promise<{ email: string; agentName: string } | null>;
+    getAccountInfo: () => Promise<{ email: string; agentName: string; syncEnabled: boolean } | null>;
   };
 };
 


### PR DESCRIPTION
## Summary

- Adds `sync_enabled?: boolean` to the `AccountData` interface in `AccountStore.ts`, fixing the missing type that caused `turnOffSync()` to rely on an unsafe type cast
- Introduces a `getSyncEnabled(account)` helper that returns `account?.sync_enabled !== false` (defaults to `true` for Chrome-parity: sync is on by default for signed-in accounts without the field)
- Removes the `as typeof account & { sync_enabled: boolean }` cast in `SignOutController.turnOffSync()` — no longer needed now that the field is typed
- Adds a post-save verification log in `turnOffSync()` using `getSyncEnabled` to confirm the flag was persisted
- Exposes `syncEnabled` in the `identity:get-account-info` IPC response so the renderer can react to sync state changes
- Updates the preload `shell.ts` and `SignOutDialog.tsx` type declarations to include `syncEnabled: boolean` in the `getAccountInfo` return type

## Test plan

- [ ] After clicking "Turn off sync" in the sign-out dialog, `account.json` should contain `"sync_enabled": false`
- [ ] `getSyncEnabled(accountStore.load())` should return `false` after turn-off-sync
- [ ] Existing accounts without `sync_enabled` in their `account.json` should continue to work (helper returns `true` for missing field)
- [ ] `identity:get-account-info` IPC now returns `{ email, agentName, syncEnabled }` — verify `syncEnabled` is `false` after turning off sync
- [ ] `npm run typecheck` passes with no errors

Closes #237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed `sync_enabled` flag to `AccountData` and gates sync on it, fixing the unsafe cast in `turnOffSync()` while keeping sync on by default when the field is missing. Exposes `syncEnabled` via `identity:get-account-info` so the renderer can react to turn-off-sync. Closes #237.

- **Bug Fixes**
  - Add `sync_enabled?: boolean` and `getSyncEnabled(account)` (defaults to true if absent).
  - Remove unsafe cast in `SignOutController.turnOffSync()` and verify persistence in logs.
  - Return `{ email, agentName, syncEnabled }` from `identity:get-account-info`.
  - Update preload and renderer types to include `syncEnabled`.

<sup>Written for commit 644fd74ee306c9adb6f0f0e2f91eaedba4abc64b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

