### PR TITLE
fix(settings): surface error instead of false success for unimplemented re-consent flow

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -440,11 +440,11 @@ function handleGetOAuthScopes(): Array<{ scope: string; label: string; granted: 
 }
 
 function handleReConsentScope(_event: Electron.IpcMainInvokeEvent, scope: string): void {
-  // Stub: OAuth re-consent is a full flow; log intent and return OK.
-  mainLogger.info(CH_RE_CONSENT_SCOPE, {
+  mainLogger.warn(CH_RE_CONSENT_SCOPE, {
     scope,
-    msg: 'Re-consent requested — full OAuth flow not yet implemented; returning stub OK',
+    msg: 'Re-consent requested — full OAuth flow is not yet implemented',
   });
+  throw new Error('Re-consent OAuth flow is not yet implemented');
 }
 
 async function handleFactoryReset(): Promise<void> {

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -702,15 +702,15 @@ function GoogleScopesTab(): React.ReactElement {
     try {
       await window.settingsAPI.reConsentScope(scope);
       toast.show({
-        variant: 'info',
-        title: 'Re-consent initiated',
+        variant: 'success',
+        title: 'Re-consent complete',
         message: `Scope: ${scope}`,
       });
     } catch (err) {
       toast.show({
-        variant: 'error',
-        title: 'Re-consent failed',
-        message: (err as Error).message,
+        variant: 'warning',
+        title: 'Re-consent not available',
+        message: 'Re-consent is not yet available. Please sign out and sign back in to update permissions.',
       });
     } finally {
       setReconsentId(null);
@@ -756,6 +756,7 @@ function GoogleScopesTab(): React.ReactElement {
                 size="sm"
                 onClick={() => void handleReconsent(s.scope)}
                 loading={reconsentId === s.scope}
+                title="Re-consent is not yet available"
               >
                 Re-consent
               </Button>


### PR DESCRIPTION
## Summary

- The `settings:re-consent-scope` IPC handler in `ipc.ts` was a stub that silently returned `void`, causing the renderer to always show a misleading "Re-consent initiated" success toast even though nothing actually happened.
- Changed the handler to `throw new Error('Re-consent OAuth flow is not yet implemented')` and log at `warn` level instead of `info`.
- Updated the renderer catch block to show a `warning` toast with the message _"Re-consent is not yet available. Please sign out and sign back in to update permissions."_ rather than a generic error with an internal error string.
- Updated the success path to use `variant: 'success'` and title _"Re-consent complete"_ so it correctly reflects a real success if the flow is implemented in the future.
- Added a `title` tooltip on the Re-consent button so users see "Re-consent is not yet available" on hover.

Closes #201

## Test plan

- [ ] Open Settings → Google Scopes
- [ ] Click "Re-consent" on any scope
- [ ] Verify a **warning** toast appears with title "Re-consent not available" and the sign-out guidance message
- [ ] Verify no "Re-consent initiated" success toast appears
- [ ] Hover over the Re-consent button — tooltip shows "Re-consent is not yet available"
- [ ] `npm run typecheck` passes with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing a misleading success state for the unimplemented re-consent OAuth flow. The main process now throws and the UI shows a clear warning with guidance.

- **Bug Fixes**
  - IPC: change re-consent handler to throw and log at warn level.
  - UI: show a warning toast with “sign out and sign back in” guidance; update future success toast to “Re-consent complete”.
  - UX: add a tooltip on the Re-consent button (“Re-consent is not yet available”).

<sup>Written for commit a15b2ec311d97c3d940a39d622235003e3069647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

