### PR TITLE
fix(privacy): clear passwords and download history in ClearDataController

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -477,6 +477,16 @@ export class DownloadManager {
     this.broadcastState();
   }
 
+  /**
+   * Public entry point used by ClearDataController ("Clear browsing data →
+   * Download history"). Clears the in-memory download list and cancels any
+   * active downloads, then broadcasts the empty state to the renderer.
+   */
+  clearAllForPrivacy(): void {
+    mainLogger.info('DownloadManager.clearAllForPrivacy');
+    this.clearAll();
+  }
+
   // ---------------------------------------------------------------------------
   // Settings: show downloads when done
   // ---------------------------------------------------------------------------

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -840,7 +840,12 @@ app.whenReady().then(async () => {
   });
 
   // Track 5 — Settings IPC handlers
-  registerSettingsHandlers({ accountStore, keychainStore });
+  registerSettingsHandlers({
+    accountStore,
+    keychainStore,
+    getPasswordStore:   () => passwordStore,
+    getDownloadManager: () => downloadManager,
+  });
 
   // Issue #200 — let ClearDataController reach the password store + download
   // manager so the "Passwords" / "Download history" checkboxes actually wipe

--- a/my-app/src/main/privacy/ClearDataController.ts
+++ b/my-app/src/main/privacy/ClearDataController.ts
@@ -48,6 +48,9 @@ export interface ClearDataRequest {
    * clear everything — this is an Electron API limitation.
    */
   timeRangeMs: number;
+  /** Optional stores injected by the caller (main process). */
+  passwordStore?: PasswordStore;
+  downloadManager?: DownloadManager;
 }
 
 export interface ClearDataResult {
@@ -140,6 +143,7 @@ async function clearPasswords(): Promise<{ note?: string }> {
   // digest auth.
   _deps.passwordStore.deleteAllPasswords();
   await session.defaultSession.clearAuthCache();
+  mainLogger.info('privacy.clearPasswords.storeCleared');
   return { note: NOTE_RANGE_IGNORED_PASSWORDS };
 }
 

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -25,6 +25,8 @@ import {
   type ClearDataResult,
 } from '../privacy/ClearDataController';
 import { isBiometricAvailable } from '../passwords/BiometricAuth';
+import type { PasswordStore } from '../passwords/PasswordStore';
+import type { DownloadManager } from '../downloads/DownloadManager';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -114,6 +116,10 @@ const CH_SET_LIVE_CAPTION         = 'settings:set-live-caption';
 
 let _accountStore: AccountStore | null = null;
 let _keychainStore: KeychainStore | null = null;
+// Lazy getters — resolved at call-time so DownloadManager can be wired up after
+// registerSettingsHandlers() is first called (it's created inside openShellAndWire).
+let _getPasswordStore:  () => PasswordStore | null  = () => null;
+let _getDownloadManager: () => DownloadManager | null = () => null;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -563,7 +569,12 @@ async function handleClearData(
     throw new Error('timeRangeMs must be a non-negative number');
   }
 
-  return clearBrowsingData({ types: validTypes, timeRangeMs: range });
+  return clearBrowsingData({
+    types: validTypes,
+    timeRangeMs: range,
+    passwordStore: _getPasswordStore() ?? undefined,
+    downloadManager: _getDownloadManager() ?? undefined,
+  });
 }
 
 /**
@@ -918,15 +929,20 @@ function handleCloseWindow(): void {
 // ---------------------------------------------------------------------------
 
 export interface RegisterSettingsHandlersOptions {
-  accountStore:  AccountStore;
-  keychainStore: KeychainStore;
+  accountStore:       AccountStore;
+  keychainStore:      KeychainStore;
+  getPasswordStore?:  () => PasswordStore | null;
+  getDownloadManager?: () => DownloadManager | null;
 }
 
 export function registerSettingsHandlers(opts: RegisterSettingsHandlersOptions): void {
   mainLogger.info('settings.ipc.register');
 
-  _accountStore  = opts.accountStore;
-  _keychainStore = opts.keychainStore;
+  _accountStore    = opts.accountStore;
+  _keychainStore   = opts.keychainStore;
+  // Stash getters so handleClearData can resolve the live instances at call-time.
+  if (opts.getPasswordStore)  _getPasswordStore  = opts.getPasswordStore;
+  if (opts.getDownloadManager) _getDownloadManager = opts.getDownloadManager;
 
   ipcMain.handle(CH_SAVE_API_KEY,     handleSaveApiKey);
   ipcMain.handle(CH_LOAD_API_KEY,     handleLoadApiKey);
@@ -1016,8 +1032,10 @@ export function unregisterSettingsHandlers(): void {
   ipcMain.removeHandler(CH_GET_LIVE_CAPTION);
   ipcMain.removeHandler(CH_SET_LIVE_CAPTION);
 
-  _accountStore  = null;
-  _keychainStore = null;
+  _accountStore      = null;
+  _keychainStore     = null;
+  _getPasswordStore  = () => null;
+  _getDownloadManager = () => null;
 
   mainLogger.info('settings.ipc.unregister.ok');
 }


### PR DESCRIPTION
## Summary

Closes #200

- **passwords**: `clearPasswords()` now calls `PasswordStore.deleteAllPasswords()` (wipes both saved credentials and the never-save list) in addition to `session.clearAuthCache()`. The store is injected via a lazy getter so there's no circular-dependency issue.
- **downloads**: The `downloads` case now calls `DownloadManager.clearAllForPrivacy()` (new public method wrapping the existing private `clearAll()`), clearing the in-memory download history list. The manager is also resolved via a lazy getter at call-time.
- **hostedApp**: Removed from `DATA_TYPES` and from `ClearDataDialog`, `preload/settings.ts`, and `SettingsApp.tsx` — there is no backing store, so the checkbox was silently no-opping and misleading users.

## How injection works

`registerSettingsHandlers()` now accepts optional `getPasswordStore` and `getDownloadManager` getter functions. These are resolved lazily inside `handleClearData` so `DownloadManager` (created during `openShellAndWire()`) is available even though it's instantiated after settings handlers are registered.

## Test plan

- [ ] Open Settings → Privacy → Clear browsing data → Advanced tab
- [ ] Check "Passwords and other sign-in data" + clear → confirm saved passwords are gone (Settings → Passwords page should be empty)
- [ ] Start a download, then clear "Download history" → confirm the downloads panel shows empty
- [ ] Confirm "Hosted app data" checkbox no longer appears in the Advanced tab
- [ ] `npm run typecheck` in `my-app/` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure “Passwords” and “Download history” in Clear browsing data actually erase app data and the auth cache, as required by Linear #200. Also remove the misleading “Hosted app data” option.

- **Bug Fixes**
  - Passwords: `clearPasswords()` now calls `PasswordStore.deleteAllPasswords()` and `session.clearAuthCache()`.
  - Downloads: `DownloadManager.clearAllForPrivacy()` clears in-memory history and cancels active downloads.
  - UI: Removed “Hosted app data” from `DATA_TYPES`, dialog, preload, and renderer.

- **Refactors**
  - `registerSettingsHandlers()` accepts lazy `getPasswordStore` and `getDownloadManager` getters, and `handleClearData` passes them to `clearBrowsingData` to resolve instances at call time.

<sup>Written for commit dfe8b4287462c1b7ae80810b68cb43c241c16ea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

