### PR TITLE
fix(settings): complete factory reset — remove all profile dirs, local stores, and token fallbacks

### DIFF
--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -519,7 +519,74 @@ async function handleFactoryReset(): Promise<void> {
     mainLogger.warn(`${CH_FACTORY_RESET}.sockCleanupFailed`, { error: (err as Error).message });
   }
 
-  // 5. Delete logs directory
+  // 5. Delete app-local data stores (bookmarks, history, passwords, autofill)
+  const localStoreFiles = [
+    'bookmarks.json',
+    'history.json',
+    'passwords.json',
+    'autofill.json',
+  ];
+  for (const fileName of localStoreFiles) {
+    const filePath = path.join(userDataPath, fileName);
+    try {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        mainLogger.info(`${CH_FACTORY_RESET}.localStoreDeleted`, { file: fileName });
+      }
+    } catch (err) {
+      mainLogger.warn(`${CH_FACTORY_RESET}.localStoreDeleteFailed`, {
+        file: fileName,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // 6. Delete per-site data stores (permissions, granted-devices, content-categories)
+  const siteDataFiles = [
+    'permissions.json',
+    'granted-devices.json',
+    'content-categories.json',
+  ];
+  for (const fileName of siteDataFiles) {
+    const filePath = path.join(userDataPath, fileName);
+    try {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        mainLogger.info(`${CH_FACTORY_RESET}.siteDataDeleted`, { file: fileName });
+      }
+    } catch (err) {
+      mainLogger.warn(`${CH_FACTORY_RESET}.siteDataDeleteFailed`, {
+        file: fileName,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // 7. Delete safeStorage fallback token files (*.oauth-tokens.enc)
+  try {
+    const allFiles = fs.readdirSync(userDataPath);
+    for (const file of allFiles) {
+      if (file.endsWith('.oauth-tokens.enc')) {
+        fs.unlinkSync(path.join(userDataPath, file));
+        mainLogger.info(`${CH_FACTORY_RESET}.tokenFallbackDeleted`, { file });
+      }
+    }
+  } catch (err) {
+    mainLogger.warn(`${CH_FACTORY_RESET}.tokenFallbackCleanupFailed`, { error: (err as Error).message });
+  }
+
+  // 8. Delete per-profile directories (profiles/*)
+  const profilesDir = path.join(userDataPath, 'profiles');
+  try {
+    if (fs.existsSync(profilesDir)) {
+      fs.rmSync(profilesDir, { recursive: true, force: true });
+      mainLogger.info(`${CH_FACTORY_RESET}.profileDirsDeleted`);
+    }
+  } catch (err) {
+    mainLogger.warn(`${CH_FACTORY_RESET}.profileDirsDeleteFailed`, { error: (err as Error).message });
+  }
+
+  // 9. Delete logs directory
   const logsDir = path.join(userDataPath, LOGS_DIR_NAME);
   try {
     if (fs.existsSync(logsDir)) {
@@ -532,7 +599,7 @@ async function handleFactoryReset(): Promise<void> {
 
   mainLogger.info(`${CH_FACTORY_RESET}.complete`, { msg: 'Factory reset complete' });
 
-  // 6. Relaunch (skip in test environment)
+  // 10. Relaunch (skip in test environment)
   if (process.env.NODE_ENV !== 'test') {
     app.relaunch();
     app.quit();


### PR DESCRIPTION
## Summary

Fixes two issues where `handleFactoryReset()` left user data on disk after a reset:

- **#217**: Add deletion of app-local JSON stores (`bookmarks.json`, `history.json`, `passwords.json`, `autofill.json`) and `*.oauth-tokens.enc` safeStorage fallback files
- **#225**: Add recursive deletion of `profiles/` directory (all non-default per-profile dirs), plus `permissions.json`, `granted-devices.json`, and `content-categories.json`

All new deletion steps follow the existing pattern: synchronous `fs` calls wrapped in `try/catch` with `warn`-and-continue logging, so a failure in any one step never blocks the rest of the reset sequence.

Closes #217
Closes #225

## Test plan

- [ ] Factory reset from Settings clears `bookmarks.json`, `history.json`, `passwords.json`, `autofill.json` from userData
- [ ] Factory reset removes any `*.oauth-tokens.enc` files in userData (safeStorage fallback path)
- [ ] Factory reset removes `permissions.json`, `granted-devices.json`, `content-categories.json` from userData
- [ ] Factory reset recursively removes `<userData>/profiles/` and all per-profile subdirectories
- [ ] `npm run typecheck` passes with no errors
- [ ] App relaunches cleanly after reset with no stale data visible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the factory reset by deleting all local stores, per-site data, token fallbacks, and profile directories so no user data remains on disk after reset. Deletions run with synchronous `fs` and warn-and-continue logging so one failure doesn't block the reset.

- **Bug Fixes**
  - Remove app-local JSON stores: `bookmarks.json`, `history.json`, `passwords.json`, `autofill.json`.
  - Remove per-site data: `permissions.json`, `granted-devices.json`, `content-categories.json`.
  - Delete token fallback files matching `*.oauth-tokens.enc`.
  - Recursively delete `<userData>/profiles/` and all subdirectories.

<sup>Written for commit 944938faa6ab7f4c7050bda33b67504c1627f687. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

