### PR TITLE
fix(identity): persist Google scope selections and grant status in AccountData

### DIFF
--- a/my-app/src/main/identity/AccountStore.ts
+++ b/my-app/src/main/identity/AccountStore.ts
@@ -40,6 +40,17 @@ export interface AccountData {
    * Gate any sync-related behaviour on `getSyncEnabled(account)`.
    */
   sync_enabled?: boolean;
+  /**
+   * The Google OAuth scopes the user selected during onboarding (or re-consent).
+   * Stored as full scope URL strings, e.g. "https://www.googleapis.com/auth/gmail.readonly".
+   * Absent on accounts created before this field was introduced.
+   */
+  oauth_scopes?: string[];
+  /**
+   * Whether the user has been through the Google OAuth consent screen at least once.
+   * Set to true when onboarding completes successfully.
+   */
+  scopes_granted?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/main/identity/onboardingHandlers.ts
+++ b/my-app/src/main/identity/onboardingHandlers.ts
@@ -113,13 +113,15 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
       scopeCount: payload.oauth_scopes.length,
     });
 
-    // Persist completed state with timestamp
+    // Persist completed state with timestamp, including selected OAuth scopes
     const existing = accountStore.load();
     accountStore.save({
       agent_name: payload.agent_name,
       email: payload.account.email,
       created_at: existing?.created_at,
       onboarding_completed_at: new Date().toISOString(),
+      oauth_scopes: payload.oauth_scopes,
+      scopes_granted: payload.oauth_scopes.length > 0,
     });
 
     mainLogger.info('onboardingHandlers.complete.accountSaved', {

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -59,11 +59,11 @@ const ALLOWED_PAGE_ZOOM_PERCENTS = [
 ] as const;
 
 const GOOGLE_SCOPE_LIST = [
-  { scope: 'email',    label: 'Email address' },
-  { scope: 'profile',  label: 'Public profile' },
-  { scope: 'calendar', label: 'Google Calendar' },
-  { scope: 'drive',    label: 'Google Drive' },
-  { scope: 'gmail',    label: 'Gmail' },
+  { scope: 'https://www.googleapis.com/auth/gmail.readonly',  label: 'Gmail' },
+  { scope: 'https://www.googleapis.com/auth/calendar',        label: 'Google Calendar' },
+  { scope: 'https://www.googleapis.com/auth/spreadsheets',    label: 'Sheets' },
+  { scope: 'https://www.googleapis.com/auth/drive',           label: 'Google Drive' },
+  { scope: 'https://www.googleapis.com/auth/documents',       label: 'Docs' },
 ] as const;
 
 type ScopeName = typeof GOOGLE_SCOPE_LIST[number]['scope'];
@@ -430,7 +430,7 @@ function handleSetDefaultPageZoom(_event: Electron.IpcMainInvokeEvent, percent: 
 function handleGetOAuthScopes(): Array<{ scope: string; label: string; granted: boolean }> {
   mainLogger.info(CH_GET_OAUTH_SCOPES);
   const account = _accountStore?.load();
-  const grantedScopes: string[] = (account as unknown as { oauth_scopes?: string[] })?.oauth_scopes ?? [];
+  const grantedScopes: string[] = account?.oauth_scopes ?? [];
 
   const result = GOOGLE_SCOPE_LIST.map(({ scope, label }) => ({
     scope,

--- a/my-app/src/renderer/onboarding/AccountCreation.tsx
+++ b/my-app/src/renderer/onboarding/AccountCreation.tsx
@@ -16,10 +16,14 @@ const CURRENT_STEP = 3;
 interface AccountCreationProps {
   onBack: () => void;
   onComplete: (account: { email: string; display_name?: string }, scopes: GoogleOAuthScope[]) => void;
+  /** Called immediately when the user confirms scope selection, before OAuth redirect.
+   *  Allows the parent to store the selected scopes so they are available when
+   *  the OAuth callback fires asynchronously. */
+  onScopesSelected?: (scopes: GoogleOAuthScope[]) => void;
   oauthError?: string | null;
 }
 
-export function AccountCreation({ onBack, onComplete: _onComplete, oauthError }: AccountCreationProps): React.ReactElement {
+export function AccountCreation({ onBack, onComplete: _onComplete, onScopesSelected, oauthError }: AccountCreationProps): React.ReactElement {
   const [showScopesModal, setShowScopesModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -31,6 +35,10 @@ export function AccountCreation({ onBack, onComplete: _onComplete, oauthError }:
   async function handleScopesConfirm(scopes: GoogleOAuthScope[]): Promise<void> {
     setShowScopesModal(false);
     setIsLoading(true);
+
+    // Propagate selected scopes to the parent immediately so they are stored in
+    // state before the async OAuth callback fires.
+    onScopesSelected?.(scopes);
 
     try {
       if (typeof window !== 'undefined' && (window as Window & { onboardingAPI?: { startOAuth: (scopes: GoogleOAuthScope[]) => Promise<void> } }).onboardingAPI) {

--- a/my-app/src/renderer/onboarding/index.tsx
+++ b/my-app/src/renderer/onboarding/index.tsx
@@ -212,6 +212,7 @@ function OnboardingApp(): React.ReactElement {
       <AccountCreation
         onBack={() => setState((prev) => ({ ...prev, step: 'naming', oauthError: null }))}
         onComplete={(account, scopes) => void handleAccountComplete(account, scopes)}
+        onScopesSelected={(scopes) => setState((prev) => ({ ...prev, oauthScopes: scopes }))}
         oauthError={oauthError}
       />
     );


### PR DESCRIPTION
## Summary

- **Root cause — scopes dropped in `AccountCreation`**: The `onComplete` prop was renamed to `_onComplete` (intentionally unused). As a result, when the user confirmed scope selection, the scopes were passed to `startOAuth()` but never propagated back up to `OnboardingApp.state.oauthScopes`. When the async OAuth callback fired, `state.oauthScopes` was still `[]`.
- **Root cause — scopes not saved to disk**: Even if scopes reached `onboarding:complete`, the `accountStore.save()` call in `onboardingHandlers.ts` only wrote `agent_name`, `email`, `created_at`, and `onboarding_completed_at` — `oauth_scopes` was silently dropped.
- **Root cause — scope format mismatch in Settings**: `GOOGLE_SCOPE_LIST` in `settings/ipc.ts` used shorthand names (`gmail`, `calendar`, etc.) but stored scopes use full URLs (`https://www.googleapis.com/auth/gmail.readonly`). The `includes()` check always returned false so all scopes showed as "Not granted".

## Changes

- **`AccountStore.ts`**: Add `oauth_scopes?: string[]` and `scopes_granted?: boolean` to `AccountData` as first-class typed fields (removes `as unknown as` cast downstream).
- **`onboardingHandlers.ts`**: Persist `oauth_scopes` and `scopes_granted` in the `onboarding:complete` handler.
- **`AccountCreation.tsx`**: Add `onScopesSelected?: (scopes: GoogleOAuthScope[]) => void` prop; call it in `handleScopesConfirm` before starting OAuth so the parent can capture the selection synchronously.
- **`index.tsx`**: Wire `onScopesSelected` to update `state.oauthScopes` immediately, ensuring it is populated before the OAuth callback fires.
- **`settings/ipc.ts`**: Replace shorthand scope names in `GOOGLE_SCOPE_LIST` with the full scope URLs that match `GoogleScopesModal` and `GoogleOAuthScope`; use `account.oauth_scopes` directly (no cast).

## Test plan

- [ ] Run `npm run typecheck` from `my-app/` — passes with no errors.
- [ ] Complete onboarding: confirm scope selection, finish OAuth. After completion, open Settings → Google Scopes — scopes selected during onboarding should show as "Granted".
- [ ] Deselect one scope during onboarding, complete flow. That scope should show as "Not granted" in Settings.
- [ ] Sign out and sign back in — verify fresh onboarding stores new scope selections correctly.

Closes #221

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist selected Google OAuth scopes and grant status in account data so choices survive restarts and Settings shows correct “Granted” states. Fixes lost scopes during onboarding and a scope format mismatch. Closes #221.

- **Bug Fixes**
  - Add oauth_scopes and scopes_granted to AccountData; save both on onboarding:complete.
  - Add onScopesSelected in AccountCreation to sync selection to OnboardingApp before the OAuth callback.
  - Use full scope URLs in settings/ipc and read account.oauth_scopes directly (removed unsafe cast).

<sup>Written for commit 85f2fdc318e297b62e15790c14012ed4a0669621. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

