### PR TITLE
fix(onboarding+identity): stop lying about password storage and Google scope state

### DIFF
--- a/my-app/src/main/identity/AccountStore.ts
+++ b/my-app/src/main/identity/AccountStore.ts
@@ -33,6 +33,13 @@ export interface AccountData {
   created_at?: string;
   /** ISO 8601 — set when the user completes onboarding */
   onboarding_completed_at?: string;
+  /**
+   * Full Google OAuth scope URIs the user has granted
+   * (e.g. "https://www.googleapis.com/auth/gmail.readonly"). Empty if the
+   * user has never completed a Google OAuth flow. Persisted so the Settings
+   * → Google Scopes UI can accurately reflect grant state across restarts.
+   */
+  oauth_scopes?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/my-app/src/main/identity/onboardingHandlers.ts
+++ b/my-app/src/main/identity/onboardingHandlers.ts
@@ -61,6 +61,7 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
       email: existing?.email ?? '',
       created_at: existing?.created_at,
       onboarding_completed_at: existing?.onboarding_completed_at,
+      oauth_scopes: existing?.oauth_scopes,
     });
 
     mainLogger.debug('onboardingHandlers.setAgentName.ok', {
@@ -113,18 +114,22 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
       scopeCount: payload.oauth_scopes.length,
     });
 
-    // Persist completed state with timestamp
+    // Persist completed state with timestamp. Store the full OAuth scope URIs
+    // (issue #221) so Settings → Google Scopes can reflect grants accurately
+    // across restarts.
     const existing = accountStore.load();
     accountStore.save({
       agent_name: payload.agent_name,
       email: payload.account.email,
       created_at: existing?.created_at,
       onboarding_completed_at: new Date().toISOString(),
+      oauth_scopes: payload.oauth_scopes,
     });
 
     mainLogger.info('onboardingHandlers.complete.accountSaved', {
       agentName: payload.agent_name,
       email: payload.account.email,
+      scopeCount: payload.oauth_scopes.length,
     });
 
     // Small delay to let the completion animation play

--- a/my-app/src/main/oauth.ts
+++ b/my-app/src/main/oauth.ts
@@ -20,6 +20,7 @@ import { mainLogger } from './logger';
 import { OAuthClient, PROTOCOL_SCHEME } from './identity/OAuthClient';
 import { KeychainStore } from './identity/KeychainStore';
 import { AccountStore } from './identity/AccountStore';
+import type { GoogleOAuthScope } from '../shared/types';
 
 // ---------------------------------------------------------------------------
 // Module-level state
@@ -193,6 +194,7 @@ async function handleCallbackUrl(url: string): Promise<void> {
         email: tokens.email,
         display_name: tokens.display_name,
       },
+      scopes: tokens.scopes,
     });
   } catch (err) {
     const message = (err as Error).message;
@@ -211,6 +213,7 @@ async function handleCallbackUrl(url: string): Promise<void> {
 function sendCallbackResult(result: {
   success: boolean;
   account?: { email: string; display_name?: string };
+  scopes?: GoogleOAuthScope[];
   error?: string;
 }): void {
   if (!onboardingWindow || onboardingWindow.isDestroyed()) {

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -56,15 +56,27 @@ const ALLOWED_PAGE_ZOOM_PERCENTS = [
   75, 80, 90, 100, 110, 125, 150, 175, 200, 250, 300, 400, 500,
 ] as const;
 
+/**
+ * Google services shown in Settings → Google Scopes.
+ *
+ * `scope` is the full OAuth scope URI — the same string emitted by the
+ * onboarding GoogleScopesModal and persisted to AccountStore.oauth_scopes.
+ * `email` and `profile` are always requested as base scopes by OAuthClient
+ * (see BASE_SCOPES), so they are surfaced here with their canonical URIs too.
+ *
+ * Issue #221: previously used short ids ("gmail", "calendar", ...) which did
+ * not match what onboarding stored, so granted services always rendered as
+ * "Not granted".
+ */
 const GOOGLE_SCOPE_LIST = [
-  { scope: 'email',    label: 'Email address' },
-  { scope: 'profile',  label: 'Public profile' },
-  { scope: 'calendar', label: 'Google Calendar' },
-  { scope: 'drive',    label: 'Google Drive' },
-  { scope: 'gmail',    label: 'Gmail' },
+  { scope: 'email',                                              label: 'Email address' },
+  { scope: 'profile',                                            label: 'Public profile' },
+  { scope: 'https://www.googleapis.com/auth/calendar',           label: 'Google Calendar' },
+  { scope: 'https://www.googleapis.com/auth/drive',              label: 'Google Drive' },
+  { scope: 'https://www.googleapis.com/auth/gmail.readonly',     label: 'Gmail' },
+  { scope: 'https://www.googleapis.com/auth/spreadsheets',       label: 'Google Sheets' },
+  { scope: 'https://www.googleapis.com/auth/documents',          label: 'Google Docs' },
 ] as const;
-
-type ScopeName = typeof GOOGLE_SCOPE_LIST[number]['scope'];
 
 // IPC channels
 const CH_SAVE_API_KEY      = 'settings:save-api-key';
@@ -424,7 +436,9 @@ function handleSetDefaultPageZoom(_event: Electron.IpcMainInvokeEvent, percent: 
 function handleGetOAuthScopes(): Array<{ scope: string; label: string; granted: boolean }> {
   mainLogger.info(CH_GET_OAUTH_SCOPES);
   const account = _accountStore?.load();
-  const grantedScopes: string[] = (account as unknown as { oauth_scopes?: string[] })?.oauth_scopes ?? [];
+  // AccountData.oauth_scopes contains the full OAuth scope URIs persisted at
+  // onboarding completion (issue #221). Treat a missing list as "none granted".
+  const grantedScopes: string[] = account?.oauth_scopes ?? [];
 
   const result = GOOGLE_SCOPE_LIST.map(({ scope, label }) => ({
     scope,
@@ -439,12 +453,25 @@ function handleGetOAuthScopes(): Array<{ scope: string; label: string; granted: 
   return result;
 }
 
-function handleReConsentScope(_event: Electron.IpcMainInvokeEvent, scope: string): void {
-  // Stub: OAuth re-consent is a full flow; log intent and return OK.
-  mainLogger.info(CH_RE_CONSENT_SCOPE, {
+/**
+ * Settings → Google Scopes re-consent.
+ *
+ * Issue #201: this handler used to log "full OAuth flow not yet implemented"
+ * and silently return OK, so the renderer happily showed a success toast
+ * despite nothing actually running. Until re-consent from Settings is wired
+ * to a real OAuth flow (which requires routing the protocol callback back to
+ * the settings window and merging new scopes into the existing grant set),
+ * the honest behaviour is to throw so the renderer shows an error instead
+ * of a false-success toast.
+ */
+function handleReConsentScope(_event: Electron.IpcMainInvokeEvent, scope: string): Promise<never> {
+  mainLogger.warn(`${CH_RE_CONSENT_SCOPE}.notImplemented`, {
     scope,
-    msg: 'Re-consent requested — full OAuth flow not yet implemented; returning stub OK',
+    msg: 'Re-consent from Settings is not yet wired to an OAuth flow',
   });
+  return Promise.reject(
+    new Error('Re-consent from Settings is not yet available. Sign out and sign back in to change Google scopes.'),
+  );
 }
 
 async function handleFactoryReset(): Promise<void> {

--- a/my-app/src/preload/onboarding.ts
+++ b/my-app/src/preload/onboarding.ts
@@ -23,6 +23,12 @@ import type { GoogleOAuthScope, AccountInfo } from '../shared/types';
 export interface OAuthCallbackPayload {
   success: boolean;
   account?: AccountInfo;
+  /**
+   * Full Google OAuth scope URIs that Google confirmed during token exchange.
+   * Present when success is true; absent on error. Forwarded so the renderer
+   * can persist the exact scopes granted (issue #221).
+   */
+  scopes?: GoogleOAuthScope[];
   error?: string;
 }
 

--- a/my-app/src/renderer/onboarding/AccountCreation.tsx
+++ b/my-app/src/renderer/onboarding/AccountCreation.tsx
@@ -1,7 +1,11 @@
 /**
  * AccountCreation — Screen 3 of onboarding.
  *
- * Google OAuth + email/password form. Linear-inspired styling.
+ * Google OAuth sign-in only. The email/password form was removed in the fix
+ * for issue #218: the form collected a password that was silently discarded
+ * and showed a "Stored securely in your system keychain" trust signal that
+ * was not backed by any credential storage. Until a real password-backed
+ * account flow is added, the truthful answer is to offer only OAuth.
  */
 
 import React, { useState } from 'react';
@@ -15,45 +19,33 @@ const CURRENT_STEP = 3;
 
 interface AccountCreationProps {
   onBack: () => void;
-  onComplete: (account: { email: string; display_name?: string }, scopes: GoogleOAuthScope[]) => void;
+  /**
+   * Fired when OAuth has been confirmed and the caller should keep track of
+   * the chosen scopes before the callback arrives from the main process.
+   * The actual account info is delivered separately via the onOAuthCallback
+   * subscription in index.tsx.
+   */
+  onOAuthStart?: (scopes: GoogleOAuthScope[]) => void;
   oauthError?: string | null;
 }
 
-export function AccountCreation({ onBack, onComplete, oauthError }: AccountCreationProps): React.ReactElement {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
+export function AccountCreation({ onBack, onOAuthStart, oauthError }: AccountCreationProps): React.ReactElement {
   const [formError, setFormError] = useState<string | null>(null);
   const [showScopesModal, setShowScopesModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  function handleEmailSubmit(e: React.FormEvent): void {
-    e.preventDefault();
-    setFormError(null);
-
-    if (!email.trim() || !email.includes('@')) {
-      setFormError('Please enter a valid email address.');
-      return;
-    }
-    if (password.length < 8) {
-      setFormError('Password must be at least 8 characters.');
-      return;
-    }
-    if (password !== confirmPassword) {
-      setFormError('Passwords do not match.');
-      return;
-    }
-
-    onComplete({ email: email.trim() }, []);
-  }
-
   function handleGoogleClick(): void {
+    setFormError(null);
     setShowScopesModal(true);
   }
 
   async function handleScopesConfirm(scopes: GoogleOAuthScope[]): Promise<void> {
     setShowScopesModal(false);
     setIsLoading(true);
+
+    // Inform the parent of the selected scopes before starting OAuth so the
+    // oauth-callback handler in index.tsx can persist them (issue #221).
+    onOAuthStart?.(scopes);
 
     try {
       if (typeof window !== 'undefined' && (window as Window & { onboardingAPI?: { startOAuth: (scopes: GoogleOAuthScope[]) => Promise<void> } }).onboardingAPI) {
@@ -90,9 +82,9 @@ export function AccountCreation({ onBack, onComplete, oauthError }: AccountCreat
 
         <div className="onboarding-panel-left">
           <div>
-            <h1 className="onboarding-headline">Create your account</h1>
+            <h1 className="onboarding-headline">Sign in</h1>
             <p className="onboarding-subhead" style={{ marginTop: 8 }}>
-              Sign in to save your preferences and sync across devices.
+              Sign in with Google to save your preferences and sync across devices.
             </p>
           </div>
 
@@ -125,104 +117,36 @@ export function AccountCreation({ onBack, onComplete, oauthError }: AccountCreat
               </svg>
               {isLoading ? 'Opening browser\u2026' : 'Continue with Google'}
             </button>
-            <p className="account-trust-signal" aria-label="Credentials stored securely">
-              <svg width="10" height="11" viewBox="0 0 10 11" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
-                <rect x="1" y="4.5" width="8" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-                <path d="M3 4.5V3a2 2 0 0 1 4 0v1.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-              </svg>
-              Stored securely in your system keychain
-            </p>
           </div>
 
-          <div className="auth-divider">or</div>
-
-          <form className="auth-form" onSubmit={handleEmailSubmit} noValidate>
-            <div className="auth-input-group">
-              <label className="auth-label" htmlFor="email-input">Email</label>
-              <input
-                id="email-input"
-                className="auth-input"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="name@email.com"
-                autoComplete="email"
-                aria-required="true"
-              />
-            </div>
-
-            <div className="auth-input-group">
-              <label className="auth-label" htmlFor="password-input">Password</label>
-              <input
-                id="password-input"
-                className="auth-input"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="At least 8 characters"
-                autoComplete="new-password"
-                aria-required="true"
-              />
-            </div>
-
-            <div className="auth-input-group">
-              <label className="auth-label" htmlFor="confirm-password-input">Confirm password</label>
-              <input
-                id="confirm-password-input"
-                className="auth-input"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                placeholder="Re-enter your password"
-                autoComplete="new-password"
-                aria-required="true"
-              />
-            </div>
-
-            {displayError && (
-              <p
-                style={{ color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)' }}
-                role="alert"
-                aria-live="polite"
-              >
-                {displayError}
-              </p>
-            )}
-
-            <p className="legal-text">
-              By signing up you agree to our{' '}
-              <a href="#terms" onClick={(e) => e.preventDefault()}>Terms of Service</a>
-              {' '}and{' '}
-              <a href="#privacy" onClick={(e) => e.preventDefault()}>Privacy Policy</a>.
+          {displayError && (
+            <p
+              style={{ color: 'var(--color-status-error)', fontSize: 'var(--font-size-xs)' }}
+              role="alert"
+              aria-live="polite"
+            >
+              {displayError}
             </p>
+          )}
 
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button
-                type="button"
-                className="google-btn"
-                onClick={onBack}
-                style={{ flex: 1 }}
-                aria-label="Back"
-              >
-                Back
-              </button>
-              <button
-                type="submit"
-                className="auth-submit"
-                style={{ flex: 2 }}
-                aria-label="Create Account"
-              >
-                Create account
-              </button>
-            </div>
-          </form>
-
-          <p className="auth-switch">
-            Already have an account?{' '}
-            <button type="button" onClick={() => setFormError('Sign in coming soon.')}>
-              Log in
-            </button>
+          <p className="legal-text">
+            By signing in you agree to our{' '}
+            <a href="#terms" onClick={(e) => e.preventDefault()}>Terms of Service</a>
+            {' '}and{' '}
+            <a href="#privacy" onClick={(e) => e.preventDefault()}>Privacy Policy</a>.
           </p>
+
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type="button"
+              className="google-btn"
+              onClick={onBack}
+              style={{ flex: 1 }}
+              aria-label="Back"
+            >
+              Back
+            </button>
+          </div>
         </div>
 
         <div className="onboarding-panel-right">

--- a/my-app/src/renderer/onboarding/index.tsx
+++ b/my-app/src/renderer/onboarding/index.tsx
@@ -60,7 +60,14 @@ declare global {
       setAgentName: (name: string) => Promise<void>;
       getAgentName: () => Promise<string | null>;
       startOAuth: (scopes: GoogleOAuthScope[]) => Promise<void>;
-      onOAuthCallback: (cb: (payload: { success: boolean; account?: AccountInfo; error?: string }) => void) => () => void;
+      onOAuthCallback: (
+        cb: (payload: {
+          success: boolean;
+          account?: AccountInfo;
+          scopes?: GoogleOAuthScope[];
+          error?: string;
+        }) => void,
+      ) => () => void;
       completeOnboarding: (payload: {
         agent_name: string;
         account: AccountInfo;
@@ -119,20 +126,26 @@ function OnboardingApp(): React.ReactElement {
       console.debug('[onboarding] oauth-callback received', {
         success: payload.success,
         hasAccount: !!payload.account,
+        scopeCount: payload.scopes?.length ?? 0,
         error: payload.error,
       });
 
       if (payload.success && payload.account) {
+        // Prefer scopes echoed back by the OAuth callback (issue #221 — this
+        // reflects what the server actually granted). Fall back to the scopes
+        // the user picked in the modal if the callback omits them.
+        const grantedScopes = payload.scopes ?? state.oauthScopes;
         setState((prev) => ({
           ...prev,
           account: payload.account!,
+          oauthScopes: grantedScopes,
           oauthError: null,
           step: 'complete',
         }));
         void completeOnboarding(
           state.agentName ?? 'Companion',
           payload.account,
-          state.oauthScopes,
+          grantedScopes,
         );
       } else {
         setState((prev) => ({
@@ -184,17 +197,10 @@ function OnboardingApp(): React.ReactElement {
     setState((prev) => ({ ...prev, step: 'account' }));
   }
 
-  async function handleAccountComplete(
-    account: AccountInfo,
-    scopes: GoogleOAuthScope[],
-  ): Promise<void> {
-    setState((prev) => ({
-      ...prev,
-      account,
-      oauthScopes: scopes,
-      step: 'complete',
-    }));
-    await completeOnboarding(state.agentName ?? 'Companion', account, scopes);
+  function handleOAuthStart(scopes: GoogleOAuthScope[]): void {
+    // Remember what the user asked for so the oauth-callback effect can
+    // persist them (issue #221). Also clear any stale error.
+    setState((prev) => ({ ...prev, oauthScopes: scopes, oauthError: null }));
   }
 
   // -------------------------------------------------------------------------
@@ -211,7 +217,7 @@ function OnboardingApp(): React.ReactElement {
     return (
       <AccountCreation
         onBack={() => setState((prev) => ({ ...prev, step: 'naming', oauthError: null }))}
-        onComplete={(account, scopes) => void handleAccountComplete(account, scopes)}
+        onOAuthStart={handleOAuthStart}
         oauthError={oauthError}
       />
     );

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -684,11 +684,9 @@ function AppearanceTab(): React.ReactElement {
 // Google Scopes tab
 // ---------------------------------------------------------------------------
 
-function GoogleScopesTab(): React.ReactElement {
-  const toast = useToast();
-  const [scopes, setScopes]         = useState<OAuthScopeStatus[]>([]);
-  const [loading, setLoading]       = useState(true);
-  const [reconsentId, setReconsentId] = useState<string | null>(null);
+export function GoogleScopesTab(): React.ReactElement {
+  const [scopes, setScopes]   = useState<OAuthScopeStatus[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     void window.settingsAPI.getOAuthScopes().then((s) => {
@@ -696,26 +694,6 @@ function GoogleScopesTab(): React.ReactElement {
       setLoading(false);
     });
   }, []);
-
-  async function handleReconsent(scope: string): Promise<void> {
-    setReconsentId(scope);
-    try {
-      await window.settingsAPI.reConsentScope(scope);
-      toast.show({
-        variant: 'info',
-        title: 'Re-consent initiated',
-        message: `Scope: ${scope}`,
-      });
-    } catch (err) {
-      toast.show({
-        variant: 'error',
-        title: 'Re-consent failed',
-        message: (err as Error).message,
-      });
-    } finally {
-      setReconsentId(null);
-    }
-  }
 
   if (loading) {
     return (
@@ -728,11 +706,16 @@ function GoogleScopesTab(): React.ReactElement {
     );
   }
 
+  // Re-consent from Settings is not yet wired to a real OAuth flow
+  // (issue #201). Disable the control rather than pretending it worked.
+  const reconsentDisabledReason = 'Re-consent from Settings is not yet available. Sign out and sign back in to change Google scopes.';
+
   return (
     <div className="settings-section">
       <h2 className="settings-section-title">Google Scopes</h2>
       <p className="settings-section-desc">
-        Manage which Google services your agent has access to.
+        View which Google services your agent has access to. To change scopes,
+        sign out and sign back in; in-place re-consent is coming soon.
       </p>
 
       <Card variant="default" padding="none" className="settings-card">
@@ -754,8 +737,9 @@ function GoogleScopesTab(): React.ReactElement {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => void handleReconsent(s.scope)}
-                loading={reconsentId === s.scope}
+                disabled
+                title={reconsentDisabledReason}
+                aria-label={`Re-consent ${s.label} (not yet available)`}
               >
                 Re-consent
               </Button>

--- a/my-app/tests/unit/identity/AccountStore.oauthScopes.spec.ts
+++ b/my-app/tests/unit/identity/AccountStore.oauthScopes.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * AccountStore OAuth scope persistence — regression for issue #221.
+ *
+ * Issue #221: onboarding collected full Google OAuth scope URIs from the
+ * modal (e.g. "https://www.googleapis.com/auth/gmail.readonly"), but
+ * AccountStore had no field for them. The settings page then read
+ * account.oauth_scopes and always got undefined, so every Google service
+ * rendered as "Not granted" regardless of what the user actually approved.
+ *
+ * This test pins the contract that AccountData.oauth_scopes round-trips
+ * through save/load.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fsStore = new Map<string, string>();
+
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn((p: string, data: string) => { fsStore.set(p, data); }),
+    readFileSync: vi.fn((p: string) => {
+      const content = fsStore.get(p);
+      if (!content) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return content;
+    }),
+    existsSync: vi.fn((p: string) => fsStore.has(p)),
+    renameSync: vi.fn((src: string, dst: string) => {
+      const content = fsStore.get(src);
+      if (content !== undefined) {
+        fsStore.set(dst, content);
+        fsStore.delete(src);
+      }
+    }),
+  },
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn((p: string, data: string) => { fsStore.set(p, data); }),
+  readFileSync: vi.fn((p: string) => {
+    const content = fsStore.get(p);
+    if (!content) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    return content;
+  }),
+  existsSync: vi.fn((p: string) => fsStore.has(p)),
+  renameSync: vi.fn((src: string, dst: string) => {
+    const content = fsStore.get(src);
+    if (content !== undefined) {
+      fsStore.set(dst, content);
+      fsStore.delete(src);
+    }
+  }),
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn().mockReturnValue('/tmp/test-userData-oauth') },
+}));
+
+import { AccountStore } from '../../../src/main/identity/AccountStore';
+
+describe('AccountStore.oauth_scopes (issue #221)', () => {
+  let store: AccountStore;
+  const TEST_PATH = '/tmp/test-userData-oauth';
+
+  beforeEach(() => {
+    fsStore.clear();
+    store = new AccountStore(TEST_PATH);
+  });
+
+  it('round-trips oauth_scopes containing full Google OAuth scope URIs', () => {
+    const scopes = [
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/drive',
+    ];
+    store.save({
+      agent_name: 'Atlas',
+      email: 'user@example.com',
+      oauth_scopes: scopes,
+    });
+    const loaded = store.load();
+    expect(loaded?.oauth_scopes).toEqual(scopes);
+  });
+
+  it('treats oauth_scopes as optional (undefined on legacy records)', () => {
+    store.save({ agent_name: 'Atlas', email: 'user@example.com' });
+    const loaded = store.load();
+    expect(loaded?.oauth_scopes).toBeUndefined();
+  });
+
+  it('persists an empty array as empty (distinct from "no scopes stored yet")', () => {
+    store.save({
+      agent_name: 'Atlas',
+      email: 'user@example.com',
+      oauth_scopes: [],
+    });
+    const loaded = store.load();
+    expect(Array.isArray(loaded?.oauth_scopes)).toBe(true);
+    expect(loaded?.oauth_scopes).toHaveLength(0);
+  });
+});

--- a/my-app/tests/unit/onboarding/AccountCreation.spec.tsx
+++ b/my-app/tests/unit/onboarding/AccountCreation.spec.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+/**
+ * AccountCreation unit tests — regressions for issue #218.
+ *
+ * Issue #218 summary: the onboarding AccountCreation screen used to render a
+ * full email/password form, then silently throw the password away and show a
+ * "Stored securely in your system keychain" trust signal even though no
+ * credential was ever persisted. The pragmatic fix was to remove the
+ * email/password form and the keychain copy entirely; the OAuth path is now
+ * the only supported sign-in method.
+ *
+ * These tests codify that contract so no one accidentally reintroduces a
+ * password field or a false keychain claim.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/dom';
+import React from 'react';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('../../../src/renderer/design/theme.global.css', () => ({}));
+vi.mock('../../../src/renderer/design/theme.onboarding.css', () => ({}));
+vi.mock('../../../src/renderer/components/base/components.css', () => ({}));
+vi.mock('../../../src/renderer/onboarding/onboarding.css', () => ({}));
+
+import { AccountCreation } from '../../../src/renderer/onboarding/AccountCreation';
+
+describe('AccountCreation (issue #218 regressions)', () => {
+  it('does not render any password input', () => {
+    render(<AccountCreation onBack={vi.fn()} />);
+    const passwordInputs = document.querySelectorAll('input[type="password"]');
+    expect(passwordInputs.length).toBe(0);
+  });
+
+  it('does not render an email text field', () => {
+    render(<AccountCreation onBack={vi.fn()} />);
+    const emailInputs = document.querySelectorAll('input[type="email"]');
+    expect(emailInputs.length).toBe(0);
+  });
+
+  it('does not render a "Create account" submit button', () => {
+    render(<AccountCreation onBack={vi.fn()} />);
+    const createBtn = screen.queryByRole('button', { name: /create account/i });
+    expect(createBtn).toBeNull();
+  });
+
+  it('does not claim credentials are stored in the system keychain', () => {
+    render(<AccountCreation onBack={vi.fn()} />);
+    // The removed copy was "Stored securely in your system keychain".
+    // The UI must not claim ANY form of credential storage while no
+    // credential is actually being stored.
+    const text = document.body.textContent ?? '';
+    expect(text.toLowerCase()).not.toContain('keychain');
+    expect(text.toLowerCase()).not.toContain('stored securely');
+  });
+
+  it('renders the Continue with Google OAuth button', () => {
+    render(<AccountCreation onBack={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /continue with google/i });
+    expect(btn).toBeTruthy();
+  });
+
+  it('renders the Back button', () => {
+    const onBack = vi.fn();
+    render(<AccountCreation onBack={onBack} />);
+    const btn = screen.getByRole('button', { name: /^back$/i });
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an OAuth error passed in via props', () => {
+    render(<AccountCreation onBack={vi.fn()} oauthError="OAuth went wrong" />);
+    expect(screen.getByText(/oauth went wrong/i)).toBeTruthy();
+  });
+
+  it('does not render a "Log in" link that falsely promises sign-in', () => {
+    // The old component had a "Log in" button that just set an error string
+    // "Sign in coming soon." That dead-end UI has been removed with the form.
+    render(<AccountCreation onBack={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /^log in$/i })).toBeNull();
+  });
+});

--- a/my-app/tests/unit/onboarding/onboardingHandlers.spec.ts
+++ b/my-app/tests/unit/onboarding/onboardingHandlers.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * onboardingHandlers unit tests — regression for issue #221.
+ *
+ * The onboarding:complete IPC handler used to call AccountStore.save without
+ * the oauth_scopes field, so any scopes the user approved in the Google
+ * scopes modal were silently dropped. This test pins the contract that
+ * onboarding:complete persists oauth_scopes alongside the rest of the
+ * account record.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const handlers = new Map<string, (event: unknown, ...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, h: (event: unknown, ...args: unknown[]) => unknown): void => {
+      handlers.set(channel, h);
+    },
+    removeHandler: (channel: string): void => { handlers.delete(channel); },
+  },
+  BrowserWindow: class {
+    id = 1;
+    isDestroyed(): boolean { return false; }
+    close(): void { /* noop */ }
+    webContents = { send: vi.fn() };
+  },
+}));
+
+import { registerOnboardingHandlers, unregisterOnboardingHandlers } from '../../../src/main/identity/onboardingHandlers';
+
+type HandlerFn = (event: unknown, ...args: unknown[]) => unknown;
+
+function handlerFor(channel: string): HandlerFn {
+  const h = handlers.get(channel);
+  if (!h) throw new Error(`No handler for ${channel}`);
+  return h;
+}
+
+describe('onboardingHandlers.complete (issue #221)', () => {
+  const accountSave = vi.fn();
+  const accountLoad = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const accountStore: any = { save: accountSave, load: accountLoad };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const oauthClient: any = { startAuthFlow: vi.fn() };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onboardingWindow: any = {
+    id: 1,
+    isDestroyed: () => false,
+    close: vi.fn(),
+    webContents: { send: vi.fn() },
+  };
+  const openShellWindow = vi.fn(() => ({ id: 2 }));
+
+  beforeEach(() => {
+    handlers.clear();
+    accountSave.mockReset();
+    accountLoad.mockReset();
+    openShellWindow.mockClear();
+    registerOnboardingHandlers({
+      accountStore,
+      oauthClient,
+      onboardingWindow,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      openShellWindow: openShellWindow as any,
+    });
+  });
+
+  it('persists oauth_scopes in the account record on completion', async () => {
+    accountLoad.mockReturnValue(null);
+    const scopes = [
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/calendar',
+    ];
+    await handlerFor('onboarding:complete')({}, {
+      agent_name: 'Atlas',
+      account: { email: 'user@example.com' },
+      oauth_scopes: scopes,
+    });
+    expect(accountSave).toHaveBeenCalledTimes(1);
+    const saved = accountSave.mock.calls[0][0];
+    expect(saved.oauth_scopes).toEqual(scopes);
+    expect(saved.agent_name).toBe('Atlas');
+    expect(saved.email).toBe('user@example.com');
+    expect(saved.onboarding_completed_at).toBeDefined();
+  });
+
+  it('persists an empty oauth_scopes array when the user declined every Google service', async () => {
+    accountLoad.mockReturnValue(null);
+    await handlerFor('onboarding:complete')({}, {
+      agent_name: 'Atlas',
+      account: { email: 'user@example.com' },
+      oauth_scopes: [],
+    });
+    const saved = accountSave.mock.calls[0][0];
+    expect(Array.isArray(saved.oauth_scopes)).toBe(true);
+    expect(saved.oauth_scopes).toHaveLength(0);
+  });
+
+  it('preserves existing oauth_scopes when re-saving via set-agent-name', () => {
+    accountLoad.mockReturnValue({
+      agent_name: 'Atlas',
+      email: 'user@example.com',
+      oauth_scopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+    });
+    handlerFor('onboarding:set-agent-name')({}, 'Atlas-2');
+    const saved = accountSave.mock.calls[0][0];
+    expect(saved.oauth_scopes).toEqual([
+      'https://www.googleapis.com/auth/gmail.readonly',
+    ]);
+  });
+
+  afterEach(() => {
+    unregisterOnboardingHandlers();
+  });
+});

--- a/my-app/tests/unit/settings/GoogleScopesTab.spec.tsx
+++ b/my-app/tests/unit/settings/GoogleScopesTab.spec.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+/**
+ * Settings → Google Scopes tab UI — regression for issue #201.
+ *
+ * The re-consent control must not produce a false "Re-consent initiated"
+ * toast while the main-process handler is a stub. It is rendered disabled
+ * with an explanatory tooltip until a real OAuth re-consent flow ships.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/dom';
+import React from 'react';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('../../../src/renderer/design/theme.global.css', () => ({}));
+vi.mock('../../../src/renderer/design/theme.onboarding.css', () => ({}));
+vi.mock('../../../src/renderer/components/base/components.css', () => ({}));
+vi.mock('../../../src/renderer/settings/settings.css', () => ({}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const settingsAPI: any = {
+  getOAuthScopes: vi.fn(async () => [
+    { scope: 'https://www.googleapis.com/auth/gmail.readonly', label: 'Gmail', granted: true },
+    { scope: 'https://www.googleapis.com/auth/calendar',        label: 'Google Calendar', granted: false },
+  ]),
+  reConsentScope: vi.fn(async () => {
+    throw new Error('reConsentScope must NOT be called while the feature is disabled (issue #201).');
+  }),
+};
+
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).settingsAPI = settingsAPI;
+  settingsAPI.getOAuthScopes.mockClear();
+  settingsAPI.reConsentScope.mockClear();
+});
+
+import { ToastProvider } from '../../../src/renderer/components/base';
+import { GoogleScopesTab } from '../../../src/renderer/settings/SettingsApp';
+
+function renderTab(): void {
+  render(
+    <ToastProvider>
+      <GoogleScopesTab />
+    </ToastProvider>,
+  );
+}
+
+describe('GoogleScopesTab (issue #201)', () => {
+  it('renders "Re-consent" buttons but they are disabled', async () => {
+    renderTab();
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /re-consent/i }).length).toBeGreaterThan(0);
+    });
+    const buttons = screen.getAllByRole('button', { name: /re-consent/i });
+    for (const btn of buttons) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+
+  it('clicking a disabled Re-consent button never calls settingsAPI.reConsentScope', async () => {
+    renderTab();
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /re-consent/i }).length).toBeGreaterThan(0);
+    });
+    const buttons = screen.getAllByRole('button', { name: /re-consent/i });
+    for (const btn of buttons) {
+      fireEvent.click(btn);
+    }
+    expect(settingsAPI.reConsentScope).not.toHaveBeenCalled();
+  });
+
+  it('does not show a "Re-consent initiated" success toast', async () => {
+    renderTab();
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /re-consent/i }).length).toBeGreaterThan(0);
+    });
+    const buttons = screen.getAllByRole('button', { name: /re-consent/i });
+    for (const btn of buttons) {
+      fireEvent.click(btn);
+    }
+    expect(document.body.textContent ?? '').not.toMatch(/re-consent initiated/i);
+  });
+
+  it('reflects the granted status returned by getOAuthScopes', async () => {
+    renderTab();
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /re-consent/i }).length).toBeGreaterThan(0);
+    });
+    // Gmail is granted, Calendar is not.
+    const text = document.body.textContent ?? '';
+    expect(text).toMatch(/granted/i);
+    expect(text).toMatch(/not granted/i);
+  });
+});

--- a/my-app/tests/unit/settings/googleScopesIpc.spec.ts
+++ b/my-app/tests/unit/settings/googleScopesIpc.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Settings IPC tests for Google scopes — regressions for issues #221 and #201.
+ *
+ * Covers:
+ *   - settings:get-oauth-scopes reports GRANTED for scopes persisted by
+ *     onboarding (full Google OAuth scope URIs), not for legacy short ids
+ *     like "gmail" / "calendar" (issue #221).
+ *   - settings:re-consent-scope rejects with an error rather than quietly
+ *     returning OK when no real OAuth flow is wired up (issue #201 — the
+ *     renderer must not be able to show a success toast).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture every handler registered via ipcMain.handle so we can invoke them
+// directly in these tests.
+const handlers = new Map<string, (event: unknown, ...args: unknown[]) => unknown>();
+const listeners = new Map<string, (event: unknown, ...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => {
+  const app = {
+    getPath: vi.fn().mockReturnValue('/tmp/test-userData-settings-scopes'),
+  };
+  const ipcMain = {
+    handle: (channel: string, h: (event: unknown, ...args: unknown[]) => unknown): void => {
+      handlers.set(channel, h);
+    },
+    on: (channel: string, h: (event: unknown, ...args: unknown[]) => unknown): void => {
+      listeners.set(channel, h);
+    },
+    removeHandler: (channel: string): void => { handlers.delete(channel); },
+    removeAllListeners: (channel: string): void => { listeners.delete(channel); },
+  };
+  const session = {
+    defaultSession: {
+      webRequest: {
+        onBeforeSendHeaders: (): void => undefined,
+      },
+    },
+  };
+  return {
+    app,
+    ipcMain,
+    session,
+    BrowserWindow: { getAllWindows: (): unknown[] => [] },
+    dialog: {},
+  };
+});
+
+// Only stub the AccountStore load() result. Other dependencies aren't
+// exercised by the handlers under test.
+const loadMock = vi.fn();
+const accountStore = {
+  load: loadMock,
+  save: vi.fn(),
+};
+
+const keychainStore = {
+  getToken: vi.fn(),
+  setToken: vi.fn(),
+};
+
+import { registerSettingsHandlers, unregisterSettingsHandlers } from '../../../src/main/settings/ipc';
+
+type HandlerResult = unknown;
+
+async function invoke(channel: string, ...args: unknown[]): Promise<HandlerResult> {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for ${channel}`);
+  return handler({}, ...args);
+}
+
+describe('settings:get-oauth-scopes (issue #221)', () => {
+  beforeEach(() => {
+    handlers.clear();
+    listeners.clear();
+    loadMock.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerSettingsHandlers({ accountStore: accountStore as any, keychainStore: keychainStore as any });
+  });
+
+  it('reports granted=true for full Google OAuth scope URIs persisted by onboarding', async () => {
+    loadMock.mockReturnValue({
+      agent_name: 'Atlas',
+      email: 'user@example.com',
+      oauth_scopes: [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/calendar',
+      ],
+    });
+    const result = (await invoke('settings:get-oauth-scopes')) as Array<{ scope: string; granted: boolean }>;
+    const gmail    = result.find((r) => r.scope === 'https://www.googleapis.com/auth/gmail.readonly');
+    const calendar = result.find((r) => r.scope === 'https://www.googleapis.com/auth/calendar');
+    const drive    = result.find((r) => r.scope === 'https://www.googleapis.com/auth/drive');
+    expect(gmail?.granted).toBe(true);
+    expect(calendar?.granted).toBe(true);
+    expect(drive?.granted).toBe(false);
+  });
+
+  it('reports granted=false for all scopes when oauth_scopes is missing from account', async () => {
+    loadMock.mockReturnValue({ agent_name: 'Atlas', email: 'user@example.com' });
+    const result = (await invoke('settings:get-oauth-scopes')) as Array<{ granted: boolean }>;
+    expect(result.every((r) => r.granted === false)).toBe(true);
+  });
+
+  it('does NOT use legacy short ids ("gmail", "calendar", ...) as scope values', async () => {
+    loadMock.mockReturnValue({ agent_name: 'Atlas', email: 'user@example.com' });
+    const result = (await invoke('settings:get-oauth-scopes')) as Array<{ scope: string }>;
+    // The old implementation listed short ids like "gmail" and "calendar".
+    // Those ids must no longer appear: the source of truth is the full URI.
+    const scopes = result.map((r) => r.scope);
+    expect(scopes).not.toContain('gmail');
+    expect(scopes).not.toContain('calendar');
+    expect(scopes).not.toContain('drive');
+    expect(scopes).toContain('https://www.googleapis.com/auth/gmail.readonly');
+    expect(scopes).toContain('https://www.googleapis.com/auth/calendar');
+    expect(scopes).toContain('https://www.googleapis.com/auth/drive');
+  });
+
+  afterEach(() => {
+    unregisterSettingsHandlers();
+  });
+});
+
+describe('settings:re-consent-scope (issue #201)', () => {
+  beforeEach(() => {
+    handlers.clear();
+    listeners.clear();
+    loadMock.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerSettingsHandlers({ accountStore: accountStore as any, keychainStore: keychainStore as any });
+  });
+
+  it('rejects instead of silently resolving when no OAuth flow is implemented', async () => {
+    // The previous implementation returned void/undefined so the renderer
+    // treated it as success. The fix is to reject so the renderer surfaces
+    // an error — or, alternatively, the button is disabled on the UI side.
+    await expect(invoke('settings:re-consent-scope', 'https://www.googleapis.com/auth/gmail.readonly'))
+      .rejects.toThrow();
+  });
+
+  it('never falsely returns ok/void for the re-consent channel', async () => {
+    let resolvedValue: unknown;
+    try {
+      resolvedValue = await invoke('settings:re-consent-scope', 'anything');
+    } catch {
+      // Expected — swallow the rejection and assert we never got a resolved value.
+      return;
+    }
+    // If we got here, the handler resolved — that's exactly the issue #201
+    // bug. Fail the test loudly.
+    throw new Error(
+      `settings:re-consent-scope should reject but resolved to: ${String(resolvedValue)}`,
+    );
+  });
+
+  afterEach(() => {
+    unregisterSettingsHandlers();
+  });
+});

--- a/my-app/vitest.config.ts
+++ b/my-app/vitest.config.ts
@@ -35,6 +35,15 @@ export default defineConfig({
       'tests/unit/zoom/**/*.spec.ts',
       'tests/unit/shell/**/*.spec.tsx',
       'tests/unit/share/**/*.spec.ts',
+      // Onboarding + identity + settings regressions for issues #218, #221,
+      // #201. Scoped to the new files rather than a broad glob so we do not
+      // accidentally pick up older jsdom specs that rely on a different
+      // setup file (tests/fixtures/onboarding-setup.ts) and would otherwise
+      // fail without @testing-library cleanup between tests.
+      'tests/unit/onboarding/AccountCreation.spec.tsx',
+      'tests/unit/onboarding/onboardingHandlers.spec.ts',
+      'tests/unit/identity/AccountStore.oauthScopes.spec.ts',
+      'tests/unit/settings/**/*.spec.{ts,tsx}',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],
     // Renderer .spec.tsx files declare jsdom via the per-file


### PR DESCRIPTION
Fixes #218, #221, #201.

## Summary

### #218 — Remove email/password onboarding path
The AccountCreation form used to collect email/password/confirmPassword,
validate them, then silently throw the password away while claiming
"Stored securely in your system keychain." There is no password-backed
account or credential storage behind that copy. The form and the keychain
trust signal are removed; Google OAuth is the only supported sign-in path
until a real password backend ships. The dead-end "Log in" link is also
removed.

### #221 — Persist Google scope grants end to end
- `AccountData` gains an `oauth_scopes?: string[]` field.
- `onboarding:complete` saves `oauth_scopes` alongside the rest of the
  account record; `onboarding:set-agent-name` preserves them.
- The `oauth-callback` payload echoes the scopes Google actually granted
  back to the renderer, so we persist what the server returned (falling
  back to the scopes the user picked in the modal).
- Settings → Google Scopes now compares against full scope URIs
  (`https://www.googleapis.com/auth/...`) instead of the legacy short ids
  (`gmail`, `calendar`, ...) that never matched what onboarding stored,
  which is why services always appeared "Not granted." Sheets and Docs
  are surfaced too so the Settings list matches the onboarding modal.

### #201 — Stop faking Google Scopes re-consent success
- `settings:re-consent-scope` now rejects with a "not yet available"
  error instead of returning void. The renderer can no longer misread
  the resolved promise as a success toast.
- The Re-consent buttons in Settings → Google Scopes render `disabled`
  with an explanatory `title`/`aria-label` until a real OAuth re-consent
  flow is wired up. A disabled button can't emit a false "Re-consent
  initiated" toast.

## Test plan

New unit coverage under `my-app/tests/unit/`:
- [x] `onboarding/AccountCreation.spec.tsx` (issue #218) — no password,
      no email input, no "Create account" / "Log in" buttons, no
      "keychain" copy.
- [x] `identity/AccountStore.oauthScopes.spec.ts` (issue #221) —
      `oauth_scopes` round-trips; empty vs undefined distinction.
- [x] `onboarding/onboardingHandlers.spec.ts` (issue #221) —
      `onboarding:complete` persists `oauth_scopes`; `set-agent-name`
      preserves them.
- [x] `settings/googleScopesIpc.spec.ts` (issues #221 + #201) —
      `get-oauth-scopes` reports grants using full URIs and not legacy
      short ids; `re-consent-scope` rejects instead of silently
      resolving.
- [x] `settings/GoogleScopesTab.spec.tsx` (issue #201) — Re-consent
      buttons render disabled and never call `settingsAPI.reConsentScope`;
      "Re-consent initiated" toast never appears.

Gate:
- `npm run lint` — 0 errors (warnings unchanged from `main`).
- `npm run typecheck` — clean.
- `npm test` — 476 / 476 passing (previously 453).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the fake email/password onboarding flow, and fixes Google OAuth scope handling so Settings shows the real grant state. Disables the misleading Google re‑consent action until a real flow ships.

- **Bug Fixes**
  - #218: Removed the email/password form and the “Stored securely in your system keychain” copy; Google OAuth is now the only sign‑in path and the dead‑end “Log in” link is gone.
  - #221: Added `oauth_scopes?: string[]` to `AccountData` and persist scopes on `onboarding:complete`; `onboarding:set-agent-name` preserves them; `oauth-callback` returns granted scopes; Settings now checks full scope URIs and includes Sheets/Docs so the list matches onboarding.
  - #201: `settings:re-consent-scope` now rejects with a clear “not yet available” error; the Re‑consent buttons are disabled with an explanatory tooltip to prevent false success toasts.

<sup>Written for commit dd52eb48b5b77e3d1596c40bc37c1f0fbc3c4acf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

