### PR TITLE
fix(identity): use BookmarkStore.deleteAll() in sign-out clear mode

### DIFF
--- a/my-app/src/main/identity/SignOutController.ts
+++ b/my-app/src/main/identity/SignOutController.ts
@@ -267,15 +267,8 @@ async function clearSyncedData(localStores?: LocalDataStores): Promise<boolean> 
     // Clear app-local on-disk stores (bookmarks, history, passwords, autofill)
     if (localStores?.bookmarkStore) {
       try {
-        const bs = localStores.bookmarkStore;
-        // Reset to empty state by clearing each root's children
-        const tree = bs.listTree();
-        for (const root of tree.roots) {
-          for (const child of root.children ?? []) {
-            bs.removeBookmark(child.id);
-          }
-        }
-        bs.flushSync();
+        localStores.bookmarkStore.deleteAll();
+        localStores.bookmarkStore.flushSync();
         mainLogger.info('SignOutController.clearSyncedData.bookmarksCleared');
       } catch (err) {
         mainLogger.warn('SignOutController.clearSyncedData.bookmarksClearFailed', {


### PR DESCRIPTION
## Summary

Main went red after #252 merged on top of #244 — the `SignOutController.spec.ts` test from #244 expects `bookmarkStore.deleteAll()` to be called in clear mode, but #252's implementation iterated tree children with `listTree()` + `removeBookmark()` instead. Both APIs exist on `BookmarkStore`; switching `clearSyncedData()` to call `deleteAll()` matches the test and is cleaner (single call vs. a nested loop that only handles the two top-level roots).

Unblocks all open PR CI runs that rebased onto the broken main.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test` — 34 files / 465 tests pass (the previously-failing `SignOutController > clear mode wipes app-local ...` now passes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch sign-out “clear” mode to use BookmarkStore.deleteAll() and then flush. This matches test expectations and fixes the failing CI on main.

- **Bug Fixes**
  - Call deleteAll() + flushSync() in clearSyncedData() for bookmarks.
  - Replace listTree()/removeBookmark() loop; resolves the failing SignOutController test and unblocks CI.

<sup>Written for commit 10164f903ae677e6f8b80b49ed5b448edbc16e21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

