### PR TITLE
fix(extensions): honest site-access selector (enforce or disable)

### DIFF
--- a/my-app/src/main/extensions/ExtensionManager.ts
+++ b/my-app/src/main/extensions/ExtensionManager.ts
@@ -18,6 +18,38 @@ import type { MV3ExtensionInfo } from './mv3/ManifestV3Runtime';
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Host-access mode.
+ *
+ * NOTE: Only `all-sites` is currently enforced — that matches Electron's
+ * default `session.loadExtension` behavior (extensions run against whatever
+ * `host_permissions` their manifest declares). `specific-sites` and
+ * `on-click` would require per-origin request filtering and activation
+ * gating that Electron does not expose out of the box, so those values
+ * are intentionally rejected by the IPC layer and hidden from the UI
+ * until real enforcement is wired up. See issue #234.
+ */
+export type HostAccessMode = 'all-sites' | 'specific-sites' | 'on-click';
+
+/** Modes that the app actually enforces today. Kept in sync with ipc.ts. */
+export const SUPPORTED_HOST_ACCESS_MODES: readonly HostAccessMode[] = ['all-sites'] as const;
+
+/**
+ * Default host-access mode for newly loaded extensions. Must be a supported
+ * mode; defaulting to a non-enforced value would repeat the bug #234 reports.
+ */
+export const DEFAULT_HOST_ACCESS: HostAccessMode = 'all-sites';
+
+export function isSupportedHostAccess(value: unknown): value is HostAccessMode {
+  return typeof value === 'string'
+    && (SUPPORTED_HOST_ACCESS_MODES as readonly string[]).includes(value);
+}
+
+/** Normalize a persisted/host-access value to one we can actually enforce. */
+export function coerceHostAccess(value: unknown): HostAccessMode {
+  return isSupportedHostAccess(value) ? value : DEFAULT_HOST_ACCESS;
+}
+
 export interface ExtensionRecord {
   id: string;
   name: string;
@@ -27,7 +59,7 @@ export interface ExtensionRecord {
   enabled: boolean;
   permissions: string[];
   hostPermissions: string[];
-  hostAccess: 'all-sites' | 'specific-sites' | 'on-click';
+  hostAccess: HostAccessMode;
   icons: Record<string, string>;
   manifestVersion: number;
 }
@@ -220,7 +252,9 @@ export class ExtensionManager {
         enabled: record.enabled,
         permissions: (manifest?.permissions as string[]) ?? [],
         hostPermissions: (manifest?.host_permissions as string[]) ?? [],
-        hostAccess: (record.hostAccess as ExtensionRecord['hostAccess']) ?? 'on-click',
+        // Coerce any legacy/unsupported persisted value (e.g. on-click, specific-sites)
+        // to the only mode we actually enforce today. See issue #234.
+        hostAccess: coerceHostAccess(record.hostAccess),
         icons: this.extractIcons(manifest, record.path),
         manifestVersion,
       });
@@ -256,7 +290,8 @@ export class ExtensionManager {
         id: ext.id,
         path: resolvedPath,
         enabled: true,
-        hostAccess: 'on-click',
+        // Default to the only mode we actually enforce. See issue #234.
+        hostAccess: DEFAULT_HOST_ACCESS,
       });
     }
 
@@ -273,7 +308,7 @@ export class ExtensionManager {
       enabled: true,
       permissions: (manifest?.permissions as string[]) ?? [],
       hostPermissions: (manifest?.host_permissions as string[]) ?? [],
-      hostAccess: 'on-click',
+      hostAccess: DEFAULT_HOST_ACCESS,
       icons: this.extractIcons(manifest, resolvedPath),
       manifestVersion: (manifest?.manifest_version as number) ?? 2,
     };
@@ -375,11 +410,19 @@ export class ExtensionManager {
     mainLogger.info(`${LOG_PREFIX}.updateExtension.ok`, { id });
   }
 
-  setHostAccess(id: string, hostAccess: ExtensionRecord['hostAccess']): void {
+  setHostAccess(id: string, hostAccess: HostAccessMode): void {
     mainLogger.info(`${LOG_PREFIX}.setHostAccess`, { id, hostAccess });
 
     const record = this.state.extensions.find((e) => e.id === id);
     if (!record) throw new Error(`Extension not found: ${id}`);
+
+    // Only accept modes we can actually enforce at runtime. Accepting a
+    // value we will never enforce is the bug issue #234 flags.
+    if (!isSupportedHostAccess(hostAccess)) {
+      throw new Error(
+        `hostAccess '${hostAccess}' is not supported yet. Supported modes: ${SUPPORTED_HOST_ACCESS_MODES.join(', ')}`,
+      );
+    }
 
     record.hostAccess = hostAccess;
     this.saveState();

--- a/my-app/src/main/extensions/ipc.ts
+++ b/my-app/src/main/extensions/ipc.ts
@@ -8,7 +8,7 @@
 import { dialog, ipcMain } from 'electron';
 import { mainLogger } from '../logger';
 import { assertString, assertOneOf } from '../ipc-validators';
-import { ExtensionManager } from './ExtensionManager';
+import { ExtensionManager, SUPPORTED_HOST_ACCESS_MODES } from './ExtensionManager';
 import type { ExtensionRecord, ExtensionCommandEntry } from './ExtensionManager';
 import { getExtensionsWindow, openExtensionsWindow } from './ExtensionsWindow';
 
@@ -31,7 +31,12 @@ const CH_CLOSE_WINDOW        = 'extensions:close-window';
 const CH_LIST_COMMANDS       = 'extensions:list-commands';
 const CH_SET_SHORTCUT        = 'extensions:set-shortcut';
 
-const ALLOWED_HOST_ACCESS = ['all-sites', 'specific-sites', 'on-click'] as const;
+// Only modes that are actually enforced at runtime are accepted here.
+// `specific-sites` and `on-click` were previously accepted and silently
+// persisted as an enum that nothing consumed — see issue #234. The UI
+// hides the unsupported options and the IPC layer rejects them so callers
+// that hand-craft IPC messages can't smuggle them into persisted state.
+const ALLOWED_HOST_ACCESS = SUPPORTED_HOST_ACCESS_MODES;
 
 // Max shortcut string length — e.g. "Ctrl+Shift+F12"
 const MAX_SHORTCUT_LEN = 64;

--- a/my-app/src/renderer/extensions/ExtensionsApp.tsx
+++ b/my-app/src/renderer/extensions/ExtensionsApp.tsx
@@ -76,6 +76,19 @@ const HOST_ACCESS_LABELS: Record<HostAccessLevel, string> = {
   'on-click': 'On click',
 };
 
+/**
+ * Which host-access modes we actually enforce at runtime today.
+ *
+ * Only `all-sites` is enforced — that matches Electron's default
+ * `session.loadExtension` behaviour. `specific-sites` and `on-click`
+ * would need per-origin request filtering and activation gating that
+ * Electron does not expose, so the UI keeps them visible but disabled
+ * rather than pretending they work. See issue #234.
+ */
+const SUPPORTED_HOST_ACCESS: ReadonlySet<HostAccessLevel> = new Set(['all-sites']);
+
+const HOST_ACCESS_UNSUPPORTED_HINT = 'Coming soon — not enforced yet';
+
 // Chrome built-in shortcuts that should be flagged as conflicts.
 // Uses the same format as Electron accelerators but lowercased for comparison.
 const CHROME_RESERVED_SHORTCUTS = new Set([
@@ -304,21 +317,41 @@ function ExtensionCard({
             </button>
             {hostMenuOpen && (
               <div className="ext-host-access-menu" role="listbox">
-                {(Object.keys(HOST_ACCESS_LABELS) as HostAccessLevel[]).map((level) => (
-                  <button
-                    key={level}
-                    type="button"
-                    role="option"
-                    aria-selected={ext.hostAccess === level}
-                    className={`ext-host-access-option ${ext.hostAccess === level ? 'ext-host-access-option--active' : ''}`}
-                    onClick={() => {
-                      onHostAccessChange(ext.id, level);
-                      setHostMenuOpen(false);
-                    }}
-                  >
-                    {HOST_ACCESS_LABELS[level]}
-                  </button>
-                ))}
+                {(Object.keys(HOST_ACCESS_LABELS) as HostAccessLevel[]).map((level) => {
+                  const supported = SUPPORTED_HOST_ACCESS.has(level);
+                  const selected = ext.hostAccess === level;
+                  const classNames = [
+                    'ext-host-access-option',
+                    selected ? 'ext-host-access-option--active' : '',
+                    supported ? '' : 'ext-host-access-option--disabled',
+                  ].filter(Boolean).join(' ');
+                  return (
+                    <button
+                      key={level}
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      aria-disabled={!supported}
+                      disabled={!supported}
+                      title={supported ? undefined : HOST_ACCESS_UNSUPPORTED_HINT}
+                      className={classNames}
+                      onClick={() => {
+                        if (!supported) return;
+                        onHostAccessChange(ext.id, level);
+                        setHostMenuOpen(false);
+                      }}
+                    >
+                      <span className="ext-host-access-option-label">
+                        {HOST_ACCESS_LABELS[level]}
+                      </span>
+                      {!supported && (
+                        <span className="ext-host-access-option-hint">
+                          {HOST_ACCESS_UNSUPPORTED_HINT}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/my-app/src/renderer/extensions/extensions.css
+++ b/my-app/src/renderer/extensions/extensions.css
@@ -342,6 +342,30 @@
   font-weight: var(--font-weight-medium);
 }
 
+.ext-host-access-option--disabled {
+  cursor: not-allowed;
+  color: var(--color-fg-disabled, var(--color-fg-tertiary));
+  opacity: 0.6;
+}
+
+.ext-host-access-option--disabled:hover {
+  /* Don't light up on hover — the option is intentionally inert. */
+  background-color: transparent;
+  color: var(--color-fg-disabled, var(--color-fg-tertiary));
+}
+
+.ext-host-access-option-label {
+  display: block;
+}
+
+.ext-host-access-option-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 10px;
+  font-style: italic;
+  color: var(--color-fg-tertiary);
+}
+
 /* ---------------------------------------------------------------------------
    Empty state
 --------------------------------------------------------------------------- */

--- a/my-app/tests/unit/extensions/ExtensionManager.spec.ts
+++ b/my-app/tests/unit/extensions/ExtensionManager.spec.ts
@@ -298,7 +298,8 @@ describe('ExtensionManager — loadUnpacked', () => {
     expect(record.permissions).toEqual(['storage']);
     expect(record.hostPermissions).toEqual(['https://*/*']);
     expect(record.enabled).toBe(true);
-    expect(record.hostAccess).toBe('on-click');
+    // Default is all-sites (the only mode actually enforced today). See #234.
+    expect(record.hostAccess).toBe('all-sites');
     // State file written
     expect(fsStore.has(STATE_PATH)).toBe(true);
     const parsed = JSON.parse(fsStore.get(STATE_PATH)!);
@@ -403,6 +404,89 @@ describe('ExtensionManager — updateExtension / setHostAccess', () => {
 
   it('setHostAccess throws for unknown id', () => {
     expect(() => mgr.setHostAccess('nope', 'all-sites')).toThrow(/not found/);
+  });
+
+  // Issue #234: the selector used to accept `specific-sites` and `on-click`
+  // and persist them as an enum that nothing enforced. Those values are now
+  // rejected at the manager boundary so the IPC and UI can't silently lie.
+  it('setHostAccess rejects specific-sites (enforcement not implemented)', () => {
+    const id = mgr.listExtensions()[0].id;
+    expect(() => mgr.setHostAccess(id, 'specific-sites' as 'all-sites'))
+      .toThrow(/not supported/);
+    expect(mgr.listExtensions()[0].hostAccess).toBe('all-sites');
+  });
+
+  it('setHostAccess rejects on-click (enforcement not implemented)', () => {
+    const id = mgr.listExtensions()[0].id;
+    expect(() => mgr.setHostAccess(id, 'on-click' as 'all-sites'))
+      .toThrow(/not supported/);
+    expect(mgr.listExtensions()[0].hostAccess).toBe('all-sites');
+  });
+
+  it('setHostAccess rejects arbitrary junk values', () => {
+    const id = mgr.listExtensions()[0].id;
+    expect(() => mgr.setHostAccess(id, 'pwned' as 'all-sites'))
+      .toThrow(/not supported/);
+  });
+});
+
+// Issue #234: legacy state files may contain the removed `on-click` /
+// `specific-sites` enum values. On load we coerce them to the only mode
+// we actually enforce so the UI reflects reality rather than a lie.
+describe('ExtensionManager — legacy hostAccess coercion (issue #234)', () => {
+  beforeEach(() => {
+    fsStore.clear();
+    dirSet.clear();
+    resetSessionMockState();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('coerces persisted on-click to all-sites on listExtensions', () => {
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [
+          { id: 'legacy-1', path: '/ext/legacy-1', enabled: true, hostAccess: 'on-click' },
+        ],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    const [rec] = mgr.listExtensions();
+    expect(rec.hostAccess).toBe('all-sites');
+  });
+
+  it('coerces persisted specific-sites to all-sites on listExtensions', () => {
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [
+          { id: 'legacy-2', path: '/ext/legacy-2', enabled: true, hostAccess: 'specific-sites' },
+        ],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    const [rec] = mgr.listExtensions();
+    expect(rec.hostAccess).toBe('all-sites');
+  });
+
+  it('coerces an unknown/garbage hostAccess value to all-sites', () => {
+    fsStore.set(
+      STATE_PATH,
+      JSON.stringify({
+        extensions: [
+          { id: 'legacy-3', path: '/ext/legacy-3', enabled: true, hostAccess: 'bogus' },
+        ],
+        developerMode: false,
+      }),
+    );
+    const mgr = new ExtensionManager();
+    const [rec] = mgr.listExtensions();
+    expect(rec.hostAccess).toBe('all-sites');
   });
 });
 

--- a/my-app/tests/unit/extensions/ExtensionsApp.spec.tsx
+++ b/my-app/tests/unit/extensions/ExtensionsApp.spec.tsx
@@ -167,18 +167,46 @@ describe('ExtensionsApp', () => {
     expect(api.closeWindow).toHaveBeenCalled();
   });
 
-  it('opens the host-access dropdown and persists a new selection', async () => {
-    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', hostAccess: 'on-click' })]);
+  it('opens the host-access dropdown and persists a supported selection', async () => {
+    // Default for new extensions is now 'all-sites' (issue #234). Start from
+    // that state and verify the menu still opens and re-persists the choice.
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', hostAccess: 'all-sites' })]);
     (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
     render(<ExtensionsApp />);
 
-    // The button label is the current value: "On click"
-    const btn = await screen.findByRole('button', { name: /on click/i });
+    // The trigger button shows the current label; find it by testable role.
+    const btn = await screen.findByRole('button', { name: /on all sites/i });
     fireEvent.click(btn);
     const allSitesOpt = await screen.findByRole('option', { name: /on all sites/i });
     await act(async () => {
       fireEvent.click(allSitesOpt);
     });
     await waitFor(() => expect(api.setHostAccess).toHaveBeenCalledWith('a', 'all-sites'));
+  });
+
+  // Issue #234: the selector used to let users pick modes the app never
+  // enforced. Those options are now rendered but disabled with honest copy.
+  it('disables unsupported host-access modes and shows a "coming soon" hint', async () => {
+    const api = makeAPI([makeExt({ id: 'a', name: 'Alpha', hostAccess: 'all-sites' })]);
+    (window as unknown as { extensionsAPI: typeof api }).extensionsAPI = api;
+    render(<ExtensionsApp />);
+
+    const btn = await screen.findByRole('button', { name: /on all sites/i });
+    fireEvent.click(btn);
+
+    const specificSitesOpt = await screen.findByRole('option', { name: /on specific sites/i });
+    const onClickOpt = await screen.findByRole('option', { name: /on click/i });
+    const allSitesOpt = await screen.findByRole('option', { name: /on all sites/i });
+
+    expect((specificSitesOpt as HTMLButtonElement).disabled).toBe(true);
+    expect((onClickOpt as HTMLButtonElement).disabled).toBe(true);
+    expect((allSitesOpt as HTMLButtonElement).disabled).toBe(false);
+
+    // Clicking a disabled option must not call the IPC — we refuse to
+    // persist a mode we can't actually enforce.
+    await act(async () => {
+      fireEvent.click(specificSitesOpt);
+    });
+    expect(api.setHostAccess).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #234.

## Problem
The Extensions UI exposed three site-access modes — `all-sites`, `specific-sites`, `on-click` — but `ExtensionManager.setHostAccess()` only persisted the enum. Nothing consumed the value, there was no allowlist model, and no runtime enforcement. `specific-sites` had no UI to add hosts at all. The menu looked functional and did nothing.

## Approach — Option B (honest disable)
Chrome-style per-origin extension gating needs machinery Electron's `session.loadExtension` does not provide (per-origin request filtering, activation gating on user click, allowlist persistence with pattern matching). Building that properly is a real feature, not a bug fix. Rather than add more fake plumbing, this PR narrows the selector to what actually works today and marks the rest honestly:

- `SUPPORTED_HOST_ACCESS_MODES = ['all-sites']` in `ExtensionManager`, matching default `loadExtension` behaviour.
- `setHostAccess()` rejects any value outside that set; the IPC `ALLOWED_HOST_ACCESS` list is sourced from the same constant so the boundary cannot drift.
- Newly loaded extensions default to `all-sites` (was `on-click`, which was never enforced). Legacy persisted `on-click` / `specific-sites` values are coerced to `all-sites` in `listExtensions()` so existing installs converge to honest state.
- The renderer still shows all three options but `specific-sites` and `on-click` are rendered as disabled buttons with a "Coming soon — not enforced yet" hint. Clicks are no-ops.

When real enforcement lands, flipping the one set in `ExtensionManager` re-enables the options everywhere.

## Files
- `src/main/extensions/ExtensionManager.ts` — `HostAccessMode` type, `SUPPORTED_HOST_ACCESS_MODES`, `DEFAULT_HOST_ACCESS`, `coerceHostAccess`, `isSupportedHostAccess`. `setHostAccess` validates; `listExtensions` coerces legacy values; `loadUnpacked` defaults to `all-sites`.
- `src/main/extensions/ipc.ts` — `ALLOWED_HOST_ACCESS` sourced from `SUPPORTED_HOST_ACCESS_MODES`.
- `src/renderer/extensions/ExtensionsApp.tsx` — `SUPPORTED_HOST_ACCESS` set gates which menu options are clickable; unsupported options render `disabled` with a "Coming soon — not enforced yet" hint and a title tooltip.
- `src/renderer/extensions/extensions.css` — styles for the disabled option state and the hint sub-text.

## Test plan
- [x] `npm run lint` — 0 errors (199 pre-existing warnings, none in touched files).
- [x] `npm run typecheck` — my files clean. Pre-existing `electron-updater` errors in `src/main/updater.ts` are unrelated to this PR (reproduce on `main`).
- [x] `npm test` — 484/484 pass.
- [x] `tests/unit/extensions/ExtensionManager.spec.ts` — new cases cover `setHostAccess` rejecting `specific-sites` / `on-click` / junk values, and a "legacy hostAccess coercion" suite that verifies persisted `on-click` / `specific-sites` / unknown values all coerce to `all-sites` on load.
- [x] `tests/unit/extensions/ExtensionsApp.spec.tsx` — updated existing host-access test to the new default; added a new case asserting the two unsupported options render as `disabled` and clicking them does not invoke `setHostAccess`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the site-access selector honest by enforcing only “All sites” and disabling unsupported modes. Fixes #234 by preventing fake selections and aligning the UI with runtime behavior.

- **Bug Fixes**
  - Introduced `SUPPORTED_HOST_ACCESS_MODES = ['all-sites']`; `setHostAccess()` rejects unsupported values. IPC `ALLOWED_HOST_ACCESS` now derives from the same constant.
  - New extensions default to `all-sites`; legacy `on-click`/`specific-sites`/unknown values are coerced to `all-sites` in `listExtensions()`.
  - UI keeps all three options visible but disables `specific-sites` and `on-click` with a “Coming soon — not enforced yet” hint; clicks are no-ops.
  - Added styles for the disabled state and tests for validation and legacy coercion.

<sup>Written for commit 2ca1c7419c5330d70fd7a9a366a20e3535678879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

