### PR TITLE
fix(extensions): register global accelerators for extension shortcuts and dispatch commands

### DIFF
--- a/my-app/src/main/extensions/ExtensionManager.ts
+++ b/my-app/src/main/extensions/ExtensionManager.ts
@@ -9,7 +9,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { app, session } from 'electron';
+import { app, session, globalShortcut, BrowserWindow } from 'electron';
 import { mainLogger } from '../logger';
 import { ManifestV3Runtime } from './mv3/ManifestV3Runtime';
 import type { MV3ExtensionInfo } from './mv3/ManifestV3Runtime';
@@ -71,6 +71,12 @@ export class ExtensionManager {
   private state: PersistedState;
   readonly mv3Runtime: ManifestV3Runtime;
 
+  /** Tracks accelerator strings currently registered via globalShortcut */
+  private registeredShortcuts = new Set<string>();
+
+  /** Optional getter for the shell window — injected after window creation */
+  private getShellWindow: (() => BrowserWindow | null) | null = null;
+
   constructor() {
     this.statePath = path.join(app.getPath('userData'), STATE_FILE_NAME);
     this.state = this.loadState();
@@ -80,6 +86,15 @@ export class ExtensionManager {
       extensionCount: this.state.extensions.length,
       developerMode: this.state.developerMode,
     });
+  }
+
+  /**
+   * Provide a getter for the shell BrowserWindow so that shortcut handlers
+   * can dispatch extension-command events to the renderer.
+   * Call this once the shell window has been created.
+   */
+  setShellWindowGetter(getter: () => BrowserWindow | null): void {
+    this.getShellWindow = getter;
   }
 
   // -------------------------------------------------------------------------
@@ -453,7 +468,116 @@ export class ExtensionManager {
       this.state.shortcuts[stateKey] = shortcut;
     }
     this.saveState();
+
+    // Re-bind all shortcuts so the new mapping takes effect immediately.
+    this.bindShortcuts();
+
     mainLogger.info(`${LOG_PREFIX}.setExtensionShortcut.ok`, { extensionId, commandName, shortcut });
+  }
+
+  /**
+   * Register all persisted extension shortcuts as Electron global shortcuts.
+   *
+   * Each entry in `state.shortcuts` maps "<extensionId>/<commandName>" to an
+   * Electron accelerator string (e.g. "Ctrl+Shift+F").  When the shortcut
+   * fires we:
+   *   - For action-trigger commands: send `extensions:command-triggered` to the
+   *     shell window so the renderer can open the extension's action popup.
+   *   - For all named commands: send the same message with the command name so
+   *     the renderer (or the extension's service worker) can react.
+   *
+   * Any previously registered extension shortcuts are unregistered first so
+   * this method is safe to call multiple times (e.g. after every mutation).
+   */
+  bindShortcuts(): void {
+    mainLogger.info(`${LOG_PREFIX}.bindShortcuts`);
+
+    // 1. Unregister shortcuts from the previous call.
+    this.unbindShortcuts();
+
+    // 2. Collect the effective shortcut for every command across loaded extensions.
+    //    We use listAllCommands() because it merges manifest defaults with
+    //    persisted overrides, and only covers currently-loaded extensions.
+    const commands = this.listAllCommands();
+
+    for (const cmd of commands) {
+      const { extensionId, commandName, shortcut } = cmd;
+      if (!shortcut) continue;
+
+      // Avoid registering the same accelerator twice (e.g. two extensions
+      // mapping to the same key — first one wins, which matches Chrome behaviour).
+      if (this.registeredShortcuts.has(shortcut)) {
+        mainLogger.warn(`${LOG_PREFIX}.bindShortcuts.duplicate`, {
+          shortcut,
+          extensionId,
+          commandName,
+          msg: 'Accelerator already registered; skipping',
+        });
+        continue;
+      }
+
+      const registered = globalShortcut.register(shortcut, () => {
+        mainLogger.info(`${LOG_PREFIX}.shortcutFired`, { extensionId, commandName, shortcut });
+        this.dispatchExtensionCommand(extensionId, commandName);
+      });
+
+      if (registered) {
+        this.registeredShortcuts.add(shortcut);
+        mainLogger.info(`${LOG_PREFIX}.bindShortcuts.registered`, {
+          extensionId,
+          commandName,
+          shortcut,
+        });
+      } else {
+        mainLogger.warn(`${LOG_PREFIX}.bindShortcuts.registerFailed`, {
+          extensionId,
+          commandName,
+          shortcut,
+          msg: 'globalShortcut.register returned false — accelerator may be claimed by another app',
+        });
+      }
+    }
+
+    mainLogger.info(`${LOG_PREFIX}.bindShortcuts.ok`, {
+      registered: this.registeredShortcuts.size,
+    });
+  }
+
+  /**
+   * Unregister all extension shortcuts that were registered via `bindShortcuts`.
+   * Safe to call even if no shortcuts are registered.
+   */
+  unbindShortcuts(): void {
+    mainLogger.info(`${LOG_PREFIX}.unbindShortcuts`, { count: this.registeredShortcuts.size });
+    for (const shortcut of this.registeredShortcuts) {
+      globalShortcut.unregister(shortcut);
+    }
+    this.registeredShortcuts.clear();
+  }
+
+  /**
+   * Dispatch an extension command to the shell renderer.
+   *
+   * For action-trigger commands (`_execute_action`, `_execute_browser_action`,
+   * `_execute_page_action`) the renderer should open the extension's popup.
+   * For all other commands the renderer forwards the named command to the
+   * extension's content scripts / service worker.
+   *
+   * The IPC channel `extensions:command-triggered` carries:
+   *   { extensionId: string; commandName: string }
+   */
+  private dispatchExtensionCommand(extensionId: string, commandName: string): void {
+    const win = this.getShellWindow?.();
+    if (!win || win.isDestroyed()) {
+      mainLogger.warn(`${LOG_PREFIX}.dispatchExtensionCommand.noWindow`, {
+        extensionId,
+        commandName,
+      });
+      return;
+    }
+
+    win.webContents.send('extensions:command-triggered', { extensionId, commandName });
+    mainLogger.info(`${LOG_PREFIX}.dispatchExtensionCommand.sent`, { extensionId, commandName });
   }
 
   // -------------------------------------------------------------------------
@@ -474,6 +598,7 @@ export class ExtensionManager {
 
   dispose(): void {
     mainLogger.info(`${LOG_PREFIX}.dispose`);
+    this.unbindShortcuts();
     this.mv3Runtime.dispose();
   }
 

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -890,9 +890,14 @@ app.whenReady().then(async () => {
 
 // Issue #71 — Extensions: init manager + register IPC
   extensionManager = new ExtensionManager();
+  // Wire the shell-window getter so shortcut handlers can dispatch commands.
+  extensionManager.setShellWindowGetter(() => shellWindow);
   registerExtensionsHandlers(extensionManager);
   registerMV3Handlers(extensionManager);
-  void extensionManager.loadAllEnabled();
+  void extensionManager.loadAllEnabled().then(() => {
+    // Bind persisted extension shortcuts after all enabled extensions are loaded.
+    extensionManager?.bindShortcuts();
+  });
 
   // Issue #95 — Settings zoom override IPC (needs tabManager access)
   ipcMain.handle('settings:get-zoom-overrides', () => {
@@ -1021,9 +1026,10 @@ app.whenReady().then(async () => {
     unregisterAutofillHandlers();
     // Issue #202 — cancel the periodic auto-update check timer.
     stopUpdater();
-    // ExtensionManager currently has no dispose()/destroy() hook; its
-    // internal MV3 runtime tears itself down via its own lifecycle. If a
-    // top-level cleanup is ever added, wire it in here.
+    // Unregister extension global shortcuts and tear down the MV3 runtime.
+    extensionManager?.unbindShortcuts();
+    extensionManager?.dispose();
+    extensionManager = null;
     downloadManager?.destroy();
     downloadManager = null;
   });


### PR DESCRIPTION
## Summary

Closes #233.

Extension keyboard shortcuts were being stored in `extensions-state.json` via `setExtensionShortcut()`, but nothing translated those stored shortcuts into actual Electron accelerators or dispatched extension commands when pressed.

- **`ExtensionManager.bindShortcuts()`**: Iterates all effective shortcuts (merging manifest `suggested_key` defaults with persisted overrides via `listAllCommands()`), calls `globalShortcut.register()` for each non-empty accelerator. On keypress, sends `extensions:command-triggered` to the shell renderer with `{ extensionId, commandName }` so the renderer can open the extension popup (for `_execute_action` / `_execute_browser_action` / `_execute_page_action`) or forward named commands to the extension service worker. Deduplicates accelerators (first registration wins, matching Chrome behavior).
- **`ExtensionManager.unbindShortcuts()`**: Unregisters all extension-owned accelerators tracked in `registeredShortcuts`. Called at app quit and as the first step of every `bindShortcuts()` call (making re-binding idempotent).
- **`ExtensionManager.setShellWindowGetter(getter)`**: Injects a `() => BrowserWindow | null` callback so dispatch can reach the shell window without creating a circular dependency at construction time.
- **`setExtensionShortcut()`**: Now calls `bindShortcuts()` after persisting, so changes made in the Extensions settings page take effect immediately without a restart.
- **`index.ts`**: Calls `setShellWindowGetter(() => shellWindow)` right after creating the manager, calls `bindShortcuts()` once `loadAllEnabled()` resolves, and calls `unbindShortcuts()` + `dispose()` in the `will-quit` handler.

## Test plan

- [ ] Install an extension with a `commands` entry in its manifest (e.g. uBlock Origin uses `Ctrl+Shift+X`)
- [ ] Verify the shortcut fires `extensions:command-triggered` in the shell renderer
- [ ] Open Extensions > Keyboard Shortcuts, change a shortcut — verify the new key takes effect immediately (no restart required)
- [ ] Clear a shortcut — verify it no longer fires
- [ ] Quit the app — verify no globalShortcut leak warnings in the log
- [ ] `npm run typecheck` passes (only pre-existing `updater.ts` errors remain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers extension keyboard shortcuts as Electron global accelerators and dispatches commands to the renderer so actions and named commands work from the keyboard. Shortcut updates apply immediately and are cleaned up on quit.

- **Bug Fixes**
  - Added `bindShortcuts()` to register effective accelerators (manifest `suggested_key` + saved overrides) for all enabled extensions.
  - Deduplicates conflicting accelerators; first registration wins (Chrome-like behavior).
  - On keypress, sends `extensions:command-triggered` to the shell window with `{ extensionId, commandName }`.
  - `setExtensionShortcut()` now persists and rebinds shortcuts so changes take effect without restart.
  - Lifecycle wiring: `setShellWindowGetter()` injected in `index.ts`, bind after `loadAllEnabled()`, and call `unbindShortcuts()` + `dispose()` on `will-quit`.

<sup>Written for commit dc9abe9659c4982699da3b96901144dd56fb6c44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

