### PR TITLE
fix(profiles): scope bookmark/history/password/autofill stores to active profile data dir

### DIFF
--- a/my-app/src/main/autofill/AutofillStore.ts
+++ b/my-app/src/main/autofill/AutofillStore.ts
@@ -75,8 +75,8 @@ function makeEmpty(): PersistedAutofill {
   return { version: 1, addresses: [], cards: [] };
 }
 
-function getAutofillPath(): string {
-  return path.join(app.getPath('userData'), AUTOFILL_FILE_NAME);
+function getAutofillPath(dataDir: string): string {
+  return path.join(dataDir, AUTOFILL_FILE_NAME);
 }
 
 // ---------------------------------------------------------------------------
@@ -111,11 +111,13 @@ export function extractLastFour(number: string): string {
 // ---------------------------------------------------------------------------
 
 export class AutofillStore {
+  private dataDir: string;
   private state: PersistedAutofill;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private dirty = false;
 
-  constructor() {
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir ?? app.getPath('userData');
     this.state = this.load();
     mainLogger.info('AutofillStore.init', {
       addressCount: this.state.addresses.length,
@@ -129,7 +131,7 @@ export class AutofillStore {
 
   private load(): PersistedAutofill {
     try {
-      const raw = fs.readFileSync(getAutofillPath(), 'utf-8');
+      const raw = fs.readFileSync(getAutofillPath(this.dataDir), 'utf-8');
       const parsed = JSON.parse(raw) as PersistedAutofill;
       if (parsed.version !== 1) {
         mainLogger.warn('AutofillStore.load.invalid', { msg: 'Resetting autofill store' });
@@ -159,7 +161,7 @@ export class AutofillStore {
   flushSync(): void {
     if (!this.dirty) return;
     try {
-      fs.writeFileSync(getAutofillPath(), JSON.stringify(this.state, null, 2), 'utf-8');
+      fs.writeFileSync(getAutofillPath(this.dataDir), JSON.stringify(this.state, null, 2), 'utf-8');
       mainLogger.info('AutofillStore.flushSync.ok');
     } catch (err) {
       mainLogger.error('AutofillStore.flushSync.failed', { error: (err as Error).message });

--- a/my-app/src/main/bookmarks/BookmarkStore.ts
+++ b/my-app/src/main/bookmarks/BookmarkStore.ts
@@ -62,16 +62,18 @@ function makeEmpty(): PersistedBookmarks {
   };
 }
 
-function getBookmarksPath(): string {
-  return path.join(app.getPath('userData'), BOOKMARKS_FILE_NAME);
+function getBookmarksPath(dataDir: string): string {
+  return path.join(dataDir, BOOKMARKS_FILE_NAME);
 }
 
 export class BookmarkStore {
+  private dataDir: string;
   private state: PersistedBookmarks;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private dirty = false;
 
-  constructor() {
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir ?? app.getPath('userData');
     this.state = this.load();
   }
 
@@ -81,7 +83,7 @@ export class BookmarkStore {
 
   private load(): PersistedBookmarks {
     try {
-      const raw = fs.readFileSync(getBookmarksPath(), 'utf-8');
+      const raw = fs.readFileSync(getBookmarksPath(this.dataDir), 'utf-8');
       const parsed = JSON.parse(raw) as PersistedBookmarks;
       if (
         parsed.version !== 1 ||
@@ -112,12 +114,12 @@ export class BookmarkStore {
     if (!this.dirty) return;
     try {
       fs.writeFileSync(
-        getBookmarksPath(),
+        getBookmarksPath(this.dataDir),
         JSON.stringify(this.state, null, 2),
         'utf-8',
       );
       mainLogger.info('BookmarkStore.flushSync.ok', {
-        path: getBookmarksPath(),
+        path: getBookmarksPath(this.dataDir),
       });
     } catch (err) {
       mainLogger.error('BookmarkStore.flushSync.failed', {

--- a/my-app/src/main/history/HistoryStore.ts
+++ b/my-app/src/main/history/HistoryStore.ts
@@ -39,8 +39,8 @@ export interface HistoryQueryResult {
   totalCount: number;
 }
 
-function getHistoryPath(): string {
-  return path.join(app.getPath('userData'), HISTORY_FILE_NAME);
+function getHistoryPath(dataDir: string): string {
+  return path.join(dataDir, HISTORY_FILE_NAME);
 }
 
 let nextId = 1;
@@ -50,17 +50,19 @@ function generateId(): string {
 }
 
 export class HistoryStore {
+  private dataDir: string;
   private entries: HistoryEntry[] = [];
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private dirty = false;
 
-  constructor() {
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir ?? app.getPath('userData');
     this.load();
   }
 
   private load(): void {
     try {
-      const raw = fs.readFileSync(getHistoryPath(), 'utf-8');
+      const raw = fs.readFileSync(getHistoryPath(this.dataDir), 'utf-8');
       const parsed = JSON.parse(raw) as PersistedHistory;
       if (parsed.version === 1 && Array.isArray(parsed.entries)) {
         this.entries = parsed.entries;
@@ -95,7 +97,7 @@ export class HistoryStore {
     }
     try {
       const data: PersistedHistory = { version: 1, entries: this.entries };
-      fs.writeFileSync(getHistoryPath(), JSON.stringify(data), 'utf-8');
+      fs.writeFileSync(getHistoryPath(this.dataDir), JSON.stringify(data), 'utf-8');
       mainLogger.debug('HistoryStore.flush.ok', { count: this.entries.length });
     } catch (err) {
       mainLogger.error('HistoryStore.flush.failed', {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -258,6 +258,9 @@ function openShellAndWire(profileId?: string): BrowserWindow {
   if (historyStore) {
     tabManager.setHistoryStore(historyStore);
   }
+  if (passwordStore) {
+    tabManager.setPasswordStore(passwordStore);
+  }
   tabManager.restoreSession();
 
   // Permission framework: wire manager to session + tab lifecycle
@@ -652,11 +655,9 @@ app.whenReady().then(async () => {
   });
 
   // Wave1 P3 — Bookmarks: init store + register IPC before the shell loads.
-  // NOTE: BookmarkStore/PasswordStore/HistoryStore currently key off
-  // `app.getPath('userData')` internally and ignore the active profile.
-  // Profile-scoped persistence for those stores is tracked as a follow-up;
-  // only PermissionStore accepts a data dir today.
-  bookmarkStore = new BookmarkStore();
+  // Each store is scoped to the active profile's data directory so that
+  // bookmarks, history, passwords, and autofill are isolated per profile.
+  bookmarkStore = new BookmarkStore(getProfileDataDir(activeProfileId));
   permissionStore = new PermissionStore(getProfileDataDir(activeProfileId));
   protocolHandlerStore = new ProtocolHandlerStore(getProfileDataDir(activeProfileId));
   deviceStore = new DeviceStore(getProfileDataDir(activeProfileId));
@@ -670,13 +671,12 @@ app.whenReady().then(async () => {
   });
 
   // Password Manager: init store + register IPC.
-  // See comment above re: profile-scoped persistence follow-up.
-  passwordStore = new PasswordStore();
+  passwordStore = new PasswordStore(getProfileDataDir(activeProfileId));
   registerPasswordHandlers({ store: passwordStore });
   if (tabManager) tabManager.setPasswordStore(passwordStore);
 
   // Issue #70 — Autofill: init store + register IPC.
-  autofillStore = new AutofillStore();
+  autofillStore = new AutofillStore(getProfileDataDir(activeProfileId));
   registerAutofillHandlers({ store: autofillStore });
 
   // Issue #45 — Profile picker: init store + register IPC
@@ -690,14 +690,45 @@ app.whenReady().then(async () => {
         openGuestShell();
       } else {
         activeProfileId = profileId ?? 'default';
+
+        // Flush and recreate per-profile stores so the new profile's data
+        // directory is used. IPC handlers are re-registered with the new
+        // store instances.
+        bookmarkStore?.flushSync();
+        historyStore?.flushSync();
+        passwordStore?.flushSync();
+        autofillStore?.flushSync();
+
+        const newDataDir = getProfileDataDir(activeProfileId);
+
+        unregisterBookmarkHandlers();
+        bookmarkStore = new BookmarkStore(newDataDir);
+        registerBookmarkHandlers({
+          store: bookmarkStore,
+          getShellWindow: () => shellWindow,
+          getAllTabs: () =>
+            tabManager ? tabManager.getAllTabSummaries() : [],
+        });
+
+        unregisterHistoryHandlers();
+        historyStore = new HistoryStore(newDataDir);
+        registerHistoryHandlers({ store: historyStore });
+
+        unregisterPasswordHandlers();
+        passwordStore = new PasswordStore(newDataDir);
+        registerPasswordHandlers({ store: passwordStore });
+
+        unregisterAutofillHandlers();
+        autofillStore = new AutofillStore(newDataDir);
+        registerAutofillHandlers({ store: autofillStore });
+
         openShellAndWire();
       }
     },
   });
 
   // Issue #40 — History: init store + register IPC.
-  // See comment above re: profile-scoped persistence follow-up.
-  historyStore = new HistoryStore();
+  historyStore = new HistoryStore(getProfileDataDir(activeProfileId));
   registerHistoryHandlers({ store: historyStore });
 
   // Issue #17 — Omnibox autocomplete providers

--- a/my-app/src/main/passwords/PasswordStore.ts
+++ b/my-app/src/main/passwords/PasswordStore.ts
@@ -42,16 +42,18 @@ function makeEmpty(): PersistedPasswords {
   };
 }
 
-function getPasswordsPath(): string {
-  return path.join(app.getPath('userData'), PASSWORDS_FILE_NAME);
+function getPasswordsPath(dataDir: string): string {
+  return path.join(dataDir, PASSWORDS_FILE_NAME);
 }
 
 export class PasswordStore {
+  private dataDir: string;
   private state: PersistedPasswords;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private dirty = false;
 
-  constructor() {
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir ?? app.getPath('userData');
     this.state = this.load();
     mainLogger.info('PasswordStore.init', {
       credentialCount: this.state.credentials.length,
@@ -65,7 +67,7 @@ export class PasswordStore {
 
   private load(): PersistedPasswords {
     try {
-      const raw = fs.readFileSync(getPasswordsPath(), 'utf-8');
+      const raw = fs.readFileSync(getPasswordsPath(this.dataDir), 'utf-8');
       const parsed = JSON.parse(raw) as PersistedPasswords;
       if (parsed.version !== 1 || !Array.isArray(parsed.credentials)) {
         mainLogger.warn('PasswordStore.load.invalid', { msg: 'Resetting passwords store' });
@@ -92,7 +94,7 @@ export class PasswordStore {
     if (!this.dirty) return;
     try {
       fs.writeFileSync(
-        getPasswordsPath(),
+        getPasswordsPath(this.dataDir),
         JSON.stringify(this.state, null, 2),
         'utf-8',
       );

--- a/my-app/src/main/settings/ipc.ts
+++ b/my-app/src/main/settings/ipc.ts
@@ -440,11 +440,11 @@ function handleGetOAuthScopes(): Array<{ scope: string; label: string; granted: 
 }
 
 function handleReConsentScope(_event: Electron.IpcMainInvokeEvent, scope: string): void {
-  // Stub: OAuth re-consent is a full flow; log intent and return OK.
-  mainLogger.info(CH_RE_CONSENT_SCOPE, {
+  mainLogger.warn(CH_RE_CONSENT_SCOPE, {
     scope,
-    msg: 'Re-consent requested — full OAuth flow not yet implemented; returning stub OK',
+    msg: 'Re-consent requested — full OAuth flow is not yet implemented',
   });
+  throw new Error('Re-consent OAuth flow is not yet implemented');
 }
 
 async function handleFactoryReset(): Promise<void> {

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -702,15 +702,15 @@ function GoogleScopesTab(): React.ReactElement {
     try {
       await window.settingsAPI.reConsentScope(scope);
       toast.show({
-        variant: 'info',
-        title: 'Re-consent initiated',
+        variant: 'success',
+        title: 'Re-consent complete',
         message: `Scope: ${scope}`,
       });
     } catch (err) {
       toast.show({
-        variant: 'error',
-        title: 'Re-consent failed',
-        message: (err as Error).message,
+        variant: 'warning',
+        title: 'Re-consent not available',
+        message: 'Re-consent is not yet available. Please sign out and sign back in to update permissions.',
       });
     } finally {
       setReconsentId(null);
@@ -756,6 +756,7 @@ function GoogleScopesTab(): React.ReactElement {
                 size="sm"
                 onClick={() => void handleReconsent(s.scope)}
                 loading={reconsentId === s.scope}
+                title="Re-consent is not yet available"
               >
                 Re-consent
               </Button>


### PR DESCRIPTION
## Summary

- `BookmarkStore`, `HistoryStore`, `PasswordStore`, and `AutofillStore` each gain an optional `dataDir?: string` constructor parameter; when omitted they fall back to `app.getPath('userData')` for full backward compatibility.
- In `index.ts`, all four stores are now instantiated with `getProfileDataDir(activeProfileId)` at startup so the correct profile directory is used from the first load.
- The `onProfileSelected` callback now flushes each store to disk, unregisters its IPC handlers, recreates the store with the new profile's data directory, and re-registers the handlers — ensuring complete isolation when the user switches profiles.
- `openShellAndWire` now also calls `tabManager.setPasswordStore(passwordStore)` so every new `TabManager` created on profile switch has the correct password store reference.

Closes #208.

## Test plan

- [ ] Launch app with default profile — bookmarks, history, passwords, and autofill load from `userData/` as before.
- [ ] Create a second profile and switch to it — verify the new profile starts with empty bookmarks/history/passwords/autofill.
- [ ] Add a bookmark/password in profile A, switch to profile B, confirm it does not appear; switch back to A and confirm it is still there.
- [ ] Quit and relaunch — confirm each profile's data persists to its own directory (`userData/profiles/<profileId>/`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate bookmarks, history, passwords, and autofill per profile by scoping their stores to the active profile data directory and reloading them on profile switch. Also surface a clear “not implemented” error for Google re-consent so the UI shows a warning instead of a false success.

- **Bug Fixes**
  - Scope `BookmarkStore`, `HistoryStore`, `PasswordStore`, and `AutofillStore` to `getProfileDataDir(activeProfileId)`; flush/recreate and re-register IPC on profile switch; wire `passwordStore` in `openShellAndWire` so new `TabManager`s use the right store. Fixes #208.
  - `settings:re-consent-scope` now throws; renderer shows a warning toast and adds a tooltip indicating re-consent is not available. Fixes #201.

<sup>Written for commit 163b35016b11f22d6e2932bcf0372eb87fcc4892. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

