### PR TITLE
fix(content-settings): actually enforce popups/JavaScript/images policies (or disable the UI)

### DIFF
--- a/my-app/src/main/content-categories/ContentPolicyEnforcer.ts
+++ b/my-app/src/main/content-categories/ContentPolicyEnforcer.ts
@@ -1,0 +1,169 @@
+/**
+ * ContentPolicyEnforcer — the missing runtime consumer for
+ * {@link ContentCategoryStore}. Issue #222: the Settings > Content tab
+ * persisted policies for popups / JavaScript / images / sound but nothing
+ * applied them to live browsing. This class is the "enforcement" side.
+ *
+ * Scope (wave 1 — categories we actually wire here):
+ *   - images:     webRequest.onBeforeRequest cancels image resource types
+ *                 when the resolved policy (origin override -> default) is 'block'.
+ *   - popups:     a predicate + allow(origin) escape hatch. TabManager's
+ *                 setWindowOpenHandler must call shouldBlockPopup() before
+ *                 creating a new tab from window.open / target=_blank.
+ *   - javascript: read at tab-creation time to set WebPreferences.javascript.
+ *                 Changing JS policy does NOT retroactively affect already-open
+ *                 tabs; a reload is required (consistent with Chrome).
+ *   - sound:      setAudioMuted() on the tab's webContents after each
+ *                 navigation, OR'd with MutedSitesStore (any mute source wins).
+ *
+ * Out of scope for this wave (UI now labels these "Not enforced yet" and
+ * the select is disabled):
+ *   - ads, automatic-downloads, protected-content, clipboard-read,
+ *     clipboard-write.
+ *
+ * Design notes:
+ *   - Electron session.webRequest allows a single listener per event type.
+ *     The extensions DNR engine also wants onBeforeRequest. We grab the slot
+ *     eagerly on install(); if DNR later calls onBeforeRequest again, its
+ *     listener will replace ours and image blocking stops. This is noted
+ *     as a follow-up — coordinating the slot needs a shared dispatcher,
+ *     out of scope for this bug-fix.
+ *   - Resolution order: per-origin override > default. An override of 'allow'
+ *     beats a default of 'block' and vice-versa.
+ */
+
+import type { Session, OnBeforeRequestListenerDetails, CallbackResponse } from 'electron';
+import { mainLogger } from '../logger';
+import {
+  ContentCategoryStore,
+  ContentCategory,
+  CategoryState,
+} from './ContentCategoryStore';
+
+const LOG = 'ContentPolicyEnforcer';
+
+// Electron resourceType values that represent "images" for our purposes.
+// 'imageSet' is not a standard Electron resourceType (that's a DNR/chrome
+// concept), so we stick to 'image'. 'favicon' is separate — users usually
+// do want favicons even with images blocked; Chrome behaves the same way.
+const IMAGE_RESOURCE_TYPES = new Set(['image']);
+
+export interface ContentPolicyEnforcerOptions {
+  store: ContentCategoryStore;
+}
+
+export class ContentPolicyEnforcer {
+  private readonly store: ContentCategoryStore;
+  private installedSession: Session | null = null;
+
+  constructor(opts: ContentPolicyEnforcerOptions) {
+    this.store = opts.store;
+    mainLogger.info(`${LOG}.ctor`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Session wiring
+  // -------------------------------------------------------------------------
+
+  /**
+   * Register the image-blocking listener on the given session. Replaces
+   * any previous onBeforeRequest listener on that session — callers that
+   * also install web-request interceptors need to coordinate (see class
+   * note above).
+   */
+  install(session: Session): void {
+    mainLogger.info(`${LOG}.install`);
+    session.webRequest.onBeforeRequest((details, callback) => {
+      this.handleBeforeRequest(details, callback);
+    });
+    this.installedSession = session;
+  }
+
+  /**
+   * Remove the listener. Called on teardown / profile switch.
+   */
+  uninstall(): void {
+    if (!this.installedSession) return;
+    mainLogger.info(`${LOG}.uninstall`);
+    // Electron's API: passing null clears the listener.
+    this.installedSession.webRequest.onBeforeRequest(null);
+    this.installedSession = null;
+  }
+
+  // Exposed for unit tests — lets us invoke the registered listener without
+  // going through a real Session.
+  handleBeforeRequest(
+    details: Pick<OnBeforeRequestListenerDetails, 'url' | 'resourceType'>,
+    callback: (response: CallbackResponse) => void,
+  ): void {
+    const resourceType = String(details.resourceType ?? 'other');
+    if (!IMAGE_RESOURCE_TYPES.has(resourceType)) {
+      callback({});
+      return;
+    }
+
+    const origin = this.extractOrigin(details.url);
+    const state = this.resolvedState(origin, 'images');
+    if (state === 'block') {
+      mainLogger.debug(`${LOG}.block.image`, { origin, url: details.url.slice(0, 120) });
+      callback({ cancel: true });
+      return;
+    }
+    callback({});
+  }
+
+  // -------------------------------------------------------------------------
+  // Public predicates (called from TabManager and tab creation)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Popups: return true if window.open / target=_blank should be denied for
+   * the given initiator origin. Default Chrome-parity policy is 'block'.
+   */
+  shouldBlockPopup(initiatorUrl: string): boolean {
+    const origin = this.extractOrigin(initiatorUrl);
+    return this.resolvedState(origin, 'popups') === 'block';
+  }
+
+  /**
+   * JavaScript: resolved policy for a given URL. Consulted at tab-creation
+   * time to flip WebPreferences.javascript off. Because WebPreferences are
+   * immutable after BrowserWindow/WebContentsView creation, runtime policy
+   * changes only take effect on the next navigation that spawns a new
+   * WebContents (or after a full reload on some Electron versions).
+   */
+  isJavaScriptAllowed(url: string): boolean {
+    const origin = this.extractOrigin(url);
+    // An explicit default of 'allow' is the Chrome-parity norm; any non-block
+    // state counts as allowed (there's no 'ask' UX for JS yet).
+    return this.resolvedState(origin, 'javascript') !== 'block';
+  }
+
+  /**
+   * Sound: return true if the tab at this URL should be muted per content
+   * policy. The caller should OR this with other mute sources (tab-mute,
+   * site-mute) — any source saying "mute" wins.
+   */
+  shouldMuteForSoundPolicy(url: string): boolean {
+    const origin = this.extractOrigin(url);
+    return this.resolvedState(origin, 'sound') === 'block';
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private resolvedState(origin: string, category: ContentCategory): CategoryState {
+    // getSiteOverride already falls through to the default when no override
+    // exists, so we only need the one call here.
+    return this.store.getSiteOverride(origin, category);
+  }
+
+  private extractOrigin(url: string): string {
+    try {
+      return new URL(url).origin;
+    } catch {
+      return url;
+    }
+  }
+}

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -16,7 +16,7 @@ import fs from 'node:fs';
 // dev-time fallback.
 loadDotEnv({ path: path.resolve(__dirname, '..', '..', '.env') });
 
-import { app, BrowserWindow, clipboard, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, dialog, shell } from 'electron';
+import { app, BrowserWindow, clipboard, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, dialog, session, shell } from 'electron';
 import started from 'electron-squirrel-startup';
 import { createShellWindow } from './window';
 import { TabManager } from './tabs/TabManager';
@@ -81,8 +81,10 @@ import { registerPermissionHandlers, unregisterPermissionHandlers } from './perm
 import { PermissionAutoRevoker } from './permissions/PermissionAutoRevoker';
 import { ProtocolHandlerStore } from './permissions/ProtocolHandlerStore';
 // Issue #54 — Content category toggles
+// Issue #222 — Enforce persisted content category policies at runtime
 import { ContentCategoryStore } from './content-categories/ContentCategoryStore';
 import { registerContentCategoryHandlers, unregisterContentCategoryHandlers } from './content-categories/ipc';
+import { ContentPolicyEnforcer } from './content-categories/ContentPolicyEnforcer';
 // Issue #71 — Extensions
 import { ExtensionManager } from './extensions/ExtensionManager';
 import { registerExtensionsHandlers, unregisterExtensionsHandlers } from './extensions/ipc';
@@ -215,6 +217,7 @@ let permissionManager: PermissionManager | null = null;
 let permissionAutoRevoker: PermissionAutoRevoker | null = null;
 let protocolHandlerStore: ProtocolHandlerStore | null = null;
 let contentCategoryStore: ContentCategoryStore | null = null;
+let contentPolicyEnforcer: ContentPolicyEnforcer | null = null;
 let extensionManager: ExtensionManager | null = null;
 let historyStore: HistoryStore | null = null;
 let shortcutsStore: ShortcutsStore | null = null;
@@ -267,6 +270,11 @@ function openShellAndWire(profileId?: string): BrowserWindow {
   }
   if (historyStore) {
     tabManager.setHistoryStore(historyStore);
+  }
+  // Issue #222 — hand the enforcer to TabManager so popup-blocking,
+  // JS-disable, and sound-policy checks have a source of truth.
+  if (contentPolicyEnforcer) {
+    tabManager.setContentPolicyEnforcer(contentPolicyEnforcer);
   }
   tabManager.restoreSession();
 
@@ -426,6 +434,12 @@ function openGuestShell(): BrowserWindow {
   if (searchEngineStore) {
     tabManager.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
   }
+  // Issue #222 — guest windows share the same default content-category
+  // policies (the store is global, not profile-scoped today). Wire the
+  // same enforcer so popups/JS block uniformly.
+  if (contentPolicyEnforcer) {
+    tabManager.setContentPolicyEnforcer(contentPolicyEnforcer);
+  }
 
   tabManager.restoreSession();
 
@@ -512,6 +526,10 @@ function openNewWindow(initialUrl?: string): BrowserWindow {
     const store = bookmarkStore;
     tm.setUrlMatchFn((candidate: string) => store.isUrlBookmarked(candidate) ? candidate : null);
   }
+  // Issue #222 — secondary profile windows still enforce content policies.
+  if (contentPolicyEnforcer) {
+    tm.setContentPolicyEnforcer(contentPolicyEnforcer);
+  }
   if (initialUrl) {
     tm.createTab(initialUrl);
   } else {
@@ -554,6 +572,8 @@ function openIncognitoWindow(initialUrl?: string): BrowserWindow {
   const tm = new TabManager(win, { guest: true, partition });
   // Incognito windows do not share the persistent group store — privacy isolation.
   if (searchEngineStore) tm.setSearchUrlTemplate(searchEngineStore.getDefault().searchUrl);
+  // Issue #222 — incognito sessions still honor content-category policies.
+  if (contentPolicyEnforcer) tm.setContentPolicyEnforcer(contentPolicyEnforcer);
   if (initialUrl) {
     tm.createTab(initialUrl);
   } else {
@@ -605,6 +625,8 @@ function openGuestWindow(partition: string, initialUrl?: string): BrowserWindow 
 
   const win = createShellWindow({ titleSuffix: ' (Guest)' });
   const tm = new TabManager(win, { guest: true, partition });
+  // Issue #222 — secondary guest windows enforce the same content policies.
+  if (contentPolicyEnforcer) tm.setContentPolicyEnforcer(contentPolicyEnforcer);
 
   if (initialUrl) {
     tm.createTab(initialUrl);
@@ -674,6 +696,17 @@ app.whenReady().then(async () => {
   deviceStore = new DeviceStore(getProfileDataDir(activeProfileId));
   contentCategoryStore = new ContentCategoryStore();
   registerContentCategoryHandlers({ store: contentCategoryStore });
+  // Issue #222 — actually enforce the persisted content-category policies.
+  // Install the image-blocking webRequest handler on the default session so
+  // `images: 'block'` cancels <img>/CSS background requests. Popup and
+  // JavaScript enforcement live in TabManager (which we hand a reference
+  // to the enforcer below once TabManager is constructed).
+  contentPolicyEnforcer = new ContentPolicyEnforcer({ store: contentCategoryStore });
+  try {
+    contentPolicyEnforcer.install(session.defaultSession);
+  } catch (err) {
+    mainLogger.error('main.contentPolicyEnforcer.installFailed', { error: (err as Error).message });
+  }
   registerBookmarkHandlers({
     store: bookmarkStore,
     getShellWindow: () => shellWindow,

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -19,6 +19,7 @@ import { NavigationController } from './NavigationController';
 import { SessionStore, PersistedSession, PersistedTab } from './SessionStore';
 import { ZoomStore, extractOrigin, zoomLevelToPercent, type ZoomEntry } from './ZoomStore';
 import { MutedSitesStore } from './MutedSitesStore';
+import type { ContentPolicyEnforcer } from '../content-categories/ContentPolicyEnforcer';
 import { parseNavigationInput, UrlMatchFn } from '../navigation';
 import path from 'node:path';
 import { mainLogger } from '../logger';
@@ -198,6 +199,10 @@ export class TabManager {
   private historyStore: HistoryStore | null = null;
   private passwordStore: PasswordStore | null = null;
   private tabGroupStore: TabGroupStore | null = null;
+  // Issue #222 — consulted before window-open / at tab creation to enforce
+  // the Settings > Content policies (popups, JS, sound) that were persisted
+  // but previously unread.
+  private contentPolicyEnforcer: ContentPolicyEnforcer | null = null;
   readonly isGuest: boolean;
   private readonly partition: string | null;
 
@@ -259,6 +264,16 @@ export class TabManager {
   setPasswordStore(store: PasswordStore): void {
     this.passwordStore = store;
     mainLogger.info('TabManager.setPasswordStore', { msg: 'Password store wired for context menu' });
+  }
+
+  /**
+   * Inject the ContentPolicyEnforcer (Issue #222). When null, tab-creation
+   * falls back to the old unchecked behavior (popups allowed, JS enabled,
+   * content-category sound policy not applied).
+   */
+  setContentPolicyEnforcer(enforcer: ContentPolicyEnforcer | null): void {
+    this.contentPolicyEnforcer = enforcer;
+    mainLogger.info('TabManager.setContentPolicyEnforcer', { attached: !!enforcer });
   }
 
   /**
@@ -505,6 +520,19 @@ export class TabManager {
     if (this.partition) {
       webPrefs.partition = this.partition;
     }
+    // Issue #222 — apply "JavaScript: block" from content settings at tab
+    // creation time. WebPreferences are immutable after WebContentsView
+    // construction, so this is the only point where the flag takes effect.
+    // New tabs without a URL (chrome://newtab) are not checked; the newtab
+    // page needs JS to function and has no origin.
+    if (
+      !isUserInitiated &&
+      this.contentPolicyEnforcer &&
+      !this.contentPolicyEnforcer.isJavaScriptAllowed(targetUrl)
+    ) {
+      webPrefs.javascript = false;
+      mainLogger.info('TabManager.createTab.jsDisabled', { tabId, url: targetUrl });
+    }
     const view = new WebContentsView({ webPreferences: webPrefs });
 
     this.win.contentView.addChildView(view);
@@ -558,6 +586,14 @@ export class TabManager {
       sandbox: true,
     };
     if (this.partition) webPrefs.partition = this.partition;
+    // Issue #222 — honor JavaScript block policy for background-opened tabs too.
+    if (
+      this.contentPolicyEnforcer &&
+      !this.contentPolicyEnforcer.isJavaScriptAllowed(url)
+    ) {
+      webPrefs.javascript = false;
+      mainLogger.info('TabManager.createBackgroundTab.jsDisabled', { tabId, url });
+    }
     const view = new WebContentsView({ webPreferences: webPrefs });
     this.win.contentView.addChildView(view);
     this.tabs.set(tabId, view);
@@ -1863,6 +1899,22 @@ export class TabManager {
     });
 
     wc.setWindowOpenHandler(({ url, disposition }) => {
+      // Issue #222 — enforce the persisted "popups" content category policy.
+      // The initiator URL is the current page; we check against its origin.
+      // Only "true popups" (no explicit user gesture — disposition is
+      // 'new-window' or 'foreground-tab' coming from window.open without a
+      // click) are blocked. target="_blank" on a user click still arrives
+      // here as 'foreground-tab' so we treat any block as final: the
+      // content-settings UI describes this as "Pop-ups AND redirects".
+      if (this.contentPolicyEnforcer?.shouldBlockPopup(wc.getURL())) {
+        mainLogger.info('TabManager.popup.blocked', {
+          tabId,
+          initiator: wc.getURL(),
+          targetUrl: url,
+          disposition,
+        });
+        return { action: 'deny' };
+      }
       if (url && !BLOCKED_SCHEMES.test(url)) {
         const background =
           disposition === 'background-tab' ||
@@ -2385,9 +2437,17 @@ export class TabManager {
 
   private applyPersistedMute(wc: Electron.WebContents): void {
     const url = wc.getURL();
-    if (this.mutedSitesStore.isMutedUrl(url)) {
+    // Issue #222 — OR together: any mute source wins. If the user set
+    // "Sound: Block" either globally or per-site in content settings, or the
+    // per-site mute store has this origin, the tab is muted.
+    const muteByContentPolicy = !!this.contentPolicyEnforcer?.shouldMuteForSoundPolicy(url);
+    const muteByPerSite = this.mutedSitesStore.isMutedUrl(url);
+    if (muteByContentPolicy || muteByPerSite) {
       wc.setAudioMuted(true);
-      mainLogger.debug('TabManager.applyPersistedMute', { url });
+      mainLogger.debug('TabManager.applyPersistedMute', {
+        url,
+        source: muteByContentPolicy ? 'content-policy' : 'muted-sites',
+      });
     }
   }
 

--- a/my-app/src/renderer/settings/SettingsApp.tsx
+++ b/my-app/src/renderer/settings/SettingsApp.tsx
@@ -1656,6 +1656,12 @@ interface ContentCategoryRow {
   description: string;
   defaultState: CategoryState;
   allowedStates: CategoryState[];
+  /**
+   * Issue #222 — whether this category is actually wired into the runtime.
+   * `false` means the toggle is persisted but has no effect; the UI disables
+   * the select and shows a "Not enforced yet" note so users aren't misled.
+   */
+  enforced: boolean;
 }
 
 const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
@@ -1665,6 +1671,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Allow sites to play audio. Autoplay is subject to browser policy.',
     defaultState: 'allow',
     allowedStates: ['allow', 'block'],
+    enforced: true,
   },
   {
     category: 'images',
@@ -1672,13 +1679,15 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Allow sites to show images.',
     defaultState: 'allow',
     allowedStates: ['allow', 'block'],
+    enforced: true,
   },
   {
     category: 'javascript',
     label: 'JavaScript',
-    description: 'Allow sites to run JavaScript.',
+    description: 'Allow sites to run JavaScript. Takes effect for newly opened tabs.',
     defaultState: 'allow',
     allowedStates: ['allow', 'block'],
+    enforced: true,
   },
   {
     category: 'popups',
@@ -1686,6 +1695,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Block sites from opening new windows or redirecting you.',
     defaultState: 'block',
     allowedStates: ['allow', 'block'],
+    enforced: true,
   },
   {
     category: 'ads',
@@ -1693,6 +1703,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Block ads on sites that show intrusive or misleading ads (Better Ads Standards).',
     defaultState: 'block',
     allowedStates: ['allow', 'block'],
+    enforced: false,
   },
   {
     category: 'automatic-downloads',
@@ -1700,6 +1711,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Ask before allowing sites to download multiple files automatically.',
     defaultState: 'ask',
     allowedStates: ['allow', 'ask', 'block'],
+    enforced: false,
   },
   {
     category: 'protected-content',
@@ -1707,6 +1719,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Allow sites to check your device for a protected content license.',
     defaultState: 'allow',
     allowedStates: ['allow', 'block'],
+    enforced: false,
   },
   {
     category: 'clipboard-read',
@@ -1714,6 +1727,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Ask before allowing sites to read data you copied.',
     defaultState: 'ask',
     allowedStates: ['allow', 'ask', 'block'],
+    enforced: false,
   },
   {
     category: 'clipboard-write',
@@ -1721,6 +1735,7 @@ const CONTENT_CATEGORY_ROWS: ContentCategoryRow[] = [
     description: 'Allow sites to write data to your clipboard when you interact with the page.',
     defaultState: 'allow',
     allowedStates: ['allow', 'block'],
+    enforced: false,
   },
 ];
 
@@ -1779,13 +1794,38 @@ function ContentCategoriesTab(): React.ReactElement {
       <Card variant="default" padding="none" className="settings-card">
         {CONTENT_CATEGORY_ROWS.map((row, idx) => {
           const currentState = defaults[row.category] ?? row.defaultState;
+          // Issue #222 — unenforced rows stay visible (so the list matches
+          // what Chrome shows) but the toggle is disabled and labelled.
+          const disabled = !row.enforced;
           return (
             <div
               key={row.category}
               className={`settings-scope-row ${idx < CONTENT_CATEGORY_ROWS.length - 1 ? 'settings-scope-row--bordered' : ''}`}
+              data-testid={`content-category-row-${row.category}`}
+              data-enforced={row.enforced ? 'true' : 'false'}
             >
               <div className="settings-scope-info">
-                <span className="settings-scope-label">{row.label}</span>
+                <span className="settings-scope-label">
+                  {row.label}
+                  {disabled && (
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        padding: '2px 6px',
+                        fontSize: 10,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.3,
+                        borderRadius: 4,
+                        background: 'var(--color-surface-muted, #eee)',
+                        color: 'var(--color-text-muted, #666)',
+                      }}
+                      title="This setting is persisted but is not yet enforced by the browser."
+                    >
+                      Not enforced yet
+                    </span>
+                  )}
+                </span>
                 <span className="settings-scope-name" style={{ fontFamily: 'var(--font-ui)', fontSize: 12 }}>
                   {row.description}
                 </span>
@@ -1794,8 +1834,11 @@ function ContentCategoriesTab(): React.ReactElement {
                 <select
                   className="settings-select"
                   value={currentState}
+                  disabled={disabled}
                   onChange={(e) => void handleChange(row.category, e.target.value as CategoryState)}
-                  style={{ minWidth: 80 }}
+                  style={{ minWidth: 80, opacity: disabled ? 0.5 : 1 }}
+                  aria-disabled={disabled}
+                  title={disabled ? 'Not enforced yet (Issue #222 follow-up)' : undefined}
                 >
                   {row.allowedStates.map((s) => (
                     <option key={s} value={s}>{STATE_LABELS[s]}</option>

--- a/my-app/tests/unit/content-categories/ContentPolicyEnforcer.spec.ts
+++ b/my-app/tests/unit/content-categories/ContentPolicyEnforcer.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * ContentPolicyEnforcer unit tests (Issue #222).
+ *
+ * Verifies the enforcement side of the Settings > Content feature actually
+ * works end-to-end at the level we control from main-process code:
+ *   - handleBeforeRequest cancels image resource types when the resolved
+ *     policy (override > default) is 'block'.
+ *   - install() wires the listener onto session.webRequest.onBeforeRequest,
+ *     using the electron-mock Session stub.
+ *   - shouldBlockPopup / isJavaScriptAllowed / shouldMuteForSoundPolicy
+ *     consult the store with per-origin override precedence.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+vi.mock('../../../src/main/logger', () => ({
+  mainLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ContentCategoryStore } from '../../../src/main/content-categories/ContentCategoryStore';
+import { ContentPolicyEnforcer } from '../../../src/main/content-categories/ContentPolicyEnforcer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshTempDir(): string {
+  const dir = path.join(os.tmpdir(), `cpe-spec-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function freshStore(): { store: ContentCategoryStore; dir: string } {
+  const dir = freshTempDir();
+  return { store: new ContentCategoryStore(dir), dir };
+}
+
+function makeSessionStub(): {
+  webRequest: {
+    onBeforeRequest: ReturnType<typeof vi.fn>;
+  };
+  lastListener: null | ((details: unknown, cb: (r: unknown) => void) => void);
+} {
+  const handle = {
+    lastListener: null as null | ((details: unknown, cb: (r: unknown) => void) => void),
+    webRequest: {
+      onBeforeRequest: vi.fn((listener: (details: unknown, cb: (r: unknown) => void) => void) => {
+        handle.lastListener = listener;
+      }),
+    },
+  };
+  return handle;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ContentPolicyEnforcer — image blocking via onBeforeRequest', () => {
+  let cleanup: string[] = [];
+
+  afterEach(() => {
+    for (const dir of cleanup) {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    cleanup = [];
+  });
+
+  beforeEach(() => {
+    cleanup = [];
+  });
+
+  it('cancels image requests when default policy is block', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    store.setDefault('images', 'block');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const cb = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'https://example.com/cat.png', resourceType: 'image' },
+      cb,
+    );
+    expect(cb).toHaveBeenCalledWith({ cancel: true });
+  });
+
+  it('allows image requests when default policy is allow', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    // Default is 'allow' from DEFAULT_CATEGORY_STATES, but be explicit.
+    store.setDefault('images', 'allow');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const cb = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'https://example.com/cat.png', resourceType: 'image' },
+      cb,
+    );
+    expect(cb).toHaveBeenCalledWith({});
+  });
+
+  it('never cancels non-image resource types even when images are blocked', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    store.setDefault('images', 'block');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const types = ['mainFrame', 'subFrame', 'stylesheet', 'script', 'font', 'xhr', 'other'] as const;
+    for (const resourceType of types) {
+      const cb = vi.fn();
+      enforcer.handleBeforeRequest(
+        { url: 'https://example.com/thing', resourceType },
+        cb,
+      );
+      expect(cb).toHaveBeenCalledWith({});
+    }
+  });
+
+  it('per-site allow override beats global block default for images', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    store.setDefault('images', 'block');
+    store.setSiteOverride('https://trusted.example', 'images', 'allow');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const cb = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'https://trusted.example/pic.jpg', resourceType: 'image' },
+      cb,
+    );
+    expect(cb).toHaveBeenCalledWith({});
+
+    const cb2 = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'https://other.example/pic.jpg', resourceType: 'image' },
+      cb2,
+    );
+    expect(cb2).toHaveBeenCalledWith({ cancel: true });
+  });
+
+  it('per-site block override beats global allow default for images', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    store.setDefault('images', 'allow');
+    store.setSiteOverride('https://ads.example', 'images', 'block');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const cb = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'https://ads.example/banner.gif', resourceType: 'image' },
+      cb,
+    );
+    expect(cb).toHaveBeenCalledWith({ cancel: true });
+  });
+
+  it('handles un-parseable URLs gracefully (falls back to default)', () => {
+    const { store, dir } = freshStore();
+    cleanup.push(dir);
+    store.setDefault('images', 'block');
+    const enforcer = new ContentPolicyEnforcer({ store });
+
+    const cb = vi.fn();
+    enforcer.handleBeforeRequest(
+      { url: 'not-a-url', resourceType: 'image' },
+      cb,
+    );
+    // Still applies default policy because origin extraction falls back to
+    // the raw url string.
+    expect(cb).toHaveBeenCalledWith({ cancel: true });
+  });
+});
+
+describe('ContentPolicyEnforcer — install wires webRequest listener', () => {
+  it('registers onBeforeRequest on the provided session', () => {
+    const { store, dir } = freshStore();
+    try {
+      const enforcer = new ContentPolicyEnforcer({ store });
+      const ses = makeSessionStub();
+      // The electron-mock session stub shape is compatible with the
+      // Session type for our purposes.
+      enforcer.install(ses as unknown as import('electron').Session);
+      expect(ses.webRequest.onBeforeRequest).toHaveBeenCalledTimes(1);
+      expect(typeof ses.lastListener).toBe('function');
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('the registered listener blocks images per store policy', () => {
+    const { store, dir } = freshStore();
+    try {
+      store.setDefault('images', 'block');
+      const enforcer = new ContentPolicyEnforcer({ store });
+      const ses = makeSessionStub();
+      enforcer.install(ses as unknown as import('electron').Session);
+      expect(ses.lastListener).not.toBeNull();
+      const cb = vi.fn();
+      ses.lastListener!(
+        { url: 'https://example.com/a.png', resourceType: 'image' },
+        cb,
+      );
+      expect(cb).toHaveBeenCalledWith({ cancel: true });
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('uninstall clears the listener with null', () => {
+    const { store, dir } = freshStore();
+    try {
+      const enforcer = new ContentPolicyEnforcer({ store });
+      const ses = makeSessionStub();
+      enforcer.install(ses as unknown as import('electron').Session);
+      enforcer.uninstall();
+      // install registered once, uninstall registered with null (clears).
+      expect(ses.webRequest.onBeforeRequest).toHaveBeenCalledTimes(2);
+      expect(ses.webRequest.onBeforeRequest).toHaveBeenLastCalledWith(null);
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+});
+
+describe('ContentPolicyEnforcer — predicates (popups, javascript, sound)', () => {
+  let dir: string;
+  let store: ContentCategoryStore;
+  let enforcer: ContentPolicyEnforcer;
+
+  beforeEach(() => {
+    const fresh = freshStore();
+    dir = fresh.dir;
+    store = fresh.store;
+    enforcer = new ContentPolicyEnforcer({ store });
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('popups: blocked by default (Chrome-parity)', () => {
+    // DEFAULT_CATEGORY_STATES has popups: 'block'.
+    expect(enforcer.shouldBlockPopup('https://example.com/page')).toBe(true);
+  });
+
+  it('popups: allow override unblocks a specific origin', () => {
+    store.setSiteOverride('https://trusted.example', 'popups', 'allow');
+    expect(enforcer.shouldBlockPopup('https://trusted.example/page')).toBe(false);
+    expect(enforcer.shouldBlockPopup('https://other.example/page')).toBe(true);
+  });
+
+  it('popups: global allow lets all popups through', () => {
+    store.setDefault('popups', 'allow');
+    expect(enforcer.shouldBlockPopup('https://any.example/page')).toBe(false);
+  });
+
+  it('javascript: allowed by default', () => {
+    expect(enforcer.isJavaScriptAllowed('https://example.com/')).toBe(true);
+  });
+
+  it('javascript: global block disables JS for all origins', () => {
+    store.setDefault('javascript', 'block');
+    expect(enforcer.isJavaScriptAllowed('https://anywhere.example/')).toBe(false);
+  });
+
+  it('javascript: per-origin allow override beats global block', () => {
+    store.setDefault('javascript', 'block');
+    store.setSiteOverride('https://app.example', 'javascript', 'allow');
+    expect(enforcer.isJavaScriptAllowed('https://app.example/x')).toBe(true);
+    expect(enforcer.isJavaScriptAllowed('https://elsewhere.example/x')).toBe(false);
+  });
+
+  it('sound: not muted by default', () => {
+    expect(enforcer.shouldMuteForSoundPolicy('https://example.com/')).toBe(false);
+  });
+
+  it('sound: global block mutes every origin', () => {
+    store.setDefault('sound', 'block');
+    expect(enforcer.shouldMuteForSoundPolicy('https://one.example/')).toBe(true);
+    expect(enforcer.shouldMuteForSoundPolicy('https://two.example/')).toBe(true);
+  });
+
+  it('sound: per-origin block mutes only that origin', () => {
+    store.setSiteOverride('https://noisy.example', 'sound', 'block');
+    expect(enforcer.shouldMuteForSoundPolicy('https://noisy.example/')).toBe(true);
+    expect(enforcer.shouldMuteForSoundPolicy('https://quiet.example/')).toBe(false);
+  });
+});

--- a/my-app/vitest.config.ts
+++ b/my-app/vitest.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
       'tests/unit/updater/**/*.spec.ts',
       // Factory-reset controller wiping (Issues #217 / #225)
       'tests/unit/settings/**/*.spec.ts',
+      // Issue #222 — content-category policies actually enforced at runtime
+      'tests/unit/content-categories/**/*.spec.ts',
     ],
     exclude: ['tests/e2e/**', 'tests/parity/**'],
     // Renderer .spec.tsx files declare jsdom via the per-file


### PR DESCRIPTION
Fixes #222.

## Summary
The Settings > Content tab persisted defaults for popups, JavaScript, images,
sound, ads, automatic-downloads, protected-content, and clipboard, but
nothing actually consumed them at runtime. Toggling "Block JavaScript" or
"Block images" had no effect.

This PR adds `ContentPolicyEnforcer`, the missing runtime consumer of
`ContentCategoryStore`, wires it through the main process, and disables
UI toggles for categories that still have no enforcement path so users
aren't misled.

## Per-category action

| Category | Action | Where |
| --- | --- | --- |
| popups | Enforced | `TabManager.setWindowOpenHandler` checks `shouldBlockPopup(initiator)` |
| images | Enforced | `session.defaultSession.webRequest.onBeforeRequest` cancels image resource types when the resolved policy is `block` |
| javascript | Enforced (new tabs) | `createTab` / `createBackgroundTab` flip `WebPreferences.javascript` off at construction — takes effect on next navigation (Chrome parity; `setWebPreferences` is per-WebContents-creation in Electron) |
| sound | Enforced | `applyPersistedMute` OR's content policy with existing per-site `MutedSitesStore` — any mute source wins |
| ads | **Disabled in UI** ("Not enforced yet" badge) | Requires the Better Ads Standards classifier; out of scope |
| automatic-downloads | **Disabled in UI** | Needs DownloadManager gating keyed on multi-download heuristic |
| protected-content | **Disabled in UI** | EME flag, Electron has no clean per-origin toggle |
| clipboard-read | **Disabled in UI** | Maps to `clipboard-read` permission already handled by PermissionManager; wiring the category into that overlay is a follow-up |
| clipboard-write | **Disabled in UI** | Same as clipboard-read |

Per-origin overrides beat the default for every enforced category
(verified in tests).

## Where enforcement lives
- New: `my-app/src/main/content-categories/ContentPolicyEnforcer.ts`
  - `install(session)` registers `webRequest.onBeforeRequest` for image blocking
  - `shouldBlockPopup(initiatorUrl)` / `isJavaScriptAllowed(url)` / `shouldMuteForSoundPolicy(url)` predicates
- `my-app/src/main/index.ts` — constructs the enforcer, calls `install(session.defaultSession)`, hands it to every `TabManager` (primary + new window + incognito + guest + secondary guest)
- `my-app/src/main/tabs/TabManager.ts`
  - `setContentPolicyEnforcer(...)` setter
  - `setWindowOpenHandler` consults `shouldBlockPopup` before creating a tab
  - `createTab` / `createBackgroundTab` set `WebPreferences.javascript`
  - `applyPersistedMute` applies sound policy
- `my-app/src/renderer/settings/SettingsApp.tsx` — new `enforced` flag on each row; rows with `enforced: false` render with a "Not enforced yet" badge and a disabled `<select>`

## Tests
18 new unit tests in `my-app/tests/unit/content-categories/ContentPolicyEnforcer.spec.ts`:
- image blocking via `onBeforeRequest` (allow, block, non-image types, per-site overrides in both directions, unparseable URL)
- `install()` wires the listener onto the session stub from `tests/fixtures/electron-mock.ts`; `uninstall()` clears it with `null`
- predicate tests for `shouldBlockPopup` / `isJavaScriptAllowed` / `shouldMuteForSoundPolicy` with per-origin override precedence

Added `tests/unit/content-categories/**/*.spec.ts` to `vitest.config.ts` includes.

## Gate
- `npm run lint` — 0 errors (199 pre-existing warnings, none in new files)
- `npm run typecheck` — clean
- `npm test` — 36 files / 495 tests pass (was 35 / 477)

## Test plan
- [ ] Launch app, Settings > Content, set Images = Block. Navigate to a page with `<img>` tags; they should not render (favicons still load — intentional, Chrome parity).
- [ ] Per-site override: click the site info pill, allow images for a specific origin, confirm images load only there.
- [ ] Set Pop-ups = Block (the default). Click a `window.open(...)` trigger; no tab opens. Set to Allow; tab opens.
- [ ] Set JavaScript = Block. Open a new tab to a JS-heavy site; JS should not run. (Existing tabs keep JS until reload — documented.)
- [ ] Set Sound = Block. Open a page that autoplays audio; tab should be muted.
- [ ] Settings rows for Intrusive ads / Automatic downloads / Protected content IDs / Clipboard read / Clipboard write show a "Not enforced yet" badge and their `<select>` is disabled.

## Known follow-ups
- When the MV3 DeclarativeNetRequestEngine registers its own `onBeforeRequest` listener (only if an extension with `declarativeNetRequest` permission is installed), it will replace ours and image blocking stops. Coordinating the single webRequest slot needs a shared dispatcher; noted in the `ContentPolicyEnforcer` class doc.
- The five "Not enforced yet" categories should each land their own wave with dedicated enforcement mechanisms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces content settings for popups, JavaScript, images, and sound at runtime, and disables UI for categories not yet wired. Fixes #222.

- **Bug Fixes**
  - Added `ContentPolicyEnforcer` to enforce:
    - Images via `webRequest.onBeforeRequest` when policy is block.
    - Popups via `TabManager` window-open handler.
    - JavaScript for new/background tabs by setting `WebPreferences.javascript`.
    - Sound by OR-ing content policy with per-site mute.
  - Installed on `session.defaultSession` and wired across default, guest, incognito, and secondary windows.
  - Per-site overrides take precedence over defaults for all enforced categories.
  - Disabled settings for ads, automatic downloads, protected content, and clipboard read/write with a “Not enforced yet” badge.

<sup>Written for commit 68e6804153c7782a842e2ebc6099a234ae175fd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

