### PR TITLE
feat(bookmarks): Cmd+click opens folder tabs; Cmd+Shift+D bookmark-all-tabs dialog

### DIFF
--- a/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
+++ b/my-app/src/renderer/shell/BookmarkAllTabsDialog.tsx
@@ -77,6 +77,14 @@ export function BookmarkAllTabsDialog({
     };
   }, [onClose]);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
   const handleSave = useCallback(async () => {
     const name = folderName.trim() || defaultName;
     try {


### PR DESCRIPTION
## Summary
Cmd+click on a bookmark folder in the toolbar opens all bookmarks in that folder as new background tabs, mirroring Chrome's behavior (closes #34). Cmd+Shift+D opens a "Bookmark all tabs" dialog that lets the user choose a folder name and destination folder before saving all open tabs as a new bookmark folder (closes #33).

## Test plan
- [ ] Cmd+click a bookmark folder in the toolbar — verify all bookmarks open as background tabs
- [ ] Press Cmd+Shift+D — verify the "Bookmark all tabs" dialog opens with a default folder name and destination picker
- [ ] Fill in a folder name and save — verify a new bookmark folder appears containing all open tabs
- [ ] Press Escape or click outside the dialog — verify it closes without saving

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shortcuts to open all tabs in a bookmark folder and to bookmark all open tabs. Closes #34 and #33.

- **New Features**
  - Cmd-click or middle-click a toolbar bookmark folder opens all its bookmarks as background tabs; context menu adds “Open all (N)”.
  - Cmd+Shift+D and the toolbar “Bookmark all tabs…” open the same dialog to name the folder and choose a destination.
  - The dialog closes on Escape and outside click; `bookmarks:bookmark-all-tabs` IPC accepts optional `parentId`.

- **Bug Fixes**
  - `usePopupLayer` now safely no-ops without `PopupLayerProvider`; guard moved inside `useEffect` to satisfy Rules of Hooks and avoid crashes.

<sup>Written for commit 1df2e05c570186054d799e7b2e091d022b83b18f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

