### PR TITLE
feat(tabs): drag tab out of strip to detach into new window

### DIFF
--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -2213,8 +2213,6 @@ ipcMain.handle('live-caption:toggle', (_e, enabled: boolean) => {
   if (shellWindow && !shellWindow.isDestroyed()) {
     shellWindow.webContents.send('live-caption:state-changed', { enabled });
   }
-  return true;
-});
 
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {

--- a/my-app/src/main/index.ts
+++ b/my-app/src/main/index.ts
@@ -2213,6 +2213,7 @@ ipcMain.handle('live-caption:toggle', (_e, enabled: boolean) => {
   if (shellWindow && !shellWindow.isDestroyed()) {
     shellWindow.webContents.send('live-caption:state-changed', { enabled });
   }
+});
 
 // Issue #81 — Three-dot app menu for non-macOS platforms.
 ipcMain.handle('menu:show-app-menu', (_event, bounds: { x: number; y: number }) => {

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -161,6 +161,7 @@ export class TabManager {
     return Array.from(TabManager.instances.values());
   }
 
+
   private win: BrowserWindow;
   private tabs: Map<string, WebContentsView> = new Map();
   private tabOrder: string[] = [];
@@ -2729,6 +2730,7 @@ export class TabManager {
       });
       return;
     }
+
 
     ipcMain.removeHandler('tabs:create');
     ipcMain.removeHandler('tabs:close');

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -317,6 +317,7 @@ export class TabManager {
     this.onActiveTabChanged = cb;
   }
 
+
   setHistoryStore(store: HistoryStore): void {
     this.historyStore = store;
     mainLogger.info('TabManager.setHistoryStore', { msg: 'History recording enabled' });

--- a/my-app/src/main/tabs/TabManager.ts
+++ b/my-app/src/main/tabs/TabManager.ts
@@ -2731,7 +2731,6 @@ export class TabManager {
       return;
     }
 
-
     ipcMain.removeHandler('tabs:create');
     ipcMain.removeHandler('tabs:close');
     ipcMain.removeHandler('tabs:activate');

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -97,6 +97,10 @@ function displayUrl(url: string): string {
   return host + path + parsed.search + parsed.hash;
 }
 
+interface PermissionEntry {
+  permissionType: string;
+  state: 'allow' | 'deny' | 'ask';
+}
 
 interface PageInfo {
   url: string;

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -97,6 +97,130 @@ function displayUrl(url: string): string {
   return host + path + parsed.search + parsed.hash;
 }
 
+
+interface PageInfo {
+  url: string;
+  isHSTS: boolean;
+  hstsMaxAge: number | null;
+  hstsIncludeSubdomains: boolean;
+  isSecure: boolean;
+  permissions: PermissionEntry[];
+  cookieCount: number;
+}
+
+const PERMISSION_LABELS: Record<string, string> = {
+  camera: 'Camera',
+  microphone: 'Microphone',
+  geolocation: 'Location',
+  notifications: 'Notifications',
+  clipboard: 'Clipboard',
+  midi: 'MIDI',
+};
+
+function PageInfoPopover({
+  security,
+  pageInfo,
+  onClose,
+}: {
+  security: 'secure' | 'insecure' | 'none';
+  pageInfo: PageInfo | null;
+  onClose: () => void;
+}): React.ReactElement {
+  const [permissions, setPermissions] = React.useState<PermissionEntry[]>(
+    pageInfo?.permissions ?? [],
+  );
+
+  const handlePermissionChange = useCallback(
+    async (permType: string, newState: string) => {
+      if (!pageInfo?.url) return;
+      try {
+        const origin = new URL(pageInfo.url).origin;
+        await electronAPI.permissions.setSite(origin, permType, newState);
+        setPermissions((prev) =>
+          prev.map((p) =>
+            p.permissionType === permType ? { ...p, state: newState as PermissionEntry['state'] } : p,
+          ),
+        );
+      } catch { /* ignore */ }
+    },
+    [pageInfo?.url],
+  );
+
+  const handleSiteSettings = useCallback(() => {
+    electronAPI.tabs.navigateActive('chrome://settings').catch(() => {});
+    onClose();
+  }, [onClose]);
+
+  const namedPerms = permissions.filter((p) => PERMISSION_LABELS[p.permissionType]);
+
+  return (
+    <div className="url-bar__page-info-popover" role="dialog" aria-label="Page info">
+      {/* Connection */}
+      <div className="url-bar__page-info-row">
+        <span className={`url-bar__page-info-status url-bar__page-info-status--${security}`}>
+          {security === 'secure'
+            ? 'Connection is secure'
+            : security === 'insecure'
+              ? 'Connection is not secure'
+              : 'No connection info'}
+        </span>
+      </div>
+      {pageInfo?.isHSTS && (
+        <div className="url-bar__page-info-row url-bar__page-info-hsts">
+          <span className="url-bar__page-info-badge">HSTS</span>
+          <span className="url-bar__page-info-hsts-detail">
+            {pageInfo.hstsIncludeSubdomains ? 'Includes subdomains' : 'This domain only'}
+            {pageInfo.hstsMaxAge != null ? ` · ${Math.round(pageInfo.hstsMaxAge / 86400)}d` : ''}
+          </span>
+        </div>
+      )}
+
+      {/* Permissions */}
+      {namedPerms.length > 0 && (
+        <>
+          <div className="url-bar__page-info-divider" />
+          <div className="url-bar__page-info-section-label">Permissions</div>
+          {namedPerms.map((p) => (
+            <div key={p.permissionType} className="url-bar__page-info-perm-row">
+              <span className="url-bar__page-info-perm-label">
+                {PERMISSION_LABELS[p.permissionType]}
+              </span>
+              <select
+                className="url-bar__page-info-perm-select"
+                value={p.state}
+                onChange={(e) => void handlePermissionChange(p.permissionType, e.target.value)}
+              >
+                <option value="allow">Allow</option>
+                <option value="deny">Block</option>
+                <option value="ask">Ask</option>
+              </select>
+            </div>
+          ))}
+        </>
+      )}
+
+      {/* Cookies & site settings */}
+      <div className="url-bar__page-info-divider" />
+      <div className="url-bar__page-info-footer">
+        {pageInfo != null && (
+          <span className="url-bar__page-info-cookies">
+            {pageInfo.cookieCount === 0
+              ? 'No cookies'
+              : `${pageInfo.cookieCount} cookie${pageInfo.cookieCount === 1 ? '' : 's'}`}
+          </span>
+        )}
+        <button
+          type="button"
+          className="url-bar__page-info-site-settings"
+          onClick={handleSiteSettings}
+        >
+          Site settings
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function URLBar({
   url,
   isLoading,
@@ -277,6 +401,47 @@ export function URLBar({
   // Hide the star on blank/new-tab URLs — nothing meaningful to bookmark.
   const starVisible = !!url && !BLANK_RE.test(url) && !NEWTAB_RE.test(url);
 
+  const [pageInfoOpen, setPageInfoOpen] = useState(false);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const securityRef = useRef<HTMLButtonElement>(null);
+
+  const handleSecurityClick = useCallback(async () => {
+    if (!pageInfoOpen) {
+      try {
+        const [base, cookieCount] = await Promise.all([
+          electronAPI.security.getPageInfo(),
+          electronAPI.security.getCookieCount(),
+        ]);
+        let permissions: PermissionEntry[] = [];
+        try {
+          const origin = new URL(base.url).origin;
+          permissions = await electronAPI.permissions.getSite(origin);
+        } catch { /* non-URL pages have no permissions */ }
+        setPageInfo({ ...base, permissions, cookieCount });
+      } catch {
+        setPageInfo(null);
+      }
+    }
+    setPageInfoOpen((v) => !v);
+  }, [pageInfoOpen]);
+
+  // Close popover on navigation (URL change)
+  useEffect(() => {
+    setPageInfoOpen(false);
+  }, [url]);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    if (!pageInfoOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (securityRef.current && !securityRef.current.closest('.url-bar__security-wrap')?.contains(e.target as Node)) {
+        setPageInfoOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [pageInfoOpen]);
+
   return (
     <div className={`url-bar url-bar--${security}`}>
       {/* Security icon */}
@@ -378,5 +543,16 @@ declare const electronAPI: {
     suggest: (payload: { input: string; remoteSearch?: boolean }) => Promise<OmniboxSuggestion[]>;
     recordSelection: (payload: { inputText: string; url: string; title: string }) => Promise<boolean>;
     removeHistory: (id: string) => Promise<boolean>;
+  };
+  security: {
+    getPageInfo: () => Promise<Omit<PageInfo, 'permissions' | 'cookieCount'>>;
+    getCookieCount: () => Promise<number>;
+  };
+  permissions: {
+    getSite: (origin: string) => Promise<PermissionEntry[]>;
+    setSite: (origin: string, permissionType: string, state: string) => Promise<void>;
+  };
+  tabs: {
+    navigateActive: (input: string) => Promise<void>;
   };
 };

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -304,7 +304,7 @@ export function URLBar({
     onNavigate(suggestion.url);
     // Record selection for ShortcutsProvider learning
     electronAPI.omnibox.recordSelection({
-      inputText: inputRef.current?.value ?? '',
+      inputText: inputValue,
       url: suggestion.url,
       title: suggestion.title,
     }).catch((err: unknown) => {
@@ -312,7 +312,7 @@ export function URLBar({
     });
     closeDropdown();
     inputRef.current?.blur();
-  }, [onNavigate, closeDropdown]);
+  }, [onNavigate, closeDropdown, inputValue]);
 
   const handleFocus = useCallback(() => {
     setIsEditing(true);

--- a/my-app/tests/visual/diff.ts
+++ b/my-app/tests/visual/diff.ts
@@ -671,31 +671,22 @@ function checkOnboardingStructure(capturePath: string, stateName: string): strin
       issues.push('Step indicator region is very dark — dots may not be rendering');
     }
 
-    // 3. Right side of image should have the mascot area — sample for non-background color
-    const mascotRegion = sampleRegionRgb(
+    // 3. Right panel should be rendered — sample for non-pure-black pixel values
+    const rightPanel = sampleRegionRgb(
       png,
       Math.floor(png.width * 0.6),
       Math.floor(png.height * 0.25),
       Math.floor(png.width * 0.35),
       Math.floor(png.height * 0.5),
     );
-    const mascotLuminance = 0.2126 * mascotRegion.r + 0.7152 * mascotRegion.g + 0.0722 * mascotRegion.b;
-    const bgSample = sampleRegionRgb(png, 0, 0, 80, 80);
-    const bgLuminance = 0.2126 * bgSample.r + 0.7152 * bgSample.g + 0.0722 * bgSample.b;
-
-    // Mascot area should be somewhat different from background
-    const mascotContrast = Math.abs(mascotLuminance - bgLuminance);
-    log('info', 'Mascot region contrast', {
+    const rightPanelLuminance = 0.2126 * rightPanel.r + 0.7152 * rightPanel.g + 0.0722 * rightPanel.b;
+    log('info', 'Right panel region sample', {
       state: stateName,
-      mascotLuminance: mascotLuminance.toFixed(1),
-      bgLuminance: bgLuminance.toFixed(1),
-      contrast: mascotContrast.toFixed(1),
+      luminance: rightPanelLuminance.toFixed(1),
     });
 
-    if (mascotContrast < 8) {
-      issues.push(
-        `Mascot region has low contrast vs background (${mascotContrast.toFixed(1)}) — character mascot may be absent`,
-      );
+    if (rightPanelLuminance < 5) {
+      issues.push('Right panel region is pure black — panel may not be rendering');
     }
 
     // 4. Left panel should have text content — check for varied pixel values

--- a/my-app/tests/visual/diff.ts
+++ b/my-app/tests/visual/diff.ts
@@ -671,22 +671,31 @@ function checkOnboardingStructure(capturePath: string, stateName: string): strin
       issues.push('Step indicator region is very dark — dots may not be rendering');
     }
 
-    // 3. Right panel should be rendered — sample for non-pure-black pixel values
-    const rightPanel = sampleRegionRgb(
+    // 3. Right side of image should have the mascot area — sample for non-background color
+    const mascotRegion = sampleRegionRgb(
       png,
       Math.floor(png.width * 0.6),
       Math.floor(png.height * 0.25),
       Math.floor(png.width * 0.35),
       Math.floor(png.height * 0.5),
     );
-    const rightPanelLuminance = 0.2126 * rightPanel.r + 0.7152 * rightPanel.g + 0.0722 * rightPanel.b;
-    log('info', 'Right panel region sample', {
+    const mascotLuminance = 0.2126 * mascotRegion.r + 0.7152 * mascotRegion.g + 0.0722 * mascotRegion.b;
+    const bgSample = sampleRegionRgb(png, 0, 0, 80, 80);
+    const bgLuminance = 0.2126 * bgSample.r + 0.7152 * bgSample.g + 0.0722 * bgSample.b;
+
+    // Mascot area should be somewhat different from background
+    const mascotContrast = Math.abs(mascotLuminance - bgLuminance);
+    log('info', 'Mascot region contrast', {
       state: stateName,
-      luminance: rightPanelLuminance.toFixed(1),
+      mascotLuminance: mascotLuminance.toFixed(1),
+      bgLuminance: bgLuminance.toFixed(1),
+      contrast: mascotContrast.toFixed(1),
     });
 
-    if (rightPanelLuminance < 5) {
-      issues.push('Right panel region is pure black — panel may not be rendering');
+    if (mascotContrast < 8) {
+      issues.push(
+        `Mascot region has low contrast vs background (${mascotContrast.toFixed(1)}) — character mascot may be absent`,
+      );
     }
 
     // 4. Left panel should have text content — check for varied pixel values


### PR DESCRIPTION
## Summary
Implements tab detach by dragging a tab below the tab strip, matching Chrome behavior. Also adds a Move to New Window option in the tab context menu. Preserves session type (incognito/guest/normal) for the detached tab.

## Test plan
- [ ] Drag a tab below the tab strip — it should open in a new window
- [ ] Right-click a tab and choose Move to New Window — tab moves to new window
- [ ] Cannot detach the last remaining tab
- [ ] Detaching from an incognito window opens an incognito window
- [ ] Detaching from a guest window preserves the guest session partition

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tab detaching: drag a tab below the tab strip or use “Move to New Window” to pop it out. Matches Chrome and keeps the correct session (normal, incognito, guest).

- **New Features**
  - Drag a tab below the strip to detach it into a new window.
  - “Move to New Window” in the tab context menu across all window types.
  - Blocks detaching the last tab; pinned tabs move instead of duplicating.
  - URL bar page-info popover with connection status, HSTS details, per-site permissions (allow/deny/ask), cookie count, and a quick link to site settings.

- **Bug Fixes**
  - Preserve session type on detach by resolving against the source window’s `TabManager`; open a matching window (incognito/guest/normal).
  - Guard `TabManager.destroy()` so closing one window doesn’t remove shared IPC handlers; clear the registry when an incognito window closes.
  - Fix omnibox selection logging to use the current input value.
  - Tests: remove duplicate `bgLuminance`/`bgSample` in onboarding checks to reduce flakiness.

<sup>Written for commit 7ca1de776db2ac1c01a18a995ba66bf338845379. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

