### PR TITLE
feat(shell): page info bubble with security, cookies, and permissions

### DIFF
--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -517,31 +517,47 @@ export function URLBar({
   return (
     <div className={`url-bar url-bar--${security}`}>
       {/* Security icon */}
-      <span className="url-bar__security" aria-label={security}>
-        {security === 'secure' && (
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-            <rect x="2" y="5" width="8" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
-            <path
-              d="M4 5V3.5a2 2 0 0 1 4 0V5"
-              stroke="currentColor"
-              strokeWidth="1.2"
-              fill="none"
-            />
-          </svg>
+      <div className="url-bar__security-wrap">
+        <button
+          ref={securityRef}
+          type="button"
+          className="url-bar__security"
+          aria-label={security === 'secure' ? 'Connection is secure' : security === 'insecure' ? 'Connection is not secure' : 'Page info'}
+          onClick={handleSecurityClick}
+          tabIndex={-1}
+        >
+          {security === 'secure' && (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <rect x="2" y="5" width="8" height="6" rx="1.5" fill="currentColor" opacity="0.6" />
+              <path
+                d="M4 5V3.5a2 2 0 0 1 4 0V5"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                fill="none"
+              />
+            </svg>
+          )}
+          {security === 'insecure' && (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M6 2L10.5 10H1.5L6 2Z"
+                stroke="#e5534b"
+                strokeWidth="1.2"
+                fill="none"
+              />
+              <line x1="6" y1="5.5" x2="6" y2="7.5" stroke="#e5534b" strokeWidth="1.2" />
+              <circle cx="6" cy="9" r="0.5" fill="#e5534b" />
+            </svg>
+          )}
+        </button>
+        {pageInfoOpen && (
+          <PageInfoPopover
+            security={security}
+            pageInfo={pageInfo}
+            onClose={() => setPageInfoOpen(false)}
+          />
         )}
-        {security === 'insecure' && (
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-            <path
-              d="M6 2L10.5 10H1.5L6 2Z"
-              stroke="#e5534b"
-              strokeWidth="1.2"
-              fill="none"
-            />
-            <line x1="6" y1="5.5" x2="6" y2="7.5" stroke="#e5534b" strokeWidth="1.2" />
-            <circle cx="6" cy="9" r="0.5" fill="#e5534b" />
-          </svg>
-        )}
-      </span>
+      </div>
 
       {/* URL input */}
       <input


### PR DESCRIPTION
## Summary
Clicking the lock/security icon in the URL bar opens a page-info popover showing connection security status, HSTS details, active permission grants with inline allow/block/ask selectors, cookie count, and a Site Settings shortcut. The bubble closes on outside-click or navigation (closes #24).

## Test plan
- [ ] Navigate to an HTTPS site, click the lock icon, and verify the popover shows "Connection is secure"
- [ ] Navigate to an HTTP site and verify the insecure warning is shown
- [ ] Grant a permission (e.g. camera) to a site and confirm it appears in the page-info popover
- [ ] Change a permission state in the popover and reload to confirm it persists
- [ ] Verify cookie count is non-zero on a site that sets cookies
- [ ] Confirm clicking outside the popover closes it
- [ ] Navigate to a new URL and confirm the popover closes automatically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a page-info bubble in the URL bar showing connection security (incl. HSTS), cookie count, and per-site permission controls, plus a Site settings shortcut. Clicking the lock button opens the popover so users can quickly review and adjust site access.

- **New Features**
  - Lock icon is now a button with aria-labels that toggles a popover showing connection status (secure/insecure), HSTS details, cookie count, and a Site settings shortcut.
  - Inline per-site permission controls (camera, microphone, location, notifications, clipboard, MIDI) with allow/block/ask; changes persist.

- **Bug Fixes**
  - Popover closes on outside click and on navigation to avoid stale info.
  - Replaced missing API with `tabs.navigateActive`; consolidated `electronAPI` types and added `security`, `permissions`, and `tabs` to fix TS redeclaration errors.

<sup>Written for commit 865b933fd2674b28e48ad47a3b3bf7ae6f87140c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

