### PR TITLE
feat(omnibox): tab-to-search shortcut for site-specific search engines

### DIFF
--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -21,7 +21,8 @@ const SECURE_RE = /^https:\/\//i;
 const INSECURE_RE = /^http:\/\//i;
 // New-tab data: URLs and about:blank are internal placeholders; the omnibox
 // renders them as empty so the "Search or enter address" placeholder shows.
-const BLANK_RE = /^(data:|about:blank$)/i;
+// Only match the app's own internal new-tab page, not arbitrary external URLs.
+const BLANK_RE = /^(data:|about:blank$|[a-z][a-z0-9+.-]*:\/\/[^/]*\/newtab\/newtab\.html)/i;
 const NEWTAB_RE = /\/newtab\/newtab\.html/i;
 
 // Subdomains that Chrome elides from display (trivial/redundant prefixes).

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -403,22 +403,25 @@ export function URLBar({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (dropdownOpen && suggestions.length > 0) {
-        if (e.key === 'ArrowDown') {
+      if (e.key === 'ArrowDown') {
+        if (dropdownOpen && suggestions.length > 0) {
           e.preventDefault();
-          setSelectedIndex((prev) => Math.min(prev + 1, suggestions.length - 1));
-          return;
+          setSelectedIndex((i) => Math.min(i + 1, suggestions.length - 1));
         }
-        if (e.key === 'ArrowUp') {
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        if (dropdownOpen && suggestions.length > 0) {
           e.preventDefault();
-          setSelectedIndex((prev) => Math.max(prev - 1, -1));
-          return;
+          setSelectedIndex((i) => Math.max(i - 1, -1));
         }
-        if (e.key === 'Enter' && selectedIndex >= 0) {
-          e.preventDefault();
-          commitSuggestion(suggestions[selectedIndex]);
-          return;
-        }
+        return;
+      }
+
+      if (dropdownOpen && e.key === 'Enter' && selectedIndex >= 0) {
+        e.preventDefault();
+        commitSuggestion(suggestions[selectedIndex]);
+        return;
       }
 
       if (e.key === 'Enter') {

--- a/my-app/src/renderer/shell/URLBar.tsx
+++ b/my-app/src/renderer/shell/URLBar.tsx
@@ -325,13 +325,15 @@ export function URLBar({
   }, []);
 
   const closeDropdown = useCallback((): void => {
-    setDropdownOpen(false);
-    setSuggestions([]);
-    setSelectedIndex(-1);
+    // Cancel any pending debounced suggestion request so stale results don't
+    // reopen the dropdown after it has been explicitly closed.
     if (suggestTimerRef.current) {
       clearTimeout(suggestTimerRef.current);
       suggestTimerRef.current = null;
     }
+    setDropdownOpen(false);
+    setSuggestions([]);
+    setSelectedIndex(-1);
   }, []);
 
 


### PR DESCRIPTION
## Summary
Implements Tab-to-search in the omnibox: when a site keyword (e.g. g, b, d) is detected in the URL bar without a trailing space, pressing Tab enters keyword search mode for that engine, matching Chrome behavior. Also adds @bing, @duckduckgo, and @yahoo keyword mode-enter via the FeaturedSearchProvider.

## Test plan
- [ ] Type g in the omnibox and press Tab — input should become 'g ' and allow typing a Google query
- [ ] Type 'b cats' and press Enter — should navigate to Bing search for cats
- [ ] Type @bing and Tab — should enter Bing keyword mode
- [ ] Confirm navigation resolves keyword+query inputs correctly end-to-end
- [ ] Verify ArrowUp/ArrowDown only preventDefault when dropdown is open

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Tab-to-Search in the omnibox. Press Tab after a site keyword to enter keyword search mode, with `@bing`, `@duckduckgo`, and `@yahoo` support, matching Chrome behavior.

- **New Features**
  - Press Tab after `g`, `b`, `d`, or `@bing`/`@duckduckgo`/`@yahoo` to start keyword mode and type a query.
  - Resolve both bare and `@`-prefixed keywords end-to-end via updated engine lookup.

- **Bug Fixes**
  - Omnibox: cancel pending suggestion timers on close to prevent stale results reopening; only preventDefault Arrow keys when the dropdown is open; commit selected suggestion on Enter only when open; fix keyword suggestion URLs; avoid stale input refs.
  - Treat only the app’s internal new tab page as blank (updated blank-page regex).

<sup>Written for commit 7cfa0ddad3306bc4c5fa77bfc8bd2d3f72d4a595. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

