### PR TITLE
feat(downloads): enable downloads internal page in forge build config

### DIFF
--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -198,13 +198,12 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
-        // Issue #37: downloads internal page preload — disabled in CI until
-        // src/preload/downloads.ts lands alongside the downloads renderer.
-        // {
-        //   entry: 'src/preload/downloads.ts',
-        //   config: 'vite.preload.config.ts',
-        //   target: 'preload',
-        // },
+        {
+          // Issue #37: downloads internal page preload
+          entry: 'src/preload/downloads.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
         {
           // Issue #26: chrome:// internal pages preload
           entry: 'src/preload/chrome.ts',
@@ -272,14 +271,11 @@ const config: ForgeConfig = {
           name: 'bookmarks',
           config: 'vite.bookmarks.config.mts',
         },
-        // Issue #37: downloads internal page renderer — disabled in CI until
-        // the missing vite.downloads.config.ts + src/renderer/downloads/
-        // scaffold lands on main. Without this guard electron-forge fails the
-        // production build. Restore once the files exist.
-        // {
-        //   name: 'downloads',
-        //   config: 'vite.downloads.config.mts',
-        // },
+        {
+          // Issue #37: downloads internal page renderer
+          name: 'downloads',
+          config: 'vite.downloads.config.mts',
+        },
         {
           // Issue #26: chrome:// internal pages renderer
           name: 'chrome_pages',


### PR DESCRIPTION
## Summary

- The downloads renderer scaffold (`src/renderer/downloads/`), preload (`src/preload/downloads.ts`), and vite config (`vite.downloads.config.mts`) all landed on main alongside the Safe Browsing PR (#266)
- The `forge.config.ts` had both the preload and renderer entries commented out with a guard noting they would be enabled once the files exist
- Uncomment both entries to enable the downloads internal page in production builds

## Test plan
- [ ] CI build succeeds with the new downloads build targets included
- [ ] Downloads page renders at the internal URL
- [ ] Download list, pause/resume/cancel, and clear-all interactions work

Closes #37

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the downloads internal page in production builds by activating its preload and renderer entries in `forge.config.ts`. Closes #37.

- **New Features**
  - Enabled preload `src/preload/downloads.ts` via `vite.preload.config.ts`.
  - Enabled renderer `downloads` via `vite.downloads.config.mts` to render the internal downloads page.

<sup>Written for commit 624a24d06cbe7dd686de8db3302613c923620ad3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

