### PR TITLE
feat(downloads): surface Safe Browsing warnings in downloads page UI

### DIFF
--- a/my-app/forge.config.ts
+++ b/my-app/forge.config.ts
@@ -198,13 +198,12 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
-        // Issue #37: downloads internal page preload — disabled in CI until
-        // src/preload/downloads.ts lands alongside the downloads renderer.
-        // {
-        //   entry: 'src/preload/downloads.ts',
-        //   config: 'vite.preload.config.ts',
-        //   target: 'preload',
-        // },
+        {
+          // Issue #37: downloads internal page preload
+          entry: 'src/preload/downloads.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
         {
           // Issue #26: chrome:// internal pages preload
           entry: 'src/preload/chrome.ts',
@@ -272,14 +271,11 @@ const config: ForgeConfig = {
           name: 'bookmarks',
           config: 'vite.bookmarks.config.mts',
         },
-        // Issue #37: downloads internal page renderer — disabled in CI until
-        // the missing vite.downloads.config.ts + src/renderer/downloads/
-        // scaffold lands on main. Without this guard electron-forge fails the
-        // production build. Restore once the files exist.
-        // {
-        //   name: 'downloads',
-        //   config: 'vite.downloads.config.mts',
-        // },
+        {
+          // Issue #37: downloads internal page renderer
+          name: 'downloads',
+          config: 'vite.downloads.config.mts',
+        },
         {
           // Issue #26: chrome:// internal pages renderer
           name: 'chrome_pages',

--- a/my-app/src/renderer/downloads/DownloadsPage.tsx
+++ b/my-app/src/renderer/downloads/DownloadsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 type DownloadStatus = 'in-progress' | 'paused' | 'completed' | 'cancelled' | 'interrupted';
+type WarningLevel = 'dangerous' | 'suspicious' | 'insecure' | null;
 
 interface DownloadItemDTO {
   id: string;
@@ -15,6 +16,8 @@ interface DownloadItemDTO {
   openWhenDone: boolean;
   speed: number;
   eta: number;
+  warningLevel?: WarningLevel;
+  warningDismissed?: boolean;
 }
 
 declare const downloadsAPI: {
@@ -26,6 +29,7 @@ declare const downloadsAPI: {
   showInFolder: (id: string) => Promise<void>;
   remove: (id: string) => Promise<void>;
   clearAll: () => Promise<void>;
+  dismissWarning: (id: string) => Promise<void>;
   onStateChanged: (cb: (downloads: DownloadItemDTO[]) => void) => () => void;
 };
 
@@ -113,6 +117,21 @@ function statusLabel(status: DownloadStatus): string {
   }
 }
 
+const WARNING_COPY: Record<NonNullable<WarningLevel>, { label: string; detail: string }> = {
+  dangerous: {
+    label: 'Dangerous file',
+    detail: 'This file may harm your device. Download has been paused.',
+  },
+  suspicious: {
+    label: 'Suspicious file',
+    detail: 'This file type is commonly used to distribute malware.',
+  },
+  insecure: {
+    label: 'Insecure download',
+    detail: 'This file was downloaded over an unencrypted connection.',
+  },
+};
+
 function DownloadEntry({
   item,
   onPause,
@@ -122,6 +141,7 @@ function DownloadEntry({
   onShowInFolder,
   onCopyLink,
   onRemove,
+  onDismissWarning,
 }: {
   item: DownloadItemDTO;
   onPause: (id: string) => void;
@@ -131,6 +151,7 @@ function DownloadEntry({
   onShowInFolder: (id: string) => void;
   onCopyLink: (url: string) => void;
   onRemove: (id: string) => void;
+  onDismissWarning: (id: string) => void;
 }): React.ReactElement {
   const isActive = item.status === 'in-progress' || item.status === 'paused';
   const isCompleted = item.status === 'completed';
@@ -139,9 +160,11 @@ function DownloadEntry({
     : 0;
 
   const ext = fileExtension(item.filename);
+  const showWarning = !!item.warningLevel && !item.warningDismissed;
+  const warningCopy = item.warningLevel ? WARNING_COPY[item.warningLevel] : null;
 
   return (
-    <div className={`dl__entry dl__entry--${item.status}`}>
+    <div className={`dl__entry dl__entry--${item.status}${showWarning ? ` dl__entry--warning-${item.warningLevel ?? ''}` : ''}`}>
       <div className="dl__entry-icon">
         <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
           <rect x="6" y="4" width="20" height="24" rx="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
@@ -167,6 +190,27 @@ function DownloadEntry({
             </span>
           )}
         </div>
+
+        {showWarning && warningCopy && (
+          <div className={`dl__warning dl__warning--${item.warningLevel ?? ''}`}>
+            <svg className="dl__warning-icon" width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M7 1.5L12.5 11.5H1.5L7 1.5Z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" fill="none" />
+              <line x1="7" y1="6" x2="7" y2="8.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+              <circle cx="7" cy="10" r="0.6" fill="currentColor" />
+            </svg>
+            <span className="dl__warning-text">
+              <strong>{warningCopy.label}:</strong> {warningCopy.detail}
+            </span>
+            <button
+              type="button"
+              className="dl__warning-dismiss"
+              onClick={() => onDismissWarning(item.id)}
+              title="Dismiss warning"
+            >
+              {item.warningLevel === 'dangerous' ? 'Keep anyway' : 'Dismiss'}
+            </button>
+          </div>
+        )}
 
         <div className="dl__entry-meta">
           {isActive && (
@@ -358,6 +402,14 @@ export function DownloadsPage(): React.ReactElement {
     setDownloads([]);
   }, []);
 
+  const handleDismissWarning = useCallback(async (id: string) => {
+    console.log('DownloadsPage.dismissWarning', { id });
+    await downloadsAPI.dismissWarning(id);
+    setDownloads((prev) =>
+      prev.map((d) => (d.id === id ? { ...d, warningDismissed: true } : d)),
+    );
+  }, []);
+
   const filtered = debouncedQuery
     ? downloads.filter((d) => matchesSearch(d, debouncedQuery))
     : downloads;
@@ -421,6 +473,7 @@ export function DownloadsPage(): React.ReactElement {
                     onShowInFolder={handleShowInFolder}
                     onCopyLink={handleCopyLink}
                     onRemove={handleRemove}
+                    onDismissWarning={handleDismissWarning}
                   />
                 ))}
               </div>

--- a/my-app/src/renderer/downloads/downloads.css
+++ b/my-app/src/renderer/downloads/downloads.css
@@ -265,6 +265,66 @@
   color: var(--color-status-danger);
 }
 
+.dl__warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  margin-top: 4px;
+  border: 1px solid;
+}
+
+.dl__warning--dangerous {
+  background-color: color-mix(in srgb, var(--color-status-danger) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-status-danger) 30%, transparent);
+  color: var(--color-status-danger);
+}
+
+.dl__warning--suspicious {
+  background-color: color-mix(in srgb, var(--color-status-warning) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-status-warning) 30%, transparent);
+  color: var(--color-status-warning);
+}
+
+.dl__warning--insecure {
+  background-color: color-mix(in srgb, var(--color-fg-tertiary) 8%, transparent);
+  border-color: var(--color-border-default);
+  color: var(--color-fg-secondary);
+}
+
+.dl__warning-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.dl__warning-text {
+  flex: 1;
+  min-width: 0;
+  color: inherit;
+}
+
+.dl__warning-dismiss {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 80ms ease;
+  white-space: nowrap;
+}
+
+.dl__warning-dismiss:hover {
+  opacity: 1;
+}
+
 .dl__toast {
   position: fixed;
   bottom: 24px;


### PR DESCRIPTION
## Summary

- The `DownloadManager` backend already classifies downloads as `dangerous`, `suspicious`, or `insecure` and auto-pauses dangerous ones — but the renderer's `DownloadItemDTO` was missing these fields and showed no warning UI
- Wire up the existing backend signal to the downloads page:
  - Add `warningLevel` and `warningDismissed` to `DownloadItemDTO`
  - Add `dismissWarning` to the `downloadsAPI` declaration
  - Render an inline warning banner per download with severity-specific copy and colors
  - Dangerous downloads label the dismiss button "Keep anyway" to reinforce the risk
  - Calling dismiss fires the IPC and applies an optimistic local state update

## Test plan
- [ ] Start a download of a file with a dangerous extension (e.g. `.exe`) — warning banner should appear, download is paused
- [ ] Click "Keep anyway" — banner disappears, download resumes
- [ ] Suspicious-level download shows amber warning with "Dismiss" button
- [ ] Insecure download (HTTP) shows muted warning with "Dismiss" button
- [ ] Warning state persists across page refreshes (backed by backend state)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Safe Browsing warnings to the downloads page so users see and act on risky files. Also enables the downloads internal page in the build so the UI ships.

- **New Features**
  - Expose `warningLevel` and `warningDismissed` on `DownloadItemDTO`.
  - Add `dismissWarning` to `downloadsAPI`.
  - Show an inline warning banner per download with severity-specific copy and styles. Dangerous files show "Keep anyway." Optimistic dismiss updates local state and triggers IPC.
  - Enable the downloads internal page in `forge.config.ts` (preload and renderer targets) to include `src/preload/downloads.ts` and `vite.downloads.config.mts` in builds.

<sup>Written for commit d0a9f81e8ebf05ef0301e5f8289874caed67b8a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

