### PR TITLE
test(search): add unit tests for SearchEngineStore

### DIFF
--- a/my-app/src/main/downloads/DownloadManager.ts
+++ b/my-app/src/main/downloads/DownloadManager.ts
@@ -47,7 +47,7 @@ export type DownloadItemDTO = Omit<DownloadItem, never>;
 const DANGEROUS_EXTS = new Set(['.exe', '.msi', '.bat', '.cmd', '.scr', '.pif', '.com', '.jar', '.vbs', '.ps1', '.psm1']);
 const SUSPICIOUS_EXTS = new Set(['.dmg', '.pkg', '.deb', '.rpm', '.sh', '.bash', '.zsh', '.app', '.crx', '.xpi']);
 
-function classifyDownload(url: string, referrer: string, filename: string): 'dangerous' | 'suspicious' | 'insecure' | null {
+export function classifyDownload(url: string, referrer: string, filename: string): 'dangerous' | 'suspicious' | 'insecure' | null {
   const ext = path.extname(filename).toLowerCase();
   // Extension checks take precedence over transport — a dangerous .exe over HTTP is still dangerous.
   if (DANGEROUS_EXTS.has(ext)) return 'dangerous';

--- a/my-app/tests/unit/downloads/DownloadManager.test.ts
+++ b/my-app/tests/unit/downloads/DownloadManager.test.ts
@@ -58,6 +58,7 @@ vi.mock('electron', () => ({
   app: {
     getPath: vi.fn(() => '/tmp'),
     dock: { setBadge: vi.fn() },
+    setBadgeCount: vi.fn(),
   },
   BrowserWindow: vi.fn(),
 }));

--- a/my-app/tests/unit/downloads/DownloadManager.test.ts
+++ b/my-app/tests/unit/downloads/DownloadManager.test.ts
@@ -1,0 +1,324 @@
+/**
+ * DownloadManager unit tests.
+ *
+ * Tests cover:
+ *   - classifyDownload: dangerous/suspicious/insecure/safe classification
+ *   - dismissWarning: marks warningDismissed, resumes paused dangerous download
+ *   - clearAll: empties in-memory download list
+ *   - removeFromList: removes a single entry
+ *   - getAll: returns current downloads list via IPC
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — electron + logger + settings/ipc (readPrefs)
+// ---------------------------------------------------------------------------
+
+const ipcHandlers: Map<string, (...args: unknown[]) => unknown> = new Map();
+let sessionWillDownloadCallback: ((event: unknown, item: MockElectronDownloadItem, wc: unknown) => void) | null = null;
+
+const { loggerSpy } = vi.hoisted(() => ({
+  loggerSpy: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
+vi.mock('../../../src/main/settings/ipc', () => ({
+  readPrefs: vi.fn(() => ({ askBeforeSave: false, defaultDownloadFolder: '' })),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcHandlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn(),
+  },
+  session: {
+    defaultSession: {
+      on: vi.fn((event: string, cb: unknown) => {
+        if (event === 'will-download') {
+          sessionWillDownloadCallback = cb as typeof sessionWillDownloadCallback;
+        }
+      }),
+    },
+  },
+  dialog: {
+    showSaveDialog: vi.fn(() => Promise.resolve({ canceled: false, filePath: '/tmp/test' })),
+  },
+  shell: {
+    openPath: vi.fn(() => Promise.resolve('')),
+    showItemInFolder: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn(() => '/tmp'),
+    dock: { setBadge: vi.fn() },
+  },
+  BrowserWindow: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock Electron DownloadItem helper
+// ---------------------------------------------------------------------------
+
+interface MockElectronDownloadItem {
+  getFilename: () => string;
+  getURL: () => string;
+  getTotalBytes: () => number;
+  getSavePath: () => string;
+  setSavePath: (p: string) => void;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  canResume: () => boolean;
+  once: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+}
+
+function makeElectronItem(overrides: Partial<{
+  filename: string;
+  url: string;
+  totalBytes: number;
+  savePath: string;
+  canResume: boolean;
+}> = {}): MockElectronDownloadItem {
+  const { filename = 'file.txt', url = 'https://example.com/file.txt', totalBytes = 1000, savePath = '/tmp/file.txt', canResume = true } = overrides;
+  return {
+    getFilename: () => filename,
+    getURL: () => url,
+    getTotalBytes: () => totalBytes,
+    getSavePath: () => savePath,
+    setSavePath: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    cancel: vi.fn(),
+    canResume: () => canResume,
+    once: vi.fn(),
+    on: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { DownloadManager, classifyDownload } from '../../../src/main/downloads/DownloadManager';
+
+// ---------------------------------------------------------------------------
+// classifyDownload tests (pure function)
+// ---------------------------------------------------------------------------
+
+describe('classifyDownload', () => {
+  describe('dangerous extensions', () => {
+    const dangerousFiles = ['setup.exe', 'install.msi', 'run.bat', 'run.cmd', 'screen.scr',
+      'hack.pif', 'dos.com', 'lib.jar', 'macro.vbs', 'script.ps1', 'module.psm1'];
+
+    for (const filename of dangerousFiles) {
+      it(`classifies ${filename} as dangerous`, () => {
+        expect(classifyDownload('https://example.com/' + filename, 'https://example.com', filename)).toBe('dangerous');
+      });
+    }
+
+    it('is case-insensitive for extension matching', () => {
+      expect(classifyDownload('https://example.com/FILE.EXE', 'https://example.com', 'FILE.EXE')).toBe('dangerous');
+    });
+
+    it('dangerous extension over HTTP is still dangerous (not overridden by insecure)', () => {
+      expect(classifyDownload('http://evil.com/payload.exe', 'https://example.com', 'payload.exe')).toBe('dangerous');
+    });
+  });
+
+  describe('suspicious extensions', () => {
+    const suspiciousFiles = ['app.dmg', 'installer.pkg', 'package.deb', 'package.rpm',
+      'script.sh', 'script.bash', 'script.zsh', 'App.app', 'extension.crx', 'addon.xpi'];
+
+    for (const filename of suspiciousFiles) {
+      it(`classifies ${filename} as suspicious`, () => {
+        expect(classifyDownload('https://example.com/' + filename, 'https://example.com', filename)).toBe('suspicious');
+      });
+    }
+  });
+
+  describe('insecure download', () => {
+    it('flags HTTP url with HTTPS referrer as insecure', () => {
+      expect(classifyDownload('http://cdn.example.com/file.zip', 'https://example.com', 'file.zip')).toBe('insecure');
+    });
+
+    it('does NOT flag HTTPS url with HTTPS referrer', () => {
+      expect(classifyDownload('https://cdn.example.com/file.zip', 'https://example.com', 'file.zip')).toBeNull();
+    });
+
+    it('does NOT flag HTTP url with HTTP referrer', () => {
+      expect(classifyDownload('http://cdn.example.com/file.zip', 'http://example.com', 'file.zip')).toBeNull();
+    });
+  });
+
+  describe('safe downloads', () => {
+    it('returns null for a plain .zip', () => {
+      expect(classifyDownload('https://example.com/archive.zip', 'https://example.com', 'archive.zip')).toBeNull();
+    });
+
+    it('returns null for a .pdf', () => {
+      expect(classifyDownload('https://example.com/doc.pdf', 'https://example.com', 'doc.pdf')).toBeNull();
+    });
+
+    it('returns null for a no-extension file', () => {
+      expect(classifyDownload('https://example.com/download', 'https://example.com', 'download')).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DownloadManager behaviour tests
+// ---------------------------------------------------------------------------
+
+describe('DownloadManager', () => {
+  let manager: DownloadManager;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockWin = {
+    isDestroyed: vi.fn(() => false),
+    setProgressBar: vi.fn(),
+    webContents: { send: vi.fn(), isDestroyed: vi.fn(() => false) },
+  } as any;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    sessionWillDownloadCallback = null;
+    vi.clearAllMocks();
+    manager = new DownloadManager(mockWin);
+  });
+
+  function simulateDownload(item: MockElectronDownloadItem): void {
+    if (!sessionWillDownloadCallback) throw new Error('will-download handler not registered');
+    sessionWillDownloadCallback({}, item, { getURL: () => 'https://example.com' });
+  }
+
+  async function callHandler(channel: string, ...args: unknown[]): Promise<unknown> {
+    const handler = ipcHandlers.get(channel);
+    if (!handler) throw new Error(`No handler for ${channel}`);
+    return handler({} as Electron.IpcMainInvokeEvent, ...args);
+  }
+
+  it('registers will-download handler on session', async () => {
+    const { session } = await import('electron');
+    expect(session.defaultSession.on).toHaveBeenCalledWith('will-download', expect.any(Function));
+  });
+
+  it('returns empty list when no downloads', async () => {
+    const result = await callHandler('downloads:get-all');
+    expect(result).toEqual([]);
+  });
+
+  it('adds a safe download with null warningLevel', async () => {
+    const item = makeElectronItem({ filename: 'report.pdf', url: 'https://example.com/report.pdf' });
+    simulateDownload(item);
+    const list = await callHandler('downloads:get-all') as unknown[];
+    expect(list).toHaveLength(1);
+    expect((list[0] as { warningLevel: null }).warningLevel).toBeNull();
+    expect((list[0] as { status: string }).status).toBe('in-progress');
+  });
+
+  it('auto-pauses a dangerous download and sets warningLevel', async () => {
+    const item = makeElectronItem({ filename: 'malware.exe', url: 'https://evil.com/malware.exe' });
+    simulateDownload(item);
+    expect(item.pause).toHaveBeenCalledOnce();
+    const list = await callHandler('downloads:get-all') as unknown[];
+    expect(list).toHaveLength(1);
+    const dl = list[0] as { warningLevel: string; status: string };
+    expect(dl.warningLevel).toBe('dangerous');
+    expect(dl.status).toBe('paused');
+  });
+
+  it('sets warningLevel for suspicious download but does NOT pause it', async () => {
+    const item = makeElectronItem({ filename: 'app.dmg', url: 'https://example.com/app.dmg' });
+    simulateDownload(item);
+    expect(item.pause).not.toHaveBeenCalled();
+    const list = await callHandler('downloads:get-all') as unknown[];
+    const dl = list[0] as { warningLevel: string; status: string };
+    expect(dl.warningLevel).toBe('suspicious');
+    expect(dl.status).toBe('in-progress');
+  });
+
+  describe('dismissWarning', () => {
+    it('marks warningDismissed and resumes a paused dangerous download', async () => {
+      const item = makeElectronItem({ filename: 'setup.exe', url: 'https://example.com/setup.exe', canResume: true });
+      simulateDownload(item);
+
+      const [dl0] = await callHandler('downloads:get-all') as Array<{ id: string; warningDismissed: boolean; status: string }>;
+      expect(dl0.warningDismissed).toBe(false);
+      expect(dl0.status).toBe('paused');
+
+      await callHandler('downloads:dismiss-warning', dl0.id);
+
+      const [dl1] = await callHandler('downloads:get-all') as Array<{ id: string; warningDismissed: boolean; status: string }>;
+      expect(dl1.warningDismissed).toBe(true);
+      expect(dl1.status).toBe('in-progress');
+      expect(item.resume).toHaveBeenCalledOnce();
+    });
+
+    it('dismisses warning on suspicious download without resuming (already in-progress)', async () => {
+      const item = makeElectronItem({ filename: 'app.dmg', url: 'https://example.com/app.dmg' });
+      simulateDownload(item);
+
+      const [dl0] = await callHandler('downloads:get-all') as Array<{ id: string; status: string }>;
+      expect(dl0.status).toBe('in-progress');
+
+      await callHandler('downloads:dismiss-warning', dl0.id);
+
+      const [dl1] = await callHandler('downloads:get-all') as Array<{ warningDismissed: boolean }>;
+      expect(dl1.warningDismissed).toBe(true);
+      expect(item.resume).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning for unknown id', async () => {
+      await callHandler('downloads:dismiss-warning', 'nonexistent-id');
+      expect(loggerSpy.warn).toHaveBeenCalledWith(
+        'DownloadManager.dismissWarning.notFound',
+        expect.objectContaining({ id: 'nonexistent-id' }),
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a download from the list', async () => {
+      const item = makeElectronItem({ filename: 'report.pdf' });
+      simulateDownload(item);
+
+      const [dl] = await callHandler('downloads:get-all') as Array<{ id: string }>;
+      await callHandler('downloads:remove', dl.id);
+
+      const list = await callHandler('downloads:get-all') as unknown[];
+      expect(list).toHaveLength(0);
+    });
+
+    it('logs a warning for unknown id', async () => {
+      await callHandler('downloads:remove', 'bad-id');
+      expect(loggerSpy.warn).toHaveBeenCalledWith(
+        'DownloadManager.removeFromList.notFound',
+        expect.objectContaining({ id: 'bad-id' }),
+      );
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears all downloads and cancels active ones', async () => {
+      const item1 = makeElectronItem({ filename: 'file1.pdf' });
+      const item2 = makeElectronItem({ filename: 'file2.pdf' });
+      simulateDownload(item1);
+      simulateDownload(item2);
+
+      expect(await callHandler('downloads:get-all') as unknown[]).toHaveLength(2);
+
+      manager.clearAll();
+
+      expect(await callHandler('downloads:get-all') as unknown[]).toHaveLength(0);
+      expect(item1.cancel).toHaveBeenCalledOnce();
+      expect(item2.cancel).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/my-app/tests/unit/search/SearchEngineStore.test.ts
+++ b/my-app/tests/unit/search/SearchEngineStore.test.ts
@@ -1,0 +1,277 @@
+/**
+ * SearchEngineStore unit tests.
+ *
+ * Tests cover:
+ *   - listAll returns built-in + custom engines
+ *   - getDefault returns Google initially and after setDefault
+ *   - setDefault throws for unknown id; persists on success
+ *   - addCustom appends an engine with a generated UUID
+ *   - updateCustom patches name/keyword/url; returns false for unknown id
+ *   - removeCustom removes entry; falls back to Google when removed id was default
+ *   - buildSearchUrl URL-encodes the query and uses the default engine's template
+ *   - Persistence round-trip via flushSync
+ *   - Corrupt / missing state file starts fresh
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { loggerSpy, mockApp } = vi.hoisted(() => ({
+  loggerSpy: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  mockApp: { getPath: vi.fn(() => os.tmpdir()) },
+}));
+
+vi.mock('electron', () => ({ app: mockApp }));
+vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
+
+// uuid: return deterministic ids for test assertions
+let uuidCounter = 0;
+vi.mock('uuid', () => ({ v4: vi.fn(() => `test-id-${++uuidCounter}`) }));
+
+import { SearchEngineStore } from '../../../src/main/search/SearchEngineStore';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'searchenginestore-'));
+  mockApp.getPath.mockReturnValue(tmpDir);
+  uuidCounter = 0;
+  vi.clearAllMocks();
+});
+
+function newStore(): SearchEngineStore {
+  return new SearchEngineStore();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SearchEngineStore', () => {
+  describe('listAll', () => {
+    it('returns the 6 built-in engines on a fresh store', () => {
+      const store = newStore();
+      const all = store.listAll();
+      expect(all.length).toBe(6);
+      expect(all.map((e) => e.id)).toEqual(['google', 'bing', 'duckduckgo', 'yahoo', 'ecosia', 'brave']);
+    });
+
+    it('built-in engines have isBuiltIn=true', () => {
+      const store = newStore();
+      expect(store.listAll().every((e) => e.isBuiltIn)).toBe(true);
+    });
+
+    it('includes custom engines after addCustom', () => {
+      const store = newStore();
+      store.addCustom({ name: 'MyEngine', keyword: 'my', searchUrl: 'https://my.com/s?q=%s' });
+      const all = store.listAll();
+      expect(all).toHaveLength(7);
+      expect(all[6].name).toBe('MyEngine');
+      expect(all[6].isBuiltIn).toBe(false);
+    });
+  });
+
+  describe('getDefault', () => {
+    it('returns Google by default', () => {
+      const store = newStore();
+      expect(store.getDefault().id).toBe('google');
+    });
+
+    it('returns the engine set via setDefault', () => {
+      const store = newStore();
+      store.setDefault('bing');
+      expect(store.getDefault().id).toBe('bing');
+    });
+
+    it('falls back to Google when persisted default id is unknown', () => {
+      const stateFile = path.join(tmpDir, 'search-engines.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        version: 1, defaultEngineId: 'nonexistent', custom: [],
+      }), 'utf-8');
+      const store = newStore();
+      expect(store.getDefault().id).toBe('google');
+    });
+  });
+
+  describe('setDefault', () => {
+    it('throws for an unknown id', () => {
+      const store = newStore();
+      expect(() => store.setDefault('notanengine')).toThrow('Unknown search engine id');
+    });
+
+    it('accepts a custom engine id', () => {
+      const store = newStore();
+      const custom = store.addCustom({ name: 'X', keyword: 'x', searchUrl: 'https://x.com/?q=%s' });
+      store.setDefault(custom.id);
+      expect(store.getDefault().id).toBe(custom.id);
+    });
+  });
+
+  describe('addCustom', () => {
+    it('returns a new engine with a generated id and isBuiltIn=false', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'Kagi', keyword: 'k', searchUrl: 'https://kagi.com/search?q=%s' });
+      expect(engine.id).toBe('test-id-1');
+      expect(engine.name).toBe('Kagi');
+      expect(engine.keyword).toBe('k');
+      expect(engine.isBuiltIn).toBe(false);
+    });
+
+    it('trims whitespace from name/keyword/searchUrl', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: '  Kagi  ', keyword: '  k  ', searchUrl: '  https://kagi.com/%s  ' });
+      expect(engine.name).toBe('Kagi');
+      expect(engine.keyword).toBe('k');
+      expect(engine.searchUrl).toBe('https://kagi.com/%s');
+    });
+
+    it('multiple addCustom calls yield distinct ids', () => {
+      const store = newStore();
+      const a = store.addCustom({ name: 'A', keyword: 'a', searchUrl: 'https://a.com/?q=%s' });
+      const b = store.addCustom({ name: 'B', keyword: 'b', searchUrl: 'https://b.com/?q=%s' });
+      expect(a.id).not.toBe(b.id);
+    });
+  });
+
+  describe('updateCustom', () => {
+    it('returns false for an unknown id', () => {
+      const store = newStore();
+      expect(store.updateCustom('bad-id', { name: 'X' })).toBe(false);
+    });
+
+    it('patches name, keyword, and searchUrl', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'Old', keyword: 'o', searchUrl: 'https://old.com/?q=%s' });
+      const ok = store.updateCustom(engine.id, { name: 'New', keyword: 'n' });
+      expect(ok).toBe(true);
+      const updated = store.listAll().find((e) => e.id === engine.id)!;
+      expect(updated.name).toBe('New');
+      expect(updated.keyword).toBe('n');
+      expect(updated.searchUrl).toBe('https://old.com/?q=%s'); // unchanged
+    });
+
+    it('partial update does not touch unset fields', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'A', keyword: 'a', searchUrl: 'https://a.com/?q=%s' });
+      store.updateCustom(engine.id, { searchUrl: 'https://b.com/?q=%s' });
+      const updated = store.listAll().find((e) => e.id === engine.id)!;
+      expect(updated.name).toBe('A');
+      expect(updated.keyword).toBe('a');
+      expect(updated.searchUrl).toBe('https://b.com/?q=%s');
+    });
+  });
+
+  describe('removeCustom', () => {
+    it('returns false for an unknown id', () => {
+      const store = newStore();
+      expect(store.removeCustom('nonexistent')).toBe(false);
+    });
+
+    it('removes the engine from listAll', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'X', keyword: 'x', searchUrl: 'https://x.com/?q=%s' });
+      expect(store.listAll()).toHaveLength(7);
+      store.removeCustom(engine.id);
+      expect(store.listAll()).toHaveLength(6);
+    });
+
+    it('falls back to Google when the removed engine was the default', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'X', keyword: 'x', searchUrl: 'https://x.com/?q=%s' });
+      store.setDefault(engine.id);
+      expect(store.getDefault().id).toBe(engine.id);
+      store.removeCustom(engine.id);
+      expect(store.getDefault().id).toBe('google');
+    });
+
+    it('removing a non-default custom does not change the default', () => {
+      const store = newStore();
+      const a = store.addCustom({ name: 'A', keyword: 'a', searchUrl: 'https://a.com/?q=%s' });
+      const b = store.addCustom({ name: 'B', keyword: 'b', searchUrl: 'https://b.com/?q=%s' });
+      store.setDefault(a.id);
+      store.removeCustom(b.id);
+      expect(store.getDefault().id).toBe(a.id);
+    });
+  });
+
+  describe('buildSearchUrl', () => {
+    it('URL-encodes the query using the default engine', () => {
+      const store = newStore();
+      const url = store.buildSearchUrl('hello world');
+      expect(url).toBe('https://www.google.com/search?q=hello%20world');
+    });
+
+    it('uses the active default engine template', () => {
+      const store = newStore();
+      store.setDefault('duckduckgo');
+      const url = store.buildSearchUrl('cats');
+      expect(url).toBe('https://duckduckgo.com/?q=cats');
+    });
+
+    it('falls back to Google if the template has no %s', () => {
+      const store = newStore();
+      const engine = store.addCustom({ name: 'Bad', keyword: 'b', searchUrl: 'https://bad.com/' });
+      store.setDefault(engine.id);
+      const url = store.buildSearchUrl('test');
+      expect(url).toBe('https://www.google.com/search?q=test');
+    });
+
+    it('encodes special characters', () => {
+      const store = newStore();
+      const url = store.buildSearchUrl('a+b=c&d');
+      expect(url).toContain('a%2Bb%3Dc%26d');
+    });
+  });
+
+  describe('persistence', () => {
+    it('persists and reloads state correctly', () => {
+      const store = newStore();
+      store.addCustom({ name: 'Kagi', keyword: 'k', searchUrl: 'https://kagi.com/search?q=%s' });
+      store.setDefault('bing');
+      store.flushSync();
+
+      const reloaded = newStore();
+      expect(reloaded.getDefault().id).toBe('bing');
+      const all = reloaded.listAll();
+      expect(all).toHaveLength(7);
+      expect(all[6].name).toBe('Kagi');
+    });
+
+    it('resets to empty if file has wrong version', () => {
+      const stateFile = path.join(tmpDir, 'search-engines.json');
+      fs.writeFileSync(stateFile, JSON.stringify({ version: 99, defaultEngineId: 'google', custom: [] }), 'utf-8');
+      const store = newStore();
+      expect(store.listAll()).toHaveLength(6);
+      expect(loggerSpy.warn).toHaveBeenCalled();
+    });
+
+    it('resets to empty if file has invalid JSON', () => {
+      const stateFile = path.join(tmpDir, 'search-engines.json');
+      fs.writeFileSync(stateFile, '{ invalid json }', 'utf-8');
+      const store = newStore();
+      expect(store.listAll()).toHaveLength(6);
+      expect(store.getDefault().id).toBe('google');
+    });
+
+    it('starts fresh (no error) when file does not exist', () => {
+      const store = newStore(); // tmpDir has no file
+      expect(store.listAll()).toHaveLength(6);
+      expect(loggerSpy.info).toHaveBeenCalledWith('SearchEngineStore.load.fresh', expect.any(Object));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 26 unit tests covering all `SearchEngineStore` public methods: `listAll`, `getDefault`, `setDefault`, `addCustom`, `updateCustom`, `removeCustom`, `buildSearchUrl`
- Tests for persistence round-trip via `flushSync` and corrupt/missing state file recovery
- Follows the same mock patterns as `DownloadManager.test.ts` (vi.hoisted, deterministic uuid, temp dir per test)

## Test plan
- [x] All 26 tests pass locally
- [x] Covers edge cases: unknown IDs, whitespace trimming, fallback to Google, version mismatch, invalid JSON

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive unit tests for `SearchEngineStore` and `DownloadManager`, and exports `classifyDownload` for direct testing. Improves coverage of safety classification, persistence, and IPC flows.

- **Test Coverage**
  - `SearchEngineStore`: 26 tests for `listAll`, `getDefault`, `setDefault`, `addCustom`, `updateCustom`, `removeCustom`, `buildSearchUrl`, `flushSync`, and corrupt/missing state recovery.
  - `DownloadManager`: tests for `classifyDownload` (dangerous/suspicious/insecure/safe), auto-pause behavior, `dismissWarning`, `remove`, `clearAll`, and IPC handlers.
  - Deterministic UUIDs, per-test temp dirs, and Electron/logger mocks; added `app.setBadgeCount` stub for Linux CI.

- **Refactors**
  - Exported `classifyDownload` from `DownloadManager.ts` to enable isolated unit testing.

<sup>Written for commit 3d4b10628cce77cf6dbd536f987f6445c060dbf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

