### PR TITLE
test(devtools): add unit tests for DevToolsWindow singleton

### DIFF
--- a/my-app/tests/unit/devtools/DevToolsWindow.test.ts
+++ b/my-app/tests/unit/devtools/DevToolsWindow.test.ts
@@ -1,0 +1,184 @@
+/**
+ * devtools/DevToolsWindow.ts unit tests.
+ *
+ * Tests cover:
+ *   - getDevToolsWindow: returns null before any window is opened
+ *   - openDevToolsWindow: creates a BrowserWindow the first time
+ *   - openDevToolsWindow: focuses existing window instead of creating a new one
+ *   - getDevToolsWindow: returns window after open, null after 'closed' event
+ *   - closeDevToolsWindow: calls close() on the existing window
+ *   - closeDevToolsWindow: is a no-op when no window exists
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { loggerSpy } = vi.hoisted(() => ({
+  loggerSpy: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
+
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>();
+  return { ...actual, default: { ...actual, join: vi.fn((...parts: string[]) => parts.join('/')) }, join: vi.fn((...parts: string[]) => parts.join('/')) };
+});
+
+const { MockBrowserWindow } = vi.hoisted(() => {
+  class MockBrowserWindow {
+    static last: MockBrowserWindow | null = null;
+    static eventHandlers: Map<string, () => void> = new Map();
+    id = Math.floor(Math.random() * 1000);
+    isDestroyed = vi.fn(() => false);
+    focus = vi.fn();
+    show = vi.fn();
+    close = vi.fn();
+    loadURL = vi.fn(() => Promise.resolve());
+    loadFile = vi.fn(() => Promise.resolve());
+    once = vi.fn((event: string, handler: () => void) => {
+      MockBrowserWindow.eventHandlers.set(`once:${event}`, handler);
+    });
+    on = vi.fn((event: string, handler: () => void) => {
+      MockBrowserWindow.eventHandlers.set(event, handler);
+    });
+    webContents = {
+      on: vi.fn(),
+      getURL: vi.fn(() => ''),
+      openDevTools: vi.fn(),
+    };
+
+    constructor() {
+      MockBrowserWindow.eventHandlers = new Map();
+      MockBrowserWindow.last = this;
+    }
+  }
+  return { MockBrowserWindow };
+});
+
+vi.mock('electron', () => ({
+  BrowserWindow: MockBrowserWindow,
+}));
+
+import {
+  openDevToolsWindow,
+  getDevToolsWindow,
+  closeDevToolsWindow,
+} from '../../../src/main/devtools/DevToolsWindow';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getLastMockWin(): MockBrowserWindow | null {
+  return MockBrowserWindow.last;
+}
+
+/** Fire a named event registered via win.on(...) */
+function fireEvent(_win: MockBrowserWindow, event: string): void {
+  const handler = MockBrowserWindow.eventHandlers.get(event);
+  if (handler) handler();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('devtools/DevToolsWindow.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore isDestroyed to default false for the last mock window if one exists
+    if (MockBrowserWindow.last) {
+      MockBrowserWindow.last.isDestroyed.mockReturnValue(false);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Before any window is opened
+  // ---------------------------------------------------------------------------
+
+  describe('before openDevToolsWindow() is called', () => {
+    it('getDevToolsWindow() returns null', () => {
+      // The module singleton is null at import time; this test must run first.
+      // If a prior test opened the window, we skip — covered by the "after" suite.
+      if (MockBrowserWindow.last === null) {
+        expect(getDevToolsWindow()).toBeNull();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // After opening
+  // ---------------------------------------------------------------------------
+
+  describe('after openDevToolsWindow() is called', () => {
+    let win: MockBrowserWindow;
+
+    beforeEach(() => {
+      if (getDevToolsWindow() === null) {
+        openDevToolsWindow();
+      }
+      win = getLastMockWin()!;
+      win.isDestroyed.mockReturnValue(false);
+    });
+
+    it('creates a BrowserWindow', () => {
+      expect(win).not.toBeNull();
+    });
+
+    it('getDevToolsWindow() returns the window', () => {
+      expect(getDevToolsWindow()).toBe(win);
+    });
+
+    it('openDevToolsWindow() focuses the existing window instead of creating a second one', () => {
+      const before = MockBrowserWindow.last;
+      openDevToolsWindow();
+      expect(MockBrowserWindow.last).toBe(before);
+      expect(win.focus).toHaveBeenCalled();
+    });
+
+    it('openDevToolsWindow() returns the same window instance', () => {
+      const result = openDevToolsWindow();
+      expect(result).toBe(win);
+    });
+
+    it('closeDevToolsWindow() calls close() on the window', () => {
+      closeDevToolsWindow();
+      expect(win.close).toHaveBeenCalled();
+    });
+
+    it('closeDevToolsWindow() does not call close() when window is destroyed', () => {
+      win.isDestroyed.mockReturnValue(true);
+      closeDevToolsWindow();
+      expect(win.close).not.toHaveBeenCalled();
+    });
+
+    it('getDevToolsWindow() returns null after window is destroyed', () => {
+      win.isDestroyed.mockReturnValue(true);
+      expect(getDevToolsWindow()).toBeNull();
+    });
+
+    it('getDevToolsWindow() returns null after the "closed" event fires', () => {
+      fireEvent(win, 'closed');
+      expect(getDevToolsWindow()).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // closeDevToolsWindow — no window scenario
+  // ---------------------------------------------------------------------------
+
+  describe('closeDevToolsWindow() with no window', () => {
+    it('does not throw when no window has been created', () => {
+      // Force destroy the existing window so the module treats it as absent
+      if (MockBrowserWindow.last) {
+        MockBrowserWindow.last.isDestroyed.mockReturnValue(true);
+        // Fire 'closed' to set module singleton to null
+        fireEvent(MockBrowserWindow.last, 'closed');
+      }
+      expect(() => closeDevToolsWindow()).not.toThrow();
+    });
+  });
+});

--- a/my-app/tests/unit/devtools/DevToolsWindow.test.ts
+++ b/my-app/tests/unit/devtools/DevToolsWindow.test.ts
@@ -72,12 +72,14 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getLastMockWin(): MockBrowserWindow | null {
+type MockWin = InstanceType<typeof MockBrowserWindow>;
+
+function getLastMockWin(): MockWin | null {
   return MockBrowserWindow.last;
 }
 
 /** Fire a named event registered via win.on(...) */
-function fireEvent(_win: MockBrowserWindow, event: string): void {
+function fireEvent(_win: MockWin, event: string): void {
   const handler = MockBrowserWindow.eventHandlers.get(event);
   if (handler) handler();
 }
@@ -114,7 +116,7 @@ describe('devtools/DevToolsWindow.ts', () => {
   // ---------------------------------------------------------------------------
 
   describe('after openDevToolsWindow() is called', () => {
-    let win: MockBrowserWindow;
+    let win: MockWin;
 
     beforeEach(() => {
       if (getDevToolsWindow() === null) {


### PR DESCRIPTION
## Summary
- Adds 10 unit tests for `src/main/devtools/DevToolsWindow.ts` covering the singleton window lifecycle
- Uses `vi.hoisted()` with a static `eventHandlers` Map to capture event listeners across `vi.clearAllMocks()` calls

## Test plan
- [x] `getDevToolsWindow()` returns null before any window is opened
- [x] `openDevToolsWindow()` creates a BrowserWindow
- [x] `openDevToolsWindow()` focuses existing window instead of creating a second one (idempotent)
- [x] `openDevToolsWindow()` returns the same window instance
- [x] `closeDevToolsWindow()` calls close() on the existing window
- [x] `closeDevToolsWindow()` is a no-op when window is destroyed
- [x] `getDevToolsWindow()` returns null after window is destroyed
- [x] `getDevToolsWindow()` returns null after the 'closed' event fires
- [x] `closeDevToolsWindow()` does not throw when no window exists
- [x] All 10 tests passing locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `src/main/devtools/DevToolsWindow.ts` to verify the singleton lifecycle and prevent duplicate windows. Covers initial null state, creation, focusing the same instance, safe close/no-op when destroyed or missing, and clearing the ref on "closed"; uses `vitest` `vi.hoisted()` to persist event handlers across resets.

- **Bug Fixes**
  - Use `InstanceType<typeof MockBrowserWindow>` to fix TS2749 in test typings.

<sup>Written for commit 41673cfbd70ebecfb3dcbe1d5f31fc6b27163d97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

