### PR TITLE
fix(onboarding): fix Linux shortcut setup

### DIFF
--- a/app/src/main/hotkeys.ts
+++ b/app/src/main/hotkeys.ts
@@ -2,7 +2,7 @@ import { app, globalShortcut } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { mainLogger } from './logger';
-import { DEFAULT_GLOBAL_CMDBAR_ACCELERATOR } from '../shared/hotkeys';
+import { defaultGlobalCmdbarAccelerator } from '../shared/hotkeys';
 
 const log = {
   info: (comp: string, ctx: object) => mainLogger.info(comp, ctx as Record<string, unknown>),
@@ -15,8 +15,9 @@ interface HotkeyStore {
   globalCmdbar: string;
 }
 
-let currentAccelerator: string = DEFAULT_GLOBAL_CMDBAR_ACCELERATOR;
+let currentAccelerator: string = defaultGlobalCmdbarAccelerator(process.platform);
 let currentCallback: (() => void) | null = null;
+let registeredAccelerator: string | null = null;
 
 function storePath(): string {
   return path.join(app.getPath('userData'), STORE_FILE);
@@ -35,7 +36,7 @@ function loadStore(): HotkeyStore {
       log.warn('hotkeys.load.failed', { error: (err as Error).message });
     }
   }
-  return { globalCmdbar: DEFAULT_GLOBAL_CMDBAR_ACCELERATOR };
+  return { globalCmdbar: defaultGlobalCmdbarAccelerator(process.platform) };
 }
 
 function saveStore(store: HotkeyStore): void {
@@ -50,72 +51,129 @@ export function getGlobalCmdbarAccelerator(): string {
   return currentAccelerator;
 }
 
+function isRegistered(accel: string): boolean {
+  return globalShortcut.isRegistered(accel);
+}
+
+function tryRegister(accel: string, callback: () => void): boolean {
+  try {
+    const ok = globalShortcut.register(accel, () => {
+      log.info('hotkeys.fired', { hotkey: accel });
+      callback();
+    });
+    return ok && isRegistered(accel);
+  } catch (err) {
+    log.warn('hotkeys.register.threw', { error: (err as Error).message, hotkey: accel });
+    return false;
+  }
+}
+
+function unregisterRegistered(): void {
+  if (!registeredAccelerator) return;
+  globalShortcut.unregister(registeredAccelerator);
+  registeredAccelerator = null;
+}
+
+function activeRegisteredAccelerator(): string | null {
+  if (!registeredAccelerator) return null;
+  return isRegistered(registeredAccelerator) ? registeredAccelerator : null;
+}
+
+function tryRestore(accel: string, callback: () => void): boolean {
+  const ok = tryRegister(accel, callback);
+  if (!ok) return false;
+  currentAccelerator = accel;
+  registeredAccelerator = accel;
+  saveStore({ globalCmdbar: accel });
+  return true;
+}
+
 export function registerHotkeys(callback: () => void): boolean {
   const { globalCmdbar } = loadStore();
   currentAccelerator = globalCmdbar;
   currentCallback = callback;
   log.info('hotkeys.register', { hotkey: currentAccelerator });
 
-  const ok = globalShortcut.register(currentAccelerator, () => {
-    log.info('hotkeys.fired', { hotkey: currentAccelerator });
-    callback();
-  });
+  unregisterRegistered();
+  const ok = tryRegister(currentAccelerator, callback);
 
   if (!ok) {
     log.warn('hotkeys.register.failed', {
       message: 'Failed to register global shortcut',
       hotkey: currentAccelerator,
     });
+    registeredAccelerator = null;
+    const fallbackAccelerator = defaultGlobalCmdbarAccelerator(process.platform);
+    const failedAccelerator = currentAccelerator;
+    if (fallbackAccelerator !== failedAccelerator && tryRestore(fallbackAccelerator, callback)) {
+      log.warn('hotkeys.register.fallback', {
+        from: failedAccelerator,
+        to: fallbackAccelerator,
+      });
+      return true;
+    }
+    return false;
   }
 
-  return ok;
+  registeredAccelerator = currentAccelerator;
+  return true;
 }
 
 export function setGlobalCmdbarAccelerator(accel: string): { ok: boolean; accelerator: string } {
   if (!accel || typeof accel !== 'string') {
     return { ok: false, accelerator: currentAccelerator };
   }
-  if (accel === currentAccelerator) {
-    return { ok: true, accelerator: currentAccelerator };
-  }
   const callback = currentCallback;
   if (!callback) {
-    log.warn('hotkeys.set.noCallback', { hotkey: accel });
+    currentAccelerator = accel;
+    saveStore({ globalCmdbar: accel });
+    log.info('hotkeys.set.deferred', { hotkey: accel });
+    return { ok: true, accelerator: currentAccelerator };
+  }
+  if (accel === currentAccelerator && activeRegisteredAccelerator() === accel) {
+    saveStore({ globalCmdbar: currentAccelerator });
+    return { ok: true, accelerator: currentAccelerator };
+  }
+
+  const previousAccelerator = currentAccelerator;
+  const previousRegisteredAccelerator = activeRegisteredAccelerator();
+
+  log.info('hotkeys.set', { from: previousAccelerator, to: accel });
+  unregisterRegistered();
+
+  const ok = tryRegister(accel, callback);
+  if (ok) {
+    currentAccelerator = accel;
+    registeredAccelerator = accel;
+    saveStore({ globalCmdbar: accel });
+    return { ok: true, accelerator: currentAccelerator };
+  }
+
+  log.warn('hotkeys.set.failed', { hotkey: accel });
+  currentAccelerator = previousAccelerator;
+  registeredAccelerator = null;
+
+  if (previousRegisteredAccelerator && tryRestore(previousRegisteredAccelerator, callback)) {
+    return { ok: false, accelerator: currentAccelerator };
+  }
+  if (previousRegisteredAccelerator) {
+    log.warn('hotkeys.rollback.failed', { hotkey: previousRegisteredAccelerator });
+  }
+
+  const fallbackAccelerator = defaultGlobalCmdbarAccelerator(process.platform);
+  if (fallbackAccelerator !== accel && tryRestore(fallbackAccelerator, callback)) {
+    log.warn('hotkeys.set.fallback', {
+      failed: accel,
+      fallback: fallbackAccelerator,
+    });
     return { ok: false, accelerator: currentAccelerator };
   }
 
-  log.info('hotkeys.set', { from: currentAccelerator, to: accel });
-  globalShortcut.unregister(currentAccelerator);
-
-  let ok = false;
-  try {
-    ok = globalShortcut.register(accel, () => {
-      log.info('hotkeys.fired', { hotkey: accel });
-      callback();
-    });
-  } catch (err) {
-    log.warn('hotkeys.set.threw', { error: (err as Error).message, hotkey: accel });
-    ok = false;
-  }
-
-  if (!ok) {
-    log.warn('hotkeys.set.failed', { hotkey: accel });
-    // Rollback: try to re-register the previous accelerator so we don't leave
-    // the user without any global trigger.
-    globalShortcut.register(currentAccelerator, () => {
-      log.info('hotkeys.fired', { hotkey: currentAccelerator });
-      callback();
-    });
-    return { ok: false, accelerator: currentAccelerator };
-  }
-
-  currentAccelerator = accel;
-  saveStore({ globalCmdbar: accel });
-  return { ok: true, accelerator: currentAccelerator };
+  return { ok: false, accelerator: currentAccelerator };
 }
 
 export function unregisterHotkeys(): void {
-  log.info('hotkeys.unregister', { hotkey: currentAccelerator });
-  globalShortcut.unregister(currentAccelerator);
+  log.info('hotkeys.unregister', { hotkey: registeredAccelerator ?? currentAccelerator });
+  unregisterRegistered();
   currentCallback = null;
 }

--- a/app/src/main/hotkeys.ts
+++ b/app/src/main/hotkeys.ts
@@ -2,7 +2,7 @@ import { app, globalShortcut } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { mainLogger } from './logger';
-import { defaultGlobalCmdbarAccelerator } from '../shared/hotkeys';
+import { defaultGlobalCmdbarAccelerator, normalizeAccelerator } from '../shared/hotkeys';
 
 const log = {
   info: (comp: string, ctx: object) => mainLogger.info(comp, ctx as Record<string, unknown>),
@@ -28,7 +28,7 @@ function loadStore(): HotkeyStore {
     const raw = fs.readFileSync(storePath(), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<HotkeyStore>;
     if (typeof parsed.globalCmdbar === 'string' && parsed.globalCmdbar.length > 0) {
-      return { globalCmdbar: parsed.globalCmdbar };
+      return { globalCmdbar: normalizeAccelerator(parsed.globalCmdbar, process.platform) };
     }
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -55,11 +55,11 @@ function isRegistered(accel: string): boolean {
   return globalShortcut.isRegistered(accel);
 }
 
-function tryRegister(accel: string, callback: () => void): boolean {
+function tryRegister(accel: string): boolean {
   try {
     const ok = globalShortcut.register(accel, () => {
       log.info('hotkeys.fired', { hotkey: accel });
-      callback();
+      currentCallback?.();
     });
     return ok && isRegistered(accel);
   } catch (err) {
@@ -79,8 +79,8 @@ function activeRegisteredAccelerator(): string | null {
   return isRegistered(registeredAccelerator) ? registeredAccelerator : null;
 }
 
-function tryRestore(accel: string, callback: () => void): boolean {
-  const ok = tryRegister(accel, callback);
+function tryRestore(accel: string): boolean {
+  const ok = tryRegister(accel);
   if (!ok) return false;
   currentAccelerator = accel;
   registeredAccelerator = accel;
@@ -94,8 +94,13 @@ export function registerHotkeys(callback: () => void): boolean {
   currentCallback = callback;
   log.info('hotkeys.register', { hotkey: currentAccelerator });
 
+  if (activeRegisteredAccelerator() === currentAccelerator) {
+    saveStore({ globalCmdbar: currentAccelerator });
+    return true;
+  }
+
   unregisterRegistered();
-  const ok = tryRegister(currentAccelerator, callback);
+  const ok = tryRegister(currentAccelerator);
 
   if (!ok) {
     log.warn('hotkeys.register.failed', {
@@ -105,7 +110,7 @@ export function registerHotkeys(callback: () => void): boolean {
     registeredAccelerator = null;
     const fallbackAccelerator = defaultGlobalCmdbarAccelerator(process.platform);
     const failedAccelerator = currentAccelerator;
-    if (fallbackAccelerator !== failedAccelerator && tryRestore(fallbackAccelerator, callback)) {
+    if (fallbackAccelerator !== failedAccelerator && tryRestore(fallbackAccelerator)) {
       log.warn('hotkeys.register.fallback', {
         from: failedAccelerator,
         to: fallbackAccelerator,
@@ -116,6 +121,7 @@ export function registerHotkeys(callback: () => void): boolean {
   }
 
   registeredAccelerator = currentAccelerator;
+  saveStore({ globalCmdbar: currentAccelerator });
   return true;
 }
 
@@ -123,14 +129,14 @@ export function setGlobalCmdbarAccelerator(accel: string): { ok: boolean; accele
   if (!accel || typeof accel !== 'string') {
     return { ok: false, accelerator: currentAccelerator };
   }
-  const callback = currentCallback;
-  if (!callback) {
-    currentAccelerator = accel;
-    saveStore({ globalCmdbar: accel });
-    log.info('hotkeys.set.deferred', { hotkey: accel });
+  const normalizedAccel = normalizeAccelerator(accel, process.platform);
+  if (!currentCallback) {
+    currentAccelerator = normalizedAccel;
+    saveStore({ globalCmdbar: normalizedAccel });
+    log.info('hotkeys.set.deferred', { hotkey: normalizedAccel });
     return { ok: true, accelerator: currentAccelerator };
   }
-  if (accel === currentAccelerator && activeRegisteredAccelerator() === accel) {
+  if (normalizedAccel === currentAccelerator && activeRegisteredAccelerator() === normalizedAccel) {
     saveStore({ globalCmdbar: currentAccelerator });
     return { ok: true, accelerator: currentAccelerator };
   }
@@ -138,22 +144,22 @@ export function setGlobalCmdbarAccelerator(accel: string): { ok: boolean; accele
   const previousAccelerator = currentAccelerator;
   const previousRegisteredAccelerator = activeRegisteredAccelerator();
 
-  log.info('hotkeys.set', { from: previousAccelerator, to: accel });
+  log.info('hotkeys.set', { from: previousAccelerator, to: normalizedAccel });
   unregisterRegistered();
 
-  const ok = tryRegister(accel, callback);
+  const ok = tryRegister(normalizedAccel);
   if (ok) {
-    currentAccelerator = accel;
-    registeredAccelerator = accel;
-    saveStore({ globalCmdbar: accel });
+    currentAccelerator = normalizedAccel;
+    registeredAccelerator = normalizedAccel;
+    saveStore({ globalCmdbar: normalizedAccel });
     return { ok: true, accelerator: currentAccelerator };
   }
 
-  log.warn('hotkeys.set.failed', { hotkey: accel });
+  log.warn('hotkeys.set.failed', { hotkey: normalizedAccel });
   currentAccelerator = previousAccelerator;
   registeredAccelerator = null;
 
-  if (previousRegisteredAccelerator && tryRestore(previousRegisteredAccelerator, callback)) {
+  if (previousRegisteredAccelerator && tryRestore(previousRegisteredAccelerator)) {
     return { ok: false, accelerator: currentAccelerator };
   }
   if (previousRegisteredAccelerator) {
@@ -161,9 +167,9 @@ export function setGlobalCmdbarAccelerator(accel: string): { ok: boolean; accele
   }
 
   const fallbackAccelerator = defaultGlobalCmdbarAccelerator(process.platform);
-  if (fallbackAccelerator !== accel && tryRestore(fallbackAccelerator, callback)) {
+  if (fallbackAccelerator !== normalizedAccel && tryRestore(fallbackAccelerator)) {
     log.warn('hotkeys.set.fallback', {
-      failed: accel,
+      failed: normalizedAccel,
       fallback: fallbackAccelerator,
     });
     return { ok: false, accelerator: currentAccelerator };

--- a/app/src/main/identity/onboardingHandlers.ts
+++ b/app/src/main/identity/onboardingHandlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow, globalShortcut, Notification, shell } from 'electron';
+import { ipcMain, BrowserWindow, Notification, shell } from 'electron';
 import { spawn } from 'node:child_process';
 import { mainLogger } from '../logger';
 import { AccountStore } from './AccountStore';
@@ -7,10 +7,8 @@ import { createPillWindow, togglePill, onPillVisibilityChange } from '../pill';
 import { saveApiKey as authSaveApiKey, setAuthMode as authSetMode, saveOpenAIKey as authSaveOpenAIKey } from './authStore';
 import { getAdapter } from '../hl/engines';
 import { enrichedEnv, resolveCliSpawn } from '../hl/engines/pathEnrich';
-import { defaultGlobalCmdbarAccelerator } from '../../shared/hotkeys';
-import { setGlobalCmdbarAccelerator } from '../hotkeys';
-
-const GLOBAL_SHORTCUT = defaultGlobalCmdbarAccelerator(process.platform);
+import { normalizeAccelerator } from '../../shared/hotkeys';
+import { getGlobalCmdbarAccelerator, registerHotkeys, setGlobalCmdbarAccelerator } from '../hotkeys';
 
 const ANTHROPIC_SERVICE = 'com.browser-use.desktop.anthropic';
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
@@ -323,8 +321,6 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
   });
 
   let pillCreated = false;
-  let currentAccelerator = GLOBAL_SHORTCUT;
-  let registeredAccelerator: string | null = null;
 
   const fireOnboardingShortcut = (accelerator: string): void => {
     mainLogger.info('onboardingHandlers.shortcutFired', { accelerator });
@@ -333,40 +329,7 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
     if (w) w.webContents.send('shortcut-activated');
   };
 
-  const tryRegisterShortcut = (accelerator: string): boolean => {
-    let ok: boolean;
-    try {
-      const registered = globalShortcut.register(accelerator, () => {
-        fireOnboardingShortcut(accelerator);
-      });
-      const isRegistered = globalShortcut.isRegistered(accelerator);
-      ok = registered && isRegistered;
-      mainLogger.info('onboardingHandlers.shortcutRegister.result', {
-        accelerator,
-        registered,
-        isRegistered,
-        ok,
-      });
-    } catch (err) {
-      mainLogger.warn('onboardingHandlers.shortcutRegister.threw', {
-        accelerator,
-        error: (err as Error).message,
-      });
-      ok = false;
-    }
-    return ok;
-  };
-
-  const unregisterRegisteredShortcut = (): string | null => {
-    const previousRegisteredAccelerator = registeredAccelerator;
-    if (previousRegisteredAccelerator) {
-      globalShortcut.unregister(previousRegisteredAccelerator);
-      registeredAccelerator = null;
-    }
-    return previousRegisteredAccelerator;
-  };
-
-  const registerOnboardingShortcut = (accelerator: string): boolean => {
+  const ensureOnboardingShortcut = (): boolean => {
     if (!pillCreated) {
       createPillWindow();
       onPillVisibilityChange((visible) => {
@@ -378,46 +341,29 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
       mainLogger.info('onboardingHandlers.pillCreated');
     }
 
-    const previousAccelerator = currentAccelerator;
-    const previousRegisteredAccelerator = unregisterRegisteredShortcut();
-    const ok = tryRegisterShortcut(accelerator);
-    if (ok) {
-      currentAccelerator = accelerator;
-      registeredAccelerator = accelerator;
-    } else if (previousRegisteredAccelerator && previousRegisteredAccelerator !== accelerator) {
-      const rollbackOk = tryRegisterShortcut(previousRegisteredAccelerator);
-      if (rollbackOk) {
-        registeredAccelerator = previousRegisteredAccelerator;
-      } else {
-        mainLogger.warn('onboardingHandlers.shortcutRollback.failed', {
-          accelerator: previousRegisteredAccelerator,
-        });
-      }
-    }
-    if (!ok) currentAccelerator = previousAccelerator;
-    return ok;
+    return registerHotkeys(() => fireOnboardingShortcut(getGlobalCmdbarAccelerator()));
   };
 
   ipcMain.handle('onboarding:listen-shortcut', () => {
-    mainLogger.info('onboardingHandlers.listenShortcut', { accelerator: currentAccelerator });
-    const ok = registerOnboardingShortcut(currentAccelerator);
-    return { ok, accelerator: currentAccelerator };
+    mainLogger.info('onboardingHandlers.listenShortcut', { accelerator: getGlobalCmdbarAccelerator() });
+    const ok = ensureOnboardingShortcut();
+    return { ok, accelerator: getGlobalCmdbarAccelerator() };
   });
 
   ipcMain.handle('onboarding:set-shortcut', (_event, accelerator: string) => {
     const validated = assertString(accelerator, 'accelerator', 100);
-    mainLogger.info('onboardingHandlers.setShortcut', { accelerator: validated });
-    const ok = registerOnboardingShortcut(validated);
-    if (ok) {
-      const persisted = setGlobalCmdbarAccelerator(validated);
-      mainLogger.info('onboardingHandlers.setShortcut.persisted', { ...persisted });
-    }
-    return { ok, accelerator: ok ? validated : currentAccelerator };
+    const normalized = normalizeAccelerator(validated, process.platform);
+    mainLogger.info('onboardingHandlers.setShortcut', { accelerator: normalized });
+    ensureOnboardingShortcut();
+    const result = setGlobalCmdbarAccelerator(normalized);
+    mainLogger.info('onboardingHandlers.setShortcut.persisted', { ...result });
+    return result;
   });
 
   ipcMain.handle('onboarding:trigger-shortcut', () => {
-    mainLogger.info('onboardingHandlers.triggerShortcut', { accelerator: currentAccelerator });
-    fireOnboardingShortcut(currentAccelerator);
+    const accelerator = getGlobalCmdbarAccelerator();
+    mainLogger.info('onboardingHandlers.triggerShortcut', { accelerator });
+    fireOnboardingShortcut(accelerator);
     return { ok: true };
   });
 
@@ -451,13 +397,6 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
     mainLogger.info('onboardingHandlers.complete.accountSaved');
 
     await new Promise((resolve) => setTimeout(resolve, 400));
-
-    const previousOnboardingAccelerator = unregisterRegisteredShortcut();
-    if (previousOnboardingAccelerator) {
-      mainLogger.info('onboardingHandlers.complete.shortcutUnregistered', {
-        accelerator: previousOnboardingAccelerator,
-      });
-    }
 
     const shell = openShellWindow();
     mainLogger.info('onboardingHandlers.complete.shellOpened', {

--- a/app/src/main/identity/onboardingHandlers.ts
+++ b/app/src/main/identity/onboardingHandlers.ts
@@ -7,8 +7,10 @@ import { createPillWindow, togglePill, onPillVisibilityChange } from '../pill';
 import { saveApiKey as authSaveApiKey, setAuthMode as authSetMode, saveOpenAIKey as authSaveOpenAIKey } from './authStore';
 import { getAdapter } from '../hl/engines';
 import { enrichedEnv, resolveCliSpawn } from '../hl/engines/pathEnrich';
+import { defaultGlobalCmdbarAccelerator } from '../../shared/hotkeys';
+import { setGlobalCmdbarAccelerator } from '../hotkeys';
 
-const GLOBAL_SHORTCUT = 'CommandOrControl+Shift+Space';
+const GLOBAL_SHORTCUT = defaultGlobalCmdbarAccelerator(process.platform);
 
 const ANTHROPIC_SERVICE = 'com.browser-use.desktop.anthropic';
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
@@ -322,6 +324,47 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
 
   let pillCreated = false;
   let currentAccelerator = GLOBAL_SHORTCUT;
+  let registeredAccelerator: string | null = null;
+
+  const fireOnboardingShortcut = (accelerator: string): void => {
+    mainLogger.info('onboardingHandlers.shortcutFired', { accelerator });
+    togglePill();
+    const w = liveOnboardingWindow();
+    if (w) w.webContents.send('shortcut-activated');
+  };
+
+  const tryRegisterShortcut = (accelerator: string): boolean => {
+    let ok: boolean;
+    try {
+      const registered = globalShortcut.register(accelerator, () => {
+        fireOnboardingShortcut(accelerator);
+      });
+      const isRegistered = globalShortcut.isRegistered(accelerator);
+      ok = registered && isRegistered;
+      mainLogger.info('onboardingHandlers.shortcutRegister.result', {
+        accelerator,
+        registered,
+        isRegistered,
+        ok,
+      });
+    } catch (err) {
+      mainLogger.warn('onboardingHandlers.shortcutRegister.threw', {
+        accelerator,
+        error: (err as Error).message,
+      });
+      ok = false;
+    }
+    return ok;
+  };
+
+  const unregisterRegisteredShortcut = (): string | null => {
+    const previousRegisteredAccelerator = registeredAccelerator;
+    if (previousRegisteredAccelerator) {
+      globalShortcut.unregister(previousRegisteredAccelerator);
+      registeredAccelerator = null;
+    }
+    return previousRegisteredAccelerator;
+  };
 
   const registerOnboardingShortcut = (accelerator: string): boolean => {
     if (!pillCreated) {
@@ -335,28 +378,47 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
       mainLogger.info('onboardingHandlers.pillCreated');
     }
 
-    globalShortcut.unregister(currentAccelerator);
-    const ok = globalShortcut.register(accelerator, () => {
-      mainLogger.info('onboardingHandlers.shortcutFired', { accelerator });
-      togglePill();
-      const w = liveOnboardingWindow();
-      if (w) w.webContents.send('shortcut-activated');
-    });
-    if (ok) currentAccelerator = accelerator;
+    const previousAccelerator = currentAccelerator;
+    const previousRegisteredAccelerator = unregisterRegisteredShortcut();
+    const ok = tryRegisterShortcut(accelerator);
+    if (ok) {
+      currentAccelerator = accelerator;
+      registeredAccelerator = accelerator;
+    } else if (previousRegisteredAccelerator && previousRegisteredAccelerator !== accelerator) {
+      const rollbackOk = tryRegisterShortcut(previousRegisteredAccelerator);
+      if (rollbackOk) {
+        registeredAccelerator = previousRegisteredAccelerator;
+      } else {
+        mainLogger.warn('onboardingHandlers.shortcutRollback.failed', {
+          accelerator: previousRegisteredAccelerator,
+        });
+      }
+    }
+    if (!ok) currentAccelerator = previousAccelerator;
     return ok;
   };
 
   ipcMain.handle('onboarding:listen-shortcut', () => {
-    mainLogger.info('onboardingHandlers.listenShortcut');
-    const ok = registerOnboardingShortcut(GLOBAL_SHORTCUT);
-    return { ok, accelerator: GLOBAL_SHORTCUT };
+    mainLogger.info('onboardingHandlers.listenShortcut', { accelerator: currentAccelerator });
+    const ok = registerOnboardingShortcut(currentAccelerator);
+    return { ok, accelerator: currentAccelerator };
   });
 
   ipcMain.handle('onboarding:set-shortcut', (_event, accelerator: string) => {
     const validated = assertString(accelerator, 'accelerator', 100);
     mainLogger.info('onboardingHandlers.setShortcut', { accelerator: validated });
     const ok = registerOnboardingShortcut(validated);
+    if (ok) {
+      const persisted = setGlobalCmdbarAccelerator(validated);
+      mainLogger.info('onboardingHandlers.setShortcut.persisted', { ...persisted });
+    }
     return { ok, accelerator: ok ? validated : currentAccelerator };
+  });
+
+  ipcMain.handle('onboarding:trigger-shortcut', () => {
+    mainLogger.info('onboardingHandlers.triggerShortcut', { accelerator: currentAccelerator });
+    fireOnboardingShortcut(currentAccelerator);
+    return { ok: true };
   });
 
   ipcMain.handle('onboarding:request-notifications', () => {
@@ -389,6 +451,13 @@ export function registerOnboardingHandlers(deps: OnboardingHandlerDeps): void {
     mainLogger.info('onboardingHandlers.complete.accountSaved');
 
     await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const previousOnboardingAccelerator = unregisterRegisteredShortcut();
+    if (previousOnboardingAccelerator) {
+      mainLogger.info('onboardingHandlers.complete.shortcutUnregistered', {
+        accelerator: previousOnboardingAccelerator,
+      });
+    }
 
     const shell = openShellWindow();
     mainLogger.info('onboardingHandlers.complete.shellOpened', {
@@ -433,6 +502,7 @@ export function unregisterOnboardingHandlers(): void {
   ipcMain.removeHandler('onboarding:open-external');
   ipcMain.removeHandler('onboarding:listen-shortcut');
   ipcMain.removeHandler('onboarding:set-shortcut');
+  ipcMain.removeHandler('onboarding:trigger-shortcut');
   ipcMain.removeHandler('onboarding:request-notifications');
   ipcMain.removeHandler('onboarding:complete');
   mainLogger.info('onboardingHandlers.unregistered');

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -18,6 +18,10 @@ loadDotEnv({ path: path.resolve(__dirname, '..', '..', '.env') });
 
 import { app, BrowserWindow, crashReporter, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell } from 'electron';
 
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal');
+}
+
 app.setName('Browser Use');
 
 // Native-crash minidumps → userData/Crashpad/. Captures GPU process,

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -17,9 +17,13 @@ import path from 'node:path';
 loadDotEnv({ path: path.resolve(__dirname, '..', '..', '.env') });
 
 import { app, BrowserWindow, crashReporter, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell } from 'electron';
+import { mergeChromiumFeature } from './startup/chromiumFeatures';
 
 if (process.platform === 'linux') {
-  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal');
+  app.commandLine.appendSwitch(
+    'enable-features',
+    mergeChromiumFeature(app.commandLine.getSwitchValue('enable-features'), 'GlobalShortcutsPortal'),
+  );
 }
 
 app.setName('Browser Use');

--- a/app/src/main/startup/chromiumFeatures.ts
+++ b/app/src/main/startup/chromiumFeatures.ts
@@ -1,0 +1,12 @@
+export function mergeChromiumFeature(existingFeatures: string, feature: string): string {
+  const features = existingFeatures
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (!features.includes(feature)) {
+    features.push(feature);
+  }
+
+  return features.join(',');
+}

--- a/app/src/preload/onboarding.ts
+++ b/app/src/preload/onboarding.ts
@@ -104,6 +104,9 @@ const onboardingAPI = {
   setShortcut: (accelerator: string): Promise<{ ok: boolean; accelerator: string }> =>
     ipcRenderer.invoke('onboarding:set-shortcut', accelerator),
 
+  triggerShortcut: (): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('onboarding:trigger-shortcut'),
+
   onShortcutActivated: (cb: () => void): (() => void) => {
     const handler = () => cb();
     ipcRenderer.on('shortcut-activated', handler);

--- a/app/src/renderer/hub/SettingsPane.tsx
+++ b/app/src/renderer/hub/SettingsPane.tsx
@@ -269,7 +269,7 @@ interface SettingsPaneProps {
   onClose: () => void;
   keybindings: KeyBinding[];
   overrides: Record<string, string[]>;
-  onUpdateBinding: (id: ActionId, keys: string[]) => void;
+  onUpdateBinding: (id: ActionId, keys: string[]) => Promise<boolean>;
   onResetBinding: (id: ActionId) => void;
   onResetAll: () => void;
   formatShortcut: (shortcut: string) => string;
@@ -278,7 +278,7 @@ interface SettingsPaneProps {
 interface KeybindRowProps {
   kb: KeyBinding;
   isOverridden: boolean;
-  onUpdate: (id: ActionId, keys: string[]) => void;
+  onUpdate: (id: ActionId, keys: string[]) => Promise<boolean>;
   onReset: (id: ActionId) => void;
   platform: string;
   formatShortcut: (shortcut: string) => string;
@@ -287,45 +287,66 @@ interface KeybindRowProps {
 function KeybindRow({ kb, isOverridden, onUpdate, onReset, platform, formatShortcut }: KeybindRowProps): React.ReactElement {
   const [recording, setRecording] = useState(false);
   const [firstKey, setFirstKey] = useState<string | null>(null);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
+  const isGlobalShortcut = kb.id === 'action.createPane';
+
+  const finishRecording = useCallback(async (keys: string[]) => {
+    setRecording(false);
+    setFirstKey(null);
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    const ok = await onUpdate(kb.id, keys);
+    setRecordingError(ok ? null : 'That shortcut is unavailable. Choose another one.');
+  }, [kb.id, onUpdate]);
 
   useEffect(() => {
     if (!recording) return;
     const timer = setTimeout(() => {
       if (firstKey) {
-        onUpdate(kb.id, [firstKey]);
+        void finishRecording([firstKey]);
+      } else {
         setRecording(false);
-        setFirstKey(null);
+        setRecordingError('No shortcut was detected. Choose another combination.');
       }
-    }, 700);
+    }, firstKey ? 700 : 8000);
 
-    const handler = (e: KeyboardEvent) => {
+    const handler = async (e: KeyboardEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
       if (e.key === 'Escape') {
         setRecording(false);
         setFirstKey(null);
+        setRecordingError(null);
+        return;
+      }
+
+      if (e.key === 'Unidentified') {
+        clearTimeout(timer);
+        setRecording(false);
+        setFirstKey(null);
+        setRecordingError('That shortcut is unavailable. Choose another one.');
         return;
       }
 
       const combo = keyboardEventToShortcut(e, platform);
       if (!combo) return;
 
+      if (isGlobalShortcut && !e.metaKey && !e.ctrlKey && !e.altKey) return;
+
       if (firstKey) {
         clearTimeout(timer);
-        onUpdate(kb.id, [`${firstKey} ${combo}`]);
-        setRecording(false);
-        setFirstKey(null);
+        await finishRecording([`${firstKey} ${combo}`]);
         return;
       }
 
       // If modifier present, commit immediately. Else wait briefly for possible chord.
       if (e.metaKey || e.ctrlKey || e.altKey) {
-        onUpdate(kb.id, [combo]);
-        setRecording(false);
+        clearTimeout(timer);
+        await finishRecording([combo]);
         return;
       }
 
+      setRecordingError(null);
       setFirstKey(combo);
     };
     window.addEventListener('keydown', handler, true);
@@ -333,7 +354,7 @@ function KeybindRow({ kb, isOverridden, onUpdate, onReset, platform, formatShort
       clearTimeout(timer);
       window.removeEventListener('keydown', handler, true);
     };
-  }, [recording, firstKey, kb.id, onUpdate, platform]);
+  }, [finishRecording, firstKey, isGlobalShortcut, platform, recording]);
 
   return (
     <div className={`settings-pane__row${isOverridden ? ' settings-pane__row--modified' : ''}`}>
@@ -342,6 +363,7 @@ function KeybindRow({ kb, isOverridden, onUpdate, onReset, platform, formatShort
         <button
           className={`settings-pane__key-btn${recording ? ' settings-pane__key-btn--recording' : ''}`}
           onClick={() => {
+            setRecordingError(null);
             setRecording(true);
             setFirstKey(null);
           }}
@@ -368,6 +390,7 @@ function KeybindRow({ kb, isOverridden, onUpdate, onReset, platform, formatShort
           </svg>
         </button>
       </div>
+      {recordingError && <span className="settings-pane__key-error">{recordingError}</span>}
     </div>
   );
 }

--- a/app/src/renderer/hub/hub.css
+++ b/app/src/renderer/hub/hub.css
@@ -3230,6 +3230,8 @@ button:focus:not(:focus-visible) {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
   padding: var(--space-2) 0;
   border-bottom: 1px solid var(--color-border-subtle);
 }
@@ -3315,6 +3317,13 @@ button:focus:not(:focus-visible) {
 .settings-pane__key-btn--recording {
   background-color: var(--color-bg-elevated);
   border-color: var(--color-accent-default);
+}
+
+.settings-pane__key-error {
+  flex-basis: 100%;
+  font-size: var(--font-size-2xs);
+  color: var(--color-status-error);
+  text-align: right;
 }
 
 .settings-pane__sublabel {

--- a/app/src/renderer/hub/useVimKeys.ts
+++ b/app/src/renderer/hub/useVimKeys.ts
@@ -116,7 +116,7 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
   const updateBinding = useCallback(async (id: ActionId, keys: string[]): Promise<boolean> => {
     if (id === 'action.createPane') {
       const api = window.electronAPI;
-      const accel = rendererToAccelerator(keys[0] ?? '');
+      const accel = rendererToAccelerator(keys[0] ?? '', platform);
       if (!accel || !api?.hotkeys?.setGlobalCmdbar) {
         console.warn('[useVimKeys] cannot set global cmdbar', { accel, hasApi: !!api });
         return false;

--- a/app/src/renderer/hub/useVimKeys.ts
+++ b/app/src/renderer/hub/useVimKeys.ts
@@ -15,7 +15,7 @@ export interface VimKeysReturn {
   chordPrefix: string | null;
   keybindings: KeyBinding[];
   overrides: Record<string, string[]>;
-  updateBinding: (id: ActionId, keys: string[]) => void;
+  updateBinding: (id: ActionId, keys: string[]) => Promise<boolean>;
   resetBinding: (id: ActionId) => void;
   resetAll: () => void;
   platform: string;
@@ -67,11 +67,21 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      const pressed = keyboardEventToShortcut(e, platform);
+      if (!pressed) return;
+
+      const createPaneBinding = keybindings.find((kb) => kb.id === 'action.createPane');
+      if (createPaneBinding?.keys.includes(pressed)) {
+        e.preventDefault();
+        setChordPrefix(null);
+        if (chordTimer.current) clearTimeout(chordTimer.current);
+        handlersRef.current['action.createPane']?.();
+        return;
+      }
+
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
 
-      const pressed = keyboardEventToShortcut(e, platform);
-      if (!pressed) return;
       const combo = chordPrefix ? `${chordPrefix} ${pressed}` : pressed;
 
       for (const kb of keybindings) {
@@ -103,27 +113,28 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [keybindings, chordPrefix, platform]);
 
-  const updateBinding = useCallback((id: ActionId, keys: string[]) => {
+  const updateBinding = useCallback(async (id: ActionId, keys: string[]): Promise<boolean> => {
     if (id === 'action.createPane') {
       const api = window.electronAPI;
       const accel = rendererToAccelerator(keys[0] ?? '');
       if (!accel || !api?.hotkeys?.setGlobalCmdbar) {
         console.warn('[useVimKeys] cannot set global cmdbar', { accel, hasApi: !!api });
-        return;
+        return false;
       }
-      api.hotkeys.setGlobalCmdbar(accel)
-        .then((result: { ok: boolean; accelerator: string }) => {
-          console.log('[useVimKeys] setGlobalCmdbar result', result);
-          if (!result.ok) {
-            // rejected; keep existing override (broadcast will re-assert)
-          }
-          // Broadcast from main will update overrides; do nothing here.
-        })
-        .catch((err: Error) => console.warn('[useVimKeys] setGlobalCmdbar failed', err));
-      return;
+      try {
+        const result = await api.hotkeys.setGlobalCmdbar(accel);
+        console.log('[useVimKeys] setGlobalCmdbar result', result);
+        const display = acceleratorToRenderer(result.accelerator, platform);
+        setOverrides((prev) => ({ ...prev, 'action.createPane': [display] }));
+        return result.ok;
+      } catch (err) {
+        console.warn('[useVimKeys] setGlobalCmdbar failed', err);
+        return false;
+      }
     }
     setOverrides((prev) => ({ ...prev, [id]: keys }));
-  }, []);
+    return true;
+  }, [platform]);
 
   const resetBinding = useCallback((id: ActionId) => {
     if (id === 'action.createPane') {

--- a/app/src/renderer/hub/useVimKeys.ts
+++ b/app/src/renderer/hub/useVimKeys.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { DEFAULT_KEYBINDINGS } from './keybindings';
 import type { ActionId, KeyBinding } from './keybindings';
 import {
-  DEFAULT_GLOBAL_CMDBAR_ACCELERATOR,
   acceleratorToRenderer,
+  defaultGlobalCmdbarAccelerator,
   fallbackShortcutPlatform,
   formatShortcutForPlatform,
   keyboardEventToShortcut,
@@ -48,7 +48,7 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
     api.hotkeys.getGlobalCmdbar()
       .then((accel: string) => {
         if (cancelled) return;
-        const display = acceleratorToRenderer(accel || DEFAULT_GLOBAL_CMDBAR_ACCELERATOR, platform);
+        const display = acceleratorToRenderer(accel || defaultGlobalCmdbarAccelerator(platform), platform);
         console.log('[useVimKeys] loaded global cmdbar accel', { accel, display });
         setOverrides((prev) => ({ ...prev, 'action.createPane': [display] }));
       })
@@ -140,7 +140,7 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
     if (id === 'action.createPane') {
       const api = window.electronAPI;
       if (!api?.hotkeys?.setGlobalCmdbar) return;
-      api.hotkeys.setGlobalCmdbar(DEFAULT_GLOBAL_CMDBAR_ACCELERATOR)
+      api.hotkeys.setGlobalCmdbar(defaultGlobalCmdbarAccelerator(platform))
         .then((result: { ok: boolean; accelerator: string }) => {
           console.log('[useVimKeys] resetGlobalCmdbar result', result);
         })
@@ -152,7 +152,7 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
       delete next[id];
       return next;
     });
-  }, []);
+  }, [platform]);
 
   const resetAll = useCallback(() => {
     setOverrides((prev) => {
@@ -161,9 +161,9 @@ export function useVimKeys(handlers: Partial<Record<ActionId, () => void>>): Vim
       return preserved;
     });
     const api = window.electronAPI;
-    api?.hotkeys?.setGlobalCmdbar?.(DEFAULT_GLOBAL_CMDBAR_ACCELERATOR)
+    api?.hotkeys?.setGlobalCmdbar?.(defaultGlobalCmdbarAccelerator(platform))
       .catch((err: Error) => console.warn('[useVimKeys] resetAll global cmdbar failed', err));
-  }, []);
+  }, [platform]);
 
   const formatShortcut = useCallback((shortcut: string) => formatShortcutForPlatform(shortcut, platform), [platform]);
 

--- a/app/src/renderer/onboarding/OnboardingApp.tsx
+++ b/app/src/renderer/onboarding/OnboardingApp.tsx
@@ -4,7 +4,13 @@ import introImage from './intro.png';
 import chromeLogo from './chrome-logo.svg';
 import claudeCodeLogo from './claude-code-logo.svg';
 import codexLogo from './codex-logo.svg';
-import { acceleratorToDisplayParts, keyboardEventToShortcut, rendererToAccelerator } from '../../shared/hotkeys';
+import {
+  acceleratorToDisplayParts,
+  defaultGlobalCmdbarAccelerator,
+  keyboardEventToShortcut,
+  normalizeShortcutPlatform,
+  rendererToAccelerator,
+} from '../../shared/hotkeys';
 
 interface ChromeProfile {
   directory: string;
@@ -79,6 +85,7 @@ declare global {
       getPlatform: () => Promise<string>;
       listenShortcut: () => Promise<{ ok: boolean; accelerator: string }>;
       setShortcut: (accelerator: string) => Promise<{ ok: boolean; accelerator: string }>;
+      triggerShortcut: () => Promise<{ ok: boolean }>;
       onShortcutActivated: (cb: () => void) => () => void;
       onTaskSubmitted: (cb: () => void) => () => void;
       onPillShown: (cb: () => void) => () => void;
@@ -102,12 +109,14 @@ declare global {
 
 type Step = 'intro' | 'profile' | 'apikey' | 'notifications' | 'shortcut';
 
-const DEFAULT_ACCELERATOR = 'CommandOrControl+Shift+Space';
-
 function buildAccelerator(e: KeyboardEvent, platform: string): string | null {
   const shortcut = keyboardEventToShortcut(e, platform);
   if (!shortcut || (!e.metaKey && !e.ctrlKey && !e.altKey)) return null;
   return rendererToAccelerator(shortcut);
+}
+
+function acceleratorsMatch(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
 }
 
 function PreferencesStep({
@@ -475,11 +484,23 @@ export function OnboardingApp() {
     window.onboardingAPI.openExternal?.('https://docs.anthropic.com/en/docs/claude-code/overview');
   }, []);
 
-  const [accelerator, setAccelerator] = useState<string>(DEFAULT_ACCELERATOR);
+  const [accelerator, setAccelerator] = useState<string>(() => defaultGlobalCmdbarAccelerator(window.onboardingAPI.platform));
   const [recording, setRecording] = useState(false);
+  const [shortcutError, setShortcutError] = useState<string | null>(null);
   const [shortcutActivated, setShortcutActivated] = useState(false);
   const [pillOpen, setPillOpen] = useState(false);
-  const platform = window.onboardingAPI.platform;
+  const [platform, setPlatform] = useState(() => normalizeShortcutPlatform(window.onboardingAPI.platform));
+  const suppressRecordingClickUntilRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.onboardingAPI.getPlatform?.().then((detectedPlatform) => {
+      if (!cancelled) setPlatform(normalizeShortcutPlatform(detectedPlatform));
+    }).catch(() => {
+      if (!cancelled) setPlatform(normalizeShortcutPlatform(window.onboardingAPI.platform));
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     window.onboardingAPI.detectChromeProfiles().then((p) => {
@@ -629,13 +650,15 @@ export function OnboardingApp() {
     }
   }, []);
 
-  // Shortcut step: register default, listen for activation + task submission
+  // Shortcut step: register the current shortcut, listen for activation + task submission
   useEffect(() => {
     if (step !== 'shortcut') return;
     window.onboardingAPI.listenShortcut().then((res) => {
       if (res.accelerator) setAccelerator(res.accelerator);
+      setShortcutError(res.ok ? null : 'That shortcut is unavailable. Choose another one.');
     });
     const unsubActivated = window.onboardingAPI.onShortcutActivated(() => {
+      setRecording(false);
       setShortcutActivated(true);
     });
     const unsubShown = window.onboardingAPI.onPillShown(() => {
@@ -657,28 +680,67 @@ export function OnboardingApp() {
   }, [step]);
 
   // Key recording
-  const recordingRef = useRef(recording);
-  recordingRef.current = recording;
+  const shouldIgnoreRecordingClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    return e.detail === 0 || Date.now() < suppressRecordingClickUntilRef.current;
+  }, []);
+
+  const startRecording = useCallback(() => {
+    setShortcutError(null);
+    setRecording(true);
+  }, []);
 
   useEffect(() => {
     if (!recording) return;
+    const timeout = window.setTimeout(() => {
+      setRecording(false);
+      setShortcutError('No shortcut was detected. Choose another combination.');
+    }, 8000);
     const handler = async (e: KeyboardEvent) => {
       e.preventDefault();
       e.stopPropagation();
+      if (e.key === 'Unidentified') {
+        window.clearTimeout(timeout);
+        setRecording(false);
+        setShortcutError('That shortcut is unavailable. Choose another one.');
+        return;
+      }
       const accel = buildAccelerator(e, platform);
       if (!accel) return;
+      window.clearTimeout(timeout);
+      suppressRecordingClickUntilRef.current = Date.now() + 700;
+      (document.activeElement as HTMLElement | null)?.blur?.();
       setRecording(false);
       try {
         const res = await window.onboardingAPI.setShortcut(accel);
         setAccelerator(res.accelerator);
+        setShortcutError(res.ok ? null : 'That shortcut is unavailable. Choose another one.');
         (document.activeElement as HTMLElement | null)?.blur?.();
       } catch (err) {
         console.error('[onboarding] setShortcut failed', err);
+        setShortcutError('Shortcut setup failed. Choose another one.');
       }
     };
     window.addEventListener('keydown', handler, true);
-    return () => window.removeEventListener('keydown', handler, true);
+    return () => {
+      window.clearTimeout(timeout);
+      window.removeEventListener('keydown', handler, true);
+    };
   }, [recording, platform]);
+
+  useEffect(() => {
+    if (step !== 'shortcut' || recording || pillOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      const accel = buildAccelerator(e, platform);
+      if (!accel || !acceleratorsMatch(accel, accelerator)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      void window.onboardingAPI.triggerShortcut().catch((err) => {
+        console.error('[onboarding] triggerShortcut failed', err);
+      });
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [accelerator, pillOpen, platform, recording, step]);
 
   return (
     <div className="onboarding-container">
@@ -1127,7 +1189,7 @@ export function OnboardingApp() {
                   type="button"
                   className="shortcut-recording shortcut-clickable"
                   onClick={(e) => {
-                    if (e.detail === 0) return;
+                    if (shouldIgnoreRecordingClick(e)) return;
                     setRecording(false);
                   }}
                   title="Click to cancel"
@@ -1140,8 +1202,8 @@ export function OnboardingApp() {
                   type="button"
                   className="shortcut-keys shortcut-clickable"
                   onClick={(e) => {
-                    if (e.detail === 0) return;
-                    setRecording(true);
+                    if (shouldIgnoreRecordingClick(e)) return;
+                    startRecording();
                   }}
                   title="Click to change shortcut"
                 >
@@ -1155,14 +1217,21 @@ export function OnboardingApp() {
               )}
             </div>
 
-            <p className="shortcut-hint">
-              Press the shortcut to try it.
+            <p className={`shortcut-hint ${shortcutError ? 'shortcut-hint-error' : ''}`}>
+              {shortcutError ?? 'Press the shortcut to try it.'}
             </p>
 
             <div className="apikey-actions">
               <button
                 className="btn btn-secondary"
-                onClick={() => setRecording((r) => !r)}
+                onClick={(e) => {
+                  if (shouldIgnoreRecordingClick(e)) return;
+                  if (recording) {
+                    setRecording(false);
+                  } else {
+                    startRecording();
+                  }
+                }}
               >
                 {recording ? 'Cancel' : 'Change shortcut'}
               </button>

--- a/app/src/renderer/onboarding/OnboardingApp.tsx
+++ b/app/src/renderer/onboarding/OnboardingApp.tsx
@@ -112,7 +112,7 @@ type Step = 'intro' | 'profile' | 'apikey' | 'notifications' | 'shortcut';
 function buildAccelerator(e: KeyboardEvent, platform: string): string | null {
   const shortcut = keyboardEventToShortcut(e, platform);
   if (!shortcut || (!e.metaKey && !e.ctrlKey && !e.altKey)) return null;
-  return rendererToAccelerator(shortcut);
+  return rendererToAccelerator(shortcut, platform);
 }
 
 function acceleratorsMatch(a: string, b: string): boolean {

--- a/app/src/renderer/onboarding/onboarding.css
+++ b/app/src/renderer/onboarding/onboarding.css
@@ -1015,6 +1015,12 @@ html, body {
   animation: pulse 2s ease-in-out infinite;
 }
 
+.shortcut-hint-error {
+  color: var(--color-status-error);
+  animation: none;
+  opacity: 1;
+}
+
 @keyframes pulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }

--- a/app/src/shared/hotkeys.ts
+++ b/app/src/shared/hotkeys.ts
@@ -8,7 +8,6 @@
  */
 
 export const DEFAULT_GLOBAL_CMDBAR_ACCELERATOR = 'CommandOrControl+Shift+Space';
-export const DEFAULT_LINUX_GLOBAL_CMDBAR_ACCELERATOR = 'Alt+Space';
 
 const MODIFIER_KEYS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
 const SPACE_KEYS = new Set([' ', '\u00A0', 'Spacebar']);
@@ -27,10 +26,8 @@ export function fallbackShortcutPlatform(platform?: string): string {
   return normalizeShortcutPlatform(platform);
 }
 
-export function defaultGlobalCmdbarAccelerator(platform?: string): string {
-  return normalizeShortcutPlatform(platform) === 'linux'
-    ? DEFAULT_LINUX_GLOBAL_CMDBAR_ACCELERATOR
-    : DEFAULT_GLOBAL_CMDBAR_ACCELERATOR;
+export function defaultGlobalCmdbarAccelerator(_platform?: string): string {
+  return DEFAULT_GLOBAL_CMDBAR_ACCELERATOR;
 }
 
 function displayModifier(part: string, platform: string): string {
@@ -91,7 +88,7 @@ function normalizeAcceleratorPart(part: string, platform?: string): string {
       return 'CommandOrControl';
     case 'cmd':
     case 'command':
-      return normalizedPlatform && normalizedPlatform !== 'darwin' ? 'Command' : 'CommandOrControl';
+      return 'CommandOrControl';
     case 'ctrl':
     case 'control':
       return normalizedPlatform === 'darwin' ? 'Control' : 'CommandOrControl';

--- a/app/src/shared/hotkeys.ts
+++ b/app/src/shared/hotkeys.ts
@@ -8,22 +8,42 @@
  */
 
 export const DEFAULT_GLOBAL_CMDBAR_ACCELERATOR = 'CommandOrControl+Shift+Space';
+export const DEFAULT_LINUX_GLOBAL_CMDBAR_ACCELERATOR = 'Alt+Space';
 
 const MODIFIER_KEYS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
+const SPACE_KEYS = new Set([' ', '\u00A0', 'Spacebar']);
+
+type ShortcutPlatform = 'darwin' | 'win32' | 'linux';
+
+export function normalizeShortcutPlatform(platform?: string): ShortcutPlatform {
+  const detected = platform ?? (typeof navigator !== 'undefined' ? navigator.platform : '');
+  if (/darwin|mac/i.test(detected)) return 'darwin';
+  if (/win/i.test(detected)) return 'win32';
+  return 'linux';
+}
 
 export function fallbackShortcutPlatform(platform?: string): string {
-  const detected = platform ?? (typeof navigator !== 'undefined' ? navigator.platform : '');
-  return /Mac/i.test(detected) ? 'darwin' : 'linux';
+  return normalizeShortcutPlatform(platform);
+}
+
+export function defaultGlobalCmdbarAccelerator(platform?: string): string {
+  return normalizeShortcutPlatform(platform) === 'linux'
+    ? DEFAULT_LINUX_GLOBAL_CMDBAR_ACCELERATOR
+    : DEFAULT_GLOBAL_CMDBAR_ACCELERATOR;
 }
 
 function displayModifier(part: string, platform: string): string {
-  const isMac = platform === 'darwin';
+  const normalizedPlatform = normalizeShortcutPlatform(platform);
+  const isMac = normalizedPlatform === 'darwin';
   switch (part) {
     case 'CommandOrControl':
     case 'Cmd':
       return isMac ? '\u2318' : 'Ctrl';
     case 'Command':
       return isMac ? '\u2318' : 'Cmd';
+    case 'Meta':
+    case 'Super':
+      return isMac ? '\u2318' : normalizedPlatform === 'win32' ? 'Win' : 'Super';
     case 'Control':
     case 'Ctrl':
       return isMac ? '\u2303' : 'Ctrl';
@@ -38,11 +58,13 @@ function displayModifier(part: string, platform: string): string {
 }
 
 export function shortcutToRenderer(shortcut: string, platform: string): string {
-  const modKey = platform === 'darwin' ? 'Cmd' : 'Ctrl';
+  const normalizedPlatform = normalizeShortcutPlatform(platform);
+  const modKey = normalizedPlatform === 'darwin' ? 'Cmd' : 'Ctrl';
   return shortcut
     .replace(/CommandOrControl/gi, modKey)
     .replace(/\bCommand\b/gi, 'Cmd')
     .replace(/\bControl\b/gi, 'Ctrl')
+    .replace(/\bMeta\b/gi, normalizedPlatform === 'win32' ? 'Win' : 'Super')
     .replace(/\bOption\b/gi, 'Alt');
 }
 
@@ -65,20 +87,32 @@ export function rendererToAccelerator(combo: string): string {
   return combo
     .replace(/\bCommandOrControl\b/gi, 'CommandOrControl')
     .replace(/\bCmd\b/gi, 'CommandOrControl')
-    .replace(/\bCtrl\b/gi, 'CommandOrControl');
+    .replace(/\bCtrl\b/gi, 'CommandOrControl')
+    .replace(/\bWin\b/gi, 'Super')
+    .replace(/\bMeta\b/gi, 'Super');
+}
+
+function keyboardEventKeyName(e: KeyboardEvent): string | null {
+  if (e.code === 'Space' || SPACE_KEYS.has(e.key)) return 'Space';
+  if (e.key.length === 0) return null;
+  return e.key;
 }
 
 export function keyboardEventToShortcut(e: KeyboardEvent, platform: string): string | null {
   if (e.key === 'Escape' || e.key === 'Tab') return null;
+  if (e.key === 'Unidentified') return null;
   if (MODIFIER_KEYS.has(e.key)) return null;
 
+  const key = keyboardEventKeyName(e);
+  if (!key) return null;
+
+  const normalizedPlatform = normalizeShortcutPlatform(platform);
   const parts: string[] = [];
-  if (e.metaKey) parts.push(platform === 'darwin' ? 'Cmd' : 'Meta');
+  if (e.metaKey) parts.push(normalizedPlatform === 'darwin' ? 'Cmd' : normalizedPlatform === 'win32' ? 'Win' : 'Super');
   if (e.ctrlKey) parts.push('Ctrl');
   if (e.altKey) parts.push('Alt');
-  if (e.shiftKey && e.key.length > 1) parts.push('Shift');
+  if (e.shiftKey) parts.push('Shift');
 
-  const key = e.key === ' ' ? 'Space' : e.key;
   parts.push(key);
   return parts.join('+');
 }

--- a/app/src/shared/hotkeys.ts
+++ b/app/src/shared/hotkeys.ts
@@ -12,6 +12,7 @@ export const DEFAULT_LINUX_GLOBAL_CMDBAR_ACCELERATOR = 'Alt+Space';
 
 const MODIFIER_KEYS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
 const SPACE_KEYS = new Set([' ', '\u00A0', 'Spacebar']);
+const MODIFIER_ORDER = ['CommandOrControl', 'Command', 'Control', 'Super', 'Alt', 'Shift'];
 
 type ShortcutPlatform = 'darwin' | 'win32' | 'linux';
 
@@ -83,17 +84,68 @@ export function acceleratorToRenderer(accel: string, platform: string): string {
   return shortcutToRenderer(accel, platform);
 }
 
-export function rendererToAccelerator(combo: string): string {
-  return combo
-    .replace(/\bCommandOrControl\b/gi, 'CommandOrControl')
-    .replace(/\bCmd\b/gi, 'CommandOrControl')
-    .replace(/\bCtrl\b/gi, 'CommandOrControl')
-    .replace(/\bWin\b/gi, 'Super')
-    .replace(/\bMeta\b/gi, 'Super');
+function normalizeAcceleratorPart(part: string, platform?: string): string {
+  const normalizedPlatform = platform ? normalizeShortcutPlatform(platform) : null;
+  switch (part.toLowerCase()) {
+    case 'commandorcontrol':
+      return 'CommandOrControl';
+    case 'cmd':
+    case 'command':
+      return normalizedPlatform && normalizedPlatform !== 'darwin' ? 'Command' : 'CommandOrControl';
+    case 'ctrl':
+    case 'control':
+      return normalizedPlatform === 'darwin' ? 'Control' : 'CommandOrControl';
+    case 'win':
+    case 'meta':
+      return 'Super';
+    case 'option':
+    case 'alt':
+      return 'Alt';
+    case 'shift':
+      return 'Shift';
+    case 'spacebar':
+    case ' ':
+    case '\u00a0':
+      return 'Space';
+    default:
+      return part.length === 1 ? part.toUpperCase() : part;
+  }
+}
+
+export function normalizeAccelerator(accel: string, platform?: string): string {
+  return accel
+    .split(' ')
+    .map((chordPart) => {
+      const modifiers = new Set<string>();
+      const keys: string[] = [];
+
+      for (const rawPart of chordPart.split('+')) {
+        const part = normalizeAcceleratorPart(rawPart.trim(), platform);
+        if (!part) continue;
+        if (MODIFIER_ORDER.includes(part)) {
+          modifiers.add(part);
+        } else {
+          keys.push(part);
+        }
+      }
+
+      return [
+        ...MODIFIER_ORDER.filter((modifier) => modifiers.has(modifier)),
+        ...keys,
+      ].join('+');
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function rendererToAccelerator(combo: string, platform?: string): string {
+  return normalizeAccelerator(combo, platform);
 }
 
 function keyboardEventKeyName(e: KeyboardEvent): string | null {
   if (e.code === 'Space' || SPACE_KEYS.has(e.key)) return 'Space';
+  if (/^Key[A-Z]$/.test(e.code)) return e.code.slice(3);
+  if (/^Digit[0-9]$/.test(e.code)) return e.code.slice(5);
   if (e.key.length === 0) return null;
   return e.key;
 }

--- a/app/tests/fixtures/electron-mock.ts
+++ b/app/tests/fixtures/electron-mock.ts
@@ -46,6 +46,7 @@ export const BrowserWindow = {
 
 export const globalShortcut = {
   register: (): boolean => false,
+  isRegistered: (): boolean => false,
   unregister: (): void => undefined,
   unregisterAll: (): void => undefined,
 };

--- a/app/tests/unit/hub/SettingsPane.spec.tsx
+++ b/app/tests/unit/hub/SettingsPane.spec.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsPane } from '../../../src/renderer/hub/SettingsPane';
+import type { ActionId, KeyBinding } from '../../../src/renderer/hub/keybindings';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../../src/renderer/hub/ConnectionsPane', () => ({
+  ConnectionsPane: (): null => null,
+}));
+
+const createPaneBinding: KeyBinding = {
+  id: 'action.createPane',
+  label: 'New pane',
+  keys: ['Cmd+Shift+Space'],
+  category: 'Actions',
+};
+
+function installElectronApi(): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      shell: { platform: 'darwin' },
+      settings: {
+        app: {
+          getInfo: vi.fn(async () => null),
+          getUpdateStatus: vi.fn(async () => ({ status: 'idle' })),
+          onUpdateStatus: vi.fn(() => undefined),
+          downloadLatest: vi.fn(),
+          installUpdate: vi.fn(),
+        },
+        privacy: {
+          get: vi.fn(async () => ({ telemetry: false, telemetryUpdatedAt: null, version: 1 })),
+          setTelemetry: vi.fn(async (telemetry: boolean) => ({ telemetry, telemetryUpdatedAt: null, version: 1 })),
+          openSystemNotifications: vi.fn(async () => ({ ok: true })),
+        },
+      },
+      on: {},
+    },
+  });
+}
+
+function renderSettingsPane(onUpdateBinding: (id: ActionId, keys: string[]) => Promise<boolean>): {
+  container: HTMLDivElement;
+  root: Root;
+} {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SettingsPane
+        open
+        onClose={vi.fn()}
+        keybindings={[createPaneBinding]}
+        overrides={{}}
+        onUpdateBinding={onUpdateBinding}
+        onResetBinding={vi.fn()}
+        onResetAll={vi.fn()}
+        formatShortcut={(shortcut) => shortcut}
+      />,
+    );
+  });
+  return { container, root };
+}
+
+function keyButton(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>('.settings-pane__key-btn');
+  if (!button) throw new Error('Missing key binding button');
+  return button;
+}
+
+describe('SettingsPane shortcut recorder', () => {
+  beforeEach(() => {
+    installElectronApi();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('records a global shortcut with the same multi-key space capture used by onboarding', async () => {
+    const onUpdateBinding = vi.fn(async () => true);
+    const { container, root } = renderSettingsPane(onUpdateBinding);
+
+    act(() => {
+      keyButton(container).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(keyButton(container).textContent).toContain('Press key');
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: '\u00A0',
+        code: 'Space',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(onUpdateBinding).toHaveBeenCalledWith('action.createPane', ['Cmd+Alt+Space']);
+    expect(container.querySelector('.settings-pane__key-error')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it('shows an unavailable-shortcut error when the global save is rejected', async () => {
+    const onUpdateBinding = vi.fn(async () => false);
+    const { container, root } = renderSettingsPane(onUpdateBinding);
+
+    act(() => {
+      keyButton(container).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: ' ',
+        code: 'Space',
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(container.querySelector('.settings-pane__key-error')?.textContent).toBe(
+      'That shortcut is unavailable. Choose another one.',
+    );
+
+    act(() => root.unmount());
+  });
+});

--- a/app/tests/unit/hub/useVimKeys.spec.tsx
+++ b/app/tests/unit/hub/useVimKeys.spec.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVimKeys } from '../../../src/renderer/hub/useVimKeys';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function installElectronApi(accelerator = 'CommandOrControl+Alt+Space'): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      shell: { platform: 'darwin' },
+      hotkeys: {
+        getGlobalCmdbar: vi.fn(async () => accelerator),
+        setGlobalCmdbar: vi.fn(async (next: string) => ({ ok: true, accelerator: next })),
+      },
+      on: {
+        globalCmdbarChanged: vi.fn(() => undefined),
+      },
+      pill: {
+        toggle: vi.fn(),
+      },
+    },
+  });
+}
+
+function Harness({ onCreatePane }: { onCreatePane: () => void }): React.ReactElement {
+  useVimKeys({ 'action.createPane': onCreatePane });
+  return <input data-testid="task-input" />;
+}
+
+function renderHarness(onCreatePane: () => void): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Harness onCreatePane={onCreatePane} />);
+  });
+  return { container, root };
+}
+
+describe('useVimKeys global command fallback', () => {
+  beforeEach(() => {
+    installElectronApi();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('fires the configured command shortcut even when an input has focus', async () => {
+    const onCreatePane = vi.fn();
+    const { container, root } = renderHarness(onCreatePane);
+    const input = container.querySelector<HTMLInputElement>('[data-testid="task-input"]');
+    if (!input) throw new Error('Missing input');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    input.focus();
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: '\u00A0',
+        code: 'Space',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(onCreatePane).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+});

--- a/app/tests/unit/hub/useVimKeys.spec.tsx
+++ b/app/tests/unit/hub/useVimKeys.spec.tsx
@@ -3,15 +3,15 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useVimKeys } from '../../../src/renderer/hub/useVimKeys';
+import { useVimKeys, type VimKeysReturn } from '../../../src/renderer/hub/useVimKeys';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function installElectronApi(accelerator = 'CommandOrControl+Alt+Space'): void {
+function installElectronApi(accelerator = 'CommandOrControl+Alt+Space', platform = 'darwin'): void {
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
     value: {
-      shell: { platform: 'darwin' },
+      shell: { platform },
       hotkeys: {
         getGlobalCmdbar: vi.fn(async () => accelerator),
         setGlobalCmdbar: vi.fn(async (next: string) => ({ ok: true, accelerator: next })),
@@ -26,17 +26,18 @@ function installElectronApi(accelerator = 'CommandOrControl+Alt+Space'): void {
   });
 }
 
-function Harness({ onCreatePane }: { onCreatePane: () => void }): React.ReactElement {
-  useVimKeys({ 'action.createPane': onCreatePane });
+function Harness({ onCreatePane, onReady }: { onCreatePane: () => void; onReady?: (vim: VimKeysReturn) => void }): React.ReactElement {
+  const vim = useVimKeys({ 'action.createPane': onCreatePane });
+  onReady?.(vim);
   return <input data-testid="task-input" />;
 }
 
-function renderHarness(onCreatePane: () => void): { container: HTMLDivElement; root: Root } {
+function renderHarness(onCreatePane: () => void, onReady?: (vim: VimKeysReturn) => void): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(<Harness onCreatePane={onCreatePane} />);
+    root.render(<Harness onCreatePane={onCreatePane} onReady={onReady} />);
   });
   return { container, root };
 }
@@ -74,6 +75,24 @@ describe('useVimKeys global command fallback', () => {
     });
 
     expect(onCreatePane).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+
+  it('resets the global command shortcut to the shared desktop default on Linux', async () => {
+    installElectronApi('Alt+Space', 'linux');
+    let vim: VimKeysReturn | null = null;
+    const { root } = renderHarness(vi.fn(), (next) => { vim = next; });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      vim?.resetBinding('action.createPane');
+    });
+
+    expect(window.electronAPI?.hotkeys?.setGlobalCmdbar).toHaveBeenCalledWith('CommandOrControl+Shift+Space');
 
     act(() => root.unmount());
   });

--- a/app/tests/unit/identity/onboardingHandlers.test.ts
+++ b/app/tests/unit/identity/onboardingHandlers.test.ts
@@ -21,19 +21,31 @@ const {
   mockGlobalShortcut,
   mockOnPillVisibilityChange,
   mockTogglePill,
+  mockGetGlobalCmdbarAccelerator,
+  mockRegisterHotkeys,
   mockSetGlobalCmdbarAccelerator,
-} = vi.hoisted(() => ({
-  loggerSpy: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  mockCreatePillWindow: vi.fn(),
-  mockGlobalShortcut: {
-    register: vi.fn((_accelerator: string, _callback: () => void) => true),
-    isRegistered: vi.fn((_accelerator: string) => true),
-    unregister: vi.fn(),
-  },
-  mockOnPillVisibilityChange: vi.fn(),
-  mockTogglePill: vi.fn(),
-  mockSetGlobalCmdbarAccelerator: vi.fn((accelerator: string) => ({ ok: true, accelerator })),
-}));
+  hotkeyState,
+} = vi.hoisted(() => {
+  const state = { accelerator: 'CommandOrControl+Shift+Space' };
+  return {
+    loggerSpy: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    mockCreatePillWindow: vi.fn(),
+    mockGlobalShortcut: {
+      register: vi.fn((_accelerator: string, _callback: () => void) => true),
+      isRegistered: vi.fn((_accelerator: string) => true),
+      unregister: vi.fn(),
+    },
+    mockOnPillVisibilityChange: vi.fn(),
+    mockTogglePill: vi.fn(),
+    hotkeyState: state,
+    mockGetGlobalCmdbarAccelerator: vi.fn(() => state.accelerator),
+    mockRegisterHotkeys: vi.fn((_callback: () => void) => true),
+    mockSetGlobalCmdbarAccelerator: vi.fn((accelerator: string) => {
+      state.accelerator = accelerator;
+      return { ok: true, accelerator };
+    }),
+  };
+});
 
 vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
 
@@ -66,6 +78,8 @@ vi.mock('../../../src/main/pill', () => ({
 }));
 
 vi.mock('../../../src/main/hotkeys', () => ({
+  getGlobalCmdbarAccelerator: mockGetGlobalCmdbarAccelerator,
+  registerHotkeys: mockRegisterHotkeys,
   setGlobalCmdbarAccelerator: mockSetGlobalCmdbarAccelerator,
 }));
 
@@ -109,10 +123,6 @@ async function invokeHandler(channel: string, ...args: unknown[]): Promise<unkno
   return handler({} as never, ...args);
 }
 
-const EXPECTED_DEFAULT_ACCELERATOR = process.platform === 'linux'
-  ? 'Alt+Space'
-  : 'CommandOrControl+Shift+Space';
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -127,7 +137,12 @@ describe('onboardingHandlers.ts', () => {
     vi.clearAllMocks();
     mockGlobalShortcut.register.mockReturnValue(true);
     mockGlobalShortcut.isRegistered.mockReturnValue(true);
-    mockSetGlobalCmdbarAccelerator.mockImplementation((accelerator: string) => ({ ok: true, accelerator }));
+    hotkeyState.accelerator = 'CommandOrControl+Shift+Space';
+    mockRegisterHotkeys.mockReturnValue(true);
+    mockSetGlobalCmdbarAccelerator.mockImplementation((accelerator: string) => {
+      hotkeyState.accelerator = accelerator;
+      return { ok: true, accelerator };
+    });
     handlers.clear();
     accountStore = makeAccountStore();
     onboardingWindow = makeWindow();
@@ -183,11 +198,11 @@ describe('onboardingHandlers.ts', () => {
       expect(openShellWindow).toHaveBeenCalled();
     });
 
-    it('unregisters the temporary onboarding shortcut before opening the shell', async () => {
+    it('keeps the shared hotkey manager registered when opening the shell', async () => {
       await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space');
       mockGlobalShortcut.unregister.mockClear();
       openShellWindow.mockImplementation(() => {
-        expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith('CommandOrControl+Alt+Space');
+        expect(mockGlobalShortcut.unregister).not.toHaveBeenCalled();
         return { id: 2 };
       });
 
@@ -213,76 +228,28 @@ describe('onboardingHandlers.ts', () => {
   });
 
   describe('shortcut setup handlers', () => {
-    it('keeps the selected accelerator when the shortcut step listens again', async () => {
-      await invokeHandler('onboarding:listen-shortcut');
+    it('registers the onboarding callback through the shared hotkey manager', async () => {
+      const result = await invokeHandler('onboarding:listen-shortcut') as { ok: boolean; accelerator: string };
 
-      const setResult = await invokeHandler('onboarding:set-shortcut', 'Alt+Space') as { ok: boolean; accelerator: string };
-      expect(setResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
-      expect(mockSetGlobalCmdbarAccelerator).toHaveBeenCalledWith('Alt+Space');
-
-      const listenResult = await invokeHandler('onboarding:listen-shortcut') as { ok: boolean; accelerator: string };
-      expect(listenResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
-      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
+      expect(result).toEqual({ ok: true, accelerator: 'CommandOrControl+Shift+Space' });
+      expect(mockCreatePillWindow).toHaveBeenCalledTimes(1);
+      expect(mockRegisterHotkeys).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    it('rolls back to the previous accelerator when registration fails', async () => {
-      await invokeHandler('onboarding:set-shortcut', 'Alt+Space');
-
-      mockGlobalShortcut.register.mockImplementation((accelerator: string) => accelerator !== 'CommandOrControl+Alt+Space');
-
+    it('persists selected shortcuts through the same manager used by settings', async () => {
       const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space') as { ok: boolean; accelerator: string };
 
-      expect(result).toEqual({ ok: false, accelerator: 'Alt+Space' });
-      expect(mockGlobalShortcut.unregister).toHaveBeenLastCalledWith('Alt+Space');
-      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
+      expect(result).toEqual({ ok: true, accelerator: 'CommandOrControl+Alt+Space' });
+      expect(mockRegisterHotkeys).toHaveBeenCalledWith(expect.any(Function));
+      expect(mockSetGlobalCmdbarAccelerator).toHaveBeenCalledWith('CommandOrControl+Alt+Space');
+      expect(mockGlobalShortcut.register).not.toHaveBeenCalled();
     });
 
-    it('does not treat a failed rollback as an active registration', async () => {
-      await invokeHandler('onboarding:set-shortcut', 'Alt+Space');
-
-      mockGlobalShortcut.register.mockReturnValue(true);
-      mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => {
-        return accelerator !== 'CommandOrControl+Alt+Space' && accelerator !== 'Alt+Space';
-      });
-
-      const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space') as { ok: boolean; accelerator: string };
-
-      expect(result).toEqual({ ok: false, accelerator: 'Alt+Space' });
-      expect(loggerSpy.warn).toHaveBeenCalledWith(
-        'onboardingHandlers.shortcutRollback.failed',
-        { accelerator: 'Alt+Space' },
-      );
-
-      mockGlobalShortcut.unregister.mockClear();
-      mockGlobalShortcut.register.mockReturnValue(true);
-      mockGlobalShortcut.isRegistered.mockReturnValue(true);
-
-      const listenResult = await invokeHandler('onboarding:listen-shortcut') as { ok: boolean; accelerator: string };
-
-      expect(listenResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
-      expect(mockGlobalShortcut.unregister).not.toHaveBeenCalled();
-      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
-    });
-
-    it('treats portal registration as failed when Electron does not report it registered', async () => {
-      mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => accelerator !== 'Alt+Space');
-
+    it('returns the manager result when a shortcut cannot be registered', async () => {
+      mockSetGlobalCmdbarAccelerator.mockImplementation(() => ({ ok: false, accelerator: 'Alt+Space' }));
       const result = await invokeHandler('onboarding:set-shortcut', 'Alt+Space') as { ok: boolean; accelerator: string };
 
-      expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
-    });
-
-    it('returns the previous accelerator when Electron rejects an invalid accelerator', async () => {
-      mockGlobalShortcut.register.mockImplementation((accelerator: string) => {
-        if (accelerator === 'CommandOrControl+Unidentified') {
-          throw new TypeError('conversion failure');
-        }
-        return true;
-      });
-
-      const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Unidentified') as { ok: boolean; accelerator: string };
-
-      expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+      expect(result).toEqual({ ok: false, accelerator: 'Alt+Space' });
     });
 
     it('lets the onboarding window trigger the shortcut as a focused-window fallback', async () => {

--- a/app/tests/unit/identity/onboardingHandlers.test.ts
+++ b/app/tests/unit/identity/onboardingHandlers.test.ts
@@ -15,8 +15,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { loggerSpy } = vi.hoisted(() => ({
+const {
+  loggerSpy,
+  mockCreatePillWindow,
+  mockGlobalShortcut,
+  mockOnPillVisibilityChange,
+  mockTogglePill,
+  mockSetGlobalCmdbarAccelerator,
+} = vi.hoisted(() => ({
   loggerSpy: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  mockCreatePillWindow: vi.fn(),
+  mockGlobalShortcut: {
+    register: vi.fn((_accelerator: string, _callback: () => void) => true),
+    isRegistered: vi.fn((_accelerator: string) => true),
+    unregister: vi.fn(),
+  },
+  mockOnPillVisibilityChange: vi.fn(),
+  mockTogglePill: vi.fn(),
+  mockSetGlobalCmdbarAccelerator: vi.fn((accelerator: string) => ({ ok: true, accelerator })),
 }));
 
 vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
@@ -33,6 +49,24 @@ vi.mock('electron', () => ({
     }),
   },
   BrowserWindow: class {},
+  Notification: class {
+    static isSupported = vi.fn(() => true);
+    show = vi.fn();
+  },
+  globalShortcut: mockGlobalShortcut,
+  shell: {
+    openExternal: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../src/main/pill', () => ({
+  createPillWindow: mockCreatePillWindow,
+  onPillVisibilityChange: mockOnPillVisibilityChange,
+  togglePill: mockTogglePill,
+}));
+
+vi.mock('../../../src/main/hotkeys', () => ({
+  setGlobalCmdbarAccelerator: mockSetGlobalCmdbarAccelerator,
 }));
 
 const mockSetPassword = vi.fn(async () => {});
@@ -63,6 +97,9 @@ function makeWindow(destroyed = false) {
     id: 1,
     isDestroyed: vi.fn(() => destroyed),
     close: vi.fn(),
+    webContents: {
+      send: vi.fn(),
+    },
   };
 }
 
@@ -71,6 +108,10 @@ async function invokeHandler(channel: string, ...args: unknown[]): Promise<unkno
   if (!handler) throw new Error(`No handler registered: ${channel}`);
   return handler({} as never, ...args);
 }
+
+const EXPECTED_DEFAULT_ACCELERATOR = process.platform === 'linux'
+  ? 'Alt+Space'
+  : 'CommandOrControl+Shift+Space';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -84,6 +125,9 @@ describe('onboardingHandlers.ts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGlobalShortcut.register.mockReturnValue(true);
+    mockGlobalShortcut.isRegistered.mockReturnValue(true);
+    mockSetGlobalCmdbarAccelerator.mockImplementation((accelerator: string) => ({ ok: true, accelerator }));
     handlers.clear();
     accountStore = makeAccountStore();
     onboardingWindow = makeWindow();
@@ -108,6 +152,10 @@ describe('onboardingHandlers.ts', () => {
     it('registers onboarding:complete', () => {
       expect(handlers.has('onboarding:complete')).toBe(true);
     });
+
+    it('registers onboarding:trigger-shortcut', () => {
+      expect(handlers.has('onboarding:trigger-shortcut')).toBe(true);
+    });
   });
 
   describe('unregisterOnboardingHandlers()', () => {
@@ -116,6 +164,7 @@ describe('onboardingHandlers.ts', () => {
       expect(handlers.has('onboarding:save-api-key')).toBe(false);
       expect(handlers.has('onboarding:test-api-key')).toBe(false);
       expect(handlers.has('onboarding:complete')).toBe(false);
+      expect(handlers.has('onboarding:trigger-shortcut')).toBe(false);
     });
   });
 
@@ -134,6 +183,19 @@ describe('onboardingHandlers.ts', () => {
       expect(openShellWindow).toHaveBeenCalled();
     });
 
+    it('unregisters the temporary onboarding shortcut before opening the shell', async () => {
+      await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space');
+      mockGlobalShortcut.unregister.mockClear();
+      openShellWindow.mockImplementation(() => {
+        expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith('CommandOrControl+Alt+Space');
+        return { id: 2 };
+      });
+
+      await invokeHandler('onboarding:complete');
+
+      expect(openShellWindow).toHaveBeenCalled();
+    });
+
     it('closes onboarding window when not destroyed', async () => {
       await invokeHandler('onboarding:complete');
       expect(onboardingWindow.close).toHaveBeenCalled();
@@ -147,6 +209,87 @@ describe('onboardingHandlers.ts', () => {
 
       await invokeHandler('onboarding:complete');
       expect(onboardingWindow.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shortcut setup handlers', () => {
+    it('keeps the selected accelerator when the shortcut step listens again', async () => {
+      await invokeHandler('onboarding:listen-shortcut');
+
+      const setResult = await invokeHandler('onboarding:set-shortcut', 'Alt+Space') as { ok: boolean; accelerator: string };
+      expect(setResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
+      expect(mockSetGlobalCmdbarAccelerator).toHaveBeenCalledWith('Alt+Space');
+
+      const listenResult = await invokeHandler('onboarding:listen-shortcut') as { ok: boolean; accelerator: string };
+      expect(listenResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
+      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
+    });
+
+    it('rolls back to the previous accelerator when registration fails', async () => {
+      await invokeHandler('onboarding:set-shortcut', 'Alt+Space');
+
+      mockGlobalShortcut.register.mockImplementation((accelerator: string) => accelerator !== 'CommandOrControl+Alt+Space');
+
+      const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space') as { ok: boolean; accelerator: string };
+
+      expect(result).toEqual({ ok: false, accelerator: 'Alt+Space' });
+      expect(mockGlobalShortcut.unregister).toHaveBeenLastCalledWith('Alt+Space');
+      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
+    });
+
+    it('does not treat a failed rollback as an active registration', async () => {
+      await invokeHandler('onboarding:set-shortcut', 'Alt+Space');
+
+      mockGlobalShortcut.register.mockReturnValue(true);
+      mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => {
+        return accelerator !== 'CommandOrControl+Alt+Space' && accelerator !== 'Alt+Space';
+      });
+
+      const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Alt+Space') as { ok: boolean; accelerator: string };
+
+      expect(result).toEqual({ ok: false, accelerator: 'Alt+Space' });
+      expect(loggerSpy.warn).toHaveBeenCalledWith(
+        'onboardingHandlers.shortcutRollback.failed',
+        { accelerator: 'Alt+Space' },
+      );
+
+      mockGlobalShortcut.unregister.mockClear();
+      mockGlobalShortcut.register.mockReturnValue(true);
+      mockGlobalShortcut.isRegistered.mockReturnValue(true);
+
+      const listenResult = await invokeHandler('onboarding:listen-shortcut') as { ok: boolean; accelerator: string };
+
+      expect(listenResult).toEqual({ ok: true, accelerator: 'Alt+Space' });
+      expect(mockGlobalShortcut.unregister).not.toHaveBeenCalled();
+      expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith('Alt+Space', expect.any(Function));
+    });
+
+    it('treats portal registration as failed when Electron does not report it registered', async () => {
+      mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => accelerator !== 'Alt+Space');
+
+      const result = await invokeHandler('onboarding:set-shortcut', 'Alt+Space') as { ok: boolean; accelerator: string };
+
+      expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+    });
+
+    it('returns the previous accelerator when Electron rejects an invalid accelerator', async () => {
+      mockGlobalShortcut.register.mockImplementation((accelerator: string) => {
+        if (accelerator === 'CommandOrControl+Unidentified') {
+          throw new TypeError('conversion failure');
+        }
+        return true;
+      });
+
+      const result = await invokeHandler('onboarding:set-shortcut', 'CommandOrControl+Unidentified') as { ok: boolean; accelerator: string };
+
+      expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+    });
+
+    it('lets the onboarding window trigger the shortcut as a focused-window fallback', async () => {
+      const result = await invokeHandler('onboarding:trigger-shortcut') as { ok: boolean };
+
+      expect(result).toEqual({ ok: true });
+      expect(mockTogglePill).toHaveBeenCalled();
     });
   });
 });

--- a/app/tests/unit/main/hotkeys.test.ts
+++ b/app/tests/unit/main/hotkeys.test.ts
@@ -88,6 +88,39 @@ describe('main/hotkeys.ts', () => {
     expect(hotkeys.getGlobalCmdbarAccelerator()).toBe(CUSTOM_ACCELERATOR);
   });
 
+  it('swaps callbacks without re-registering an already active shortcut', async () => {
+    const hotkeys = await loadHotkeys();
+    const onboardingCallback = vi.fn();
+    const shellCallback = vi.fn();
+
+    expect(hotkeys.registerHotkeys(onboardingCallback)).toBe(true);
+    expect(hotkeys.registerHotkeys(shellCallback)).toBe(true);
+
+    expect(mockGlobalShortcut.unregister).not.toHaveBeenCalled();
+    expect(mockGlobalShortcut.register).toHaveBeenCalledTimes(1);
+
+    const registeredCallback = mockGlobalShortcut.register.mock.calls[0][1] as () => void;
+    registeredCallback();
+
+    expect(onboardingCallback).not.toHaveBeenCalled();
+    expect(shellCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes duplicated modifiers from older saved shortcuts before registering', async () => {
+    fs.writeFileSync(
+      hotkeysStorePath(),
+      JSON.stringify({ globalCmdbar: 'CommandOrControl+CommandOrControl+Alt+Space' }),
+      'utf-8',
+    );
+    const hotkeys = await loadHotkeys();
+
+    expect(hotkeys.registerHotkeys(vi.fn())).toBe(true);
+
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(CUSTOM_ACCELERATOR, expect.any(Function));
+    expect(hotkeys.getGlobalCmdbarAccelerator()).toBe(CUSTOM_ACCELERATOR);
+    expect(readSavedAccelerator()).toBe(CUSTOM_ACCELERATOR);
+  });
+
   it('repairs a saved shortcut when Electron no longer reports it registered', async () => {
     const hotkeys = await loadHotkeys();
     const callback = vi.fn();

--- a/app/tests/unit/main/hotkeys.test.ts
+++ b/app/tests/unit/main/hotkeys.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  loggerSpy,
+  mockGlobalShortcut,
+  userDataPath,
+} = vi.hoisted(() => ({
+  loggerSpy: { info: vi.fn(), warn: vi.fn() },
+  mockGlobalShortcut: {
+    register: vi.fn((_accelerator: string, _callback: () => void) => true),
+    isRegistered: vi.fn((_accelerator: string) => true),
+    unregister: vi.fn(),
+  },
+  userDataPath: `/tmp/BrowserUseDesktop-hotkeys-test-${process.pid}`,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((_name: string) => userDataPath),
+  },
+  globalShortcut: mockGlobalShortcut,
+}));
+
+vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
+
+const EXPECTED_DEFAULT_ACCELERATOR = process.platform === 'linux'
+  ? 'Alt+Space'
+  : 'CommandOrControl+Shift+Space';
+
+const CUSTOM_ACCELERATOR = 'CommandOrControl+Alt+Space';
+
+function hotkeysStorePath(): string {
+  return path.join(userDataPath, 'hotkeys.json');
+}
+
+async function loadHotkeys() {
+  vi.resetModules();
+  return import('../../../src/main/hotkeys');
+}
+
+function readSavedAccelerator(): string | null {
+  try {
+    const raw = fs.readFileSync(hotkeysStorePath(), 'utf-8');
+    return (JSON.parse(raw) as { globalCmdbar?: string }).globalCmdbar ?? null;
+  } catch {
+    return null;
+  }
+}
+
+describe('main/hotkeys.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(userDataPath, { recursive: true, force: true });
+    fs.mkdirSync(userDataPath, { recursive: true });
+    mockGlobalShortcut.register.mockReturnValue(true);
+    mockGlobalShortcut.isRegistered.mockReturnValue(true);
+  });
+
+  it('persists onboarding-selected shortcuts before the app hotkey callback exists', async () => {
+    const hotkeys = await loadHotkeys();
+
+    const result = hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    expect(result).toEqual({ ok: true, accelerator: CUSTOM_ACCELERATOR });
+    expect(readSavedAccelerator()).toBe(CUSTOM_ACCELERATOR);
+    expect(mockGlobalShortcut.register).not.toHaveBeenCalled();
+
+    const reloadedHotkeys = await loadHotkeys();
+    const callback = vi.fn();
+
+    expect(reloadedHotkeys.registerHotkeys(callback)).toBe(true);
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(CUSTOM_ACCELERATOR, expect.any(Function));
+  });
+
+  it('re-registers and saves settings changes once the app callback exists', async () => {
+    const hotkeys = await loadHotkeys();
+    const callback = vi.fn();
+    hotkeys.registerHotkeys(callback);
+
+    const result = hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    expect(result).toEqual({ ok: true, accelerator: CUSTOM_ACCELERATOR });
+    expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith(EXPECTED_DEFAULT_ACCELERATOR);
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(CUSTOM_ACCELERATOR, expect.any(Function));
+    expect(readSavedAccelerator()).toBe(CUSTOM_ACCELERATOR);
+    expect(hotkeys.getGlobalCmdbarAccelerator()).toBe(CUSTOM_ACCELERATOR);
+  });
+
+  it('repairs a saved shortcut when Electron no longer reports it registered', async () => {
+    const hotkeys = await loadHotkeys();
+    const callback = vi.fn();
+    hotkeys.registerHotkeys(callback);
+    hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    mockGlobalShortcut.register.mockClear();
+    mockGlobalShortcut.unregister.mockClear();
+    mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => accelerator !== CUSTOM_ACCELERATOR);
+
+    const result = hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+    expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith(CUSTOM_ACCELERATOR);
+    expect(mockGlobalShortcut.register).toHaveBeenCalledWith(CUSTOM_ACCELERATOR, expect.any(Function));
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(EXPECTED_DEFAULT_ACCELERATOR, expect.any(Function));
+    expect(readSavedAccelerator()).toBe(EXPECTED_DEFAULT_ACCELERATOR);
+  });
+
+  it('falls back to the default when the saved startup shortcut is unavailable', async () => {
+    const hotkeys = await loadHotkeys();
+    hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    const reloadedHotkeys = await loadHotkeys();
+    const callback = vi.fn();
+    mockGlobalShortcut.register.mockImplementation((accelerator: string) => accelerator !== CUSTOM_ACCELERATOR);
+
+    expect(reloadedHotkeys.registerHotkeys(callback)).toBe(true);
+    expect(mockGlobalShortcut.register).toHaveBeenCalledWith(CUSTOM_ACCELERATOR, expect.any(Function));
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(EXPECTED_DEFAULT_ACCELERATOR, expect.any(Function));
+    expect(reloadedHotkeys.getGlobalCmdbarAccelerator()).toBe(EXPECTED_DEFAULT_ACCELERATOR);
+    expect(readSavedAccelerator()).toBe(EXPECTED_DEFAULT_ACCELERATOR);
+  });
+
+  it('rolls back to the previously registered shortcut when a settings change fails', async () => {
+    const hotkeys = await loadHotkeys();
+    const callback = vi.fn();
+    hotkeys.registerHotkeys(callback);
+
+    mockGlobalShortcut.register.mockImplementation((accelerator: string) => accelerator !== CUSTOM_ACCELERATOR);
+
+    const result = hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+    expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith(EXPECTED_DEFAULT_ACCELERATOR);
+    expect(mockGlobalShortcut.register).toHaveBeenLastCalledWith(EXPECTED_DEFAULT_ACCELERATOR, expect.any(Function));
+    expect(readSavedAccelerator()).not.toBe(CUSTOM_ACCELERATOR);
+    expect(hotkeys.getGlobalCmdbarAccelerator()).toBe(EXPECTED_DEFAULT_ACCELERATOR);
+  });
+
+  it('does not unregister a failed rollback that Electron never actually registered', async () => {
+    const hotkeys = await loadHotkeys();
+    const callback = vi.fn();
+    hotkeys.registerHotkeys(callback);
+
+    mockGlobalShortcut.register.mockReturnValue(true);
+    mockGlobalShortcut.isRegistered.mockImplementation((accelerator: string) => {
+      return accelerator !== CUSTOM_ACCELERATOR && accelerator !== EXPECTED_DEFAULT_ACCELERATOR;
+    });
+
+    const result = hotkeys.setGlobalCmdbarAccelerator(CUSTOM_ACCELERATOR);
+
+    expect(result).toEqual({ ok: false, accelerator: EXPECTED_DEFAULT_ACCELERATOR });
+    expect(loggerSpy.warn).toHaveBeenCalledWith('hotkeys.set.failed', { hotkey: CUSTOM_ACCELERATOR });
+
+    mockGlobalShortcut.unregister.mockClear();
+    hotkeys.unregisterHotkeys();
+
+    expect(mockGlobalShortcut.unregister).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/unit/main/hotkeys.test.ts
+++ b/app/tests/unit/main/hotkeys.test.ts
@@ -25,9 +25,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../../../src/main/logger', () => ({ mainLogger: loggerSpy }));
 
-const EXPECTED_DEFAULT_ACCELERATOR = process.platform === 'linux'
-  ? 'Alt+Space'
-  : 'CommandOrControl+Shift+Space';
+const EXPECTED_DEFAULT_ACCELERATOR = 'CommandOrControl+Shift+Space';
 
 const CUSTOM_ACCELERATOR = 'CommandOrControl+Alt+Space';
 

--- a/app/tests/unit/shared/hotkeys.test.ts
+++ b/app/tests/unit/shared/hotkeys.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   acceleratorToDisplayParts,
+  defaultGlobalCmdbarAccelerator,
   formatShortcutForPlatform,
   keyboardEventToShortcut,
+  normalizeShortcutPlatform,
+  rendererToAccelerator,
   shortcutToRenderer,
 } from '../../../src/shared/hotkeys';
 
@@ -10,6 +13,8 @@ describe('acceleratorToDisplayParts', () => {
   it('uses text labels for Linux and Windows modifiers', () => {
     expect(acceleratorToDisplayParts('Alt+Space', 'linux')).toEqual(['Alt', 'Space']);
     expect(acceleratorToDisplayParts('CommandOrControl+Shift+Space', 'win32')).toEqual(['Ctrl', 'Shift', 'Space']);
+    expect(acceleratorToDisplayParts('Super+Space', 'linux')).toEqual(['Super', 'Space']);
+    expect(acceleratorToDisplayParts('Super+Space', 'win32')).toEqual(['Win', 'Space']);
   });
 
   it('uses macOS glyphs only on macOS', () => {
@@ -18,9 +23,27 @@ describe('acceleratorToDisplayParts', () => {
 });
 
 describe('shortcut platform normalization', () => {
+  it('normalizes Electron and browser platform names', () => {
+    expect(normalizeShortcutPlatform('darwin')).toBe('darwin');
+    expect(normalizeShortcutPlatform('MacIntel')).toBe('darwin');
+    expect(normalizeShortcutPlatform('win32')).toBe('win32');
+    expect(normalizeShortcutPlatform('Win32')).toBe('win32');
+    expect(normalizeShortcutPlatform('Linux x86_64')).toBe('linux');
+  });
+
+  it('uses Alt+Space as the Linux default and keeps the existing default elsewhere', () => {
+    expect(defaultGlobalCmdbarAccelerator('linux')).toBe('Alt+Space');
+    expect(defaultGlobalCmdbarAccelerator('Linux x86_64')).toBe('Alt+Space');
+    expect(defaultGlobalCmdbarAccelerator('darwin')).toBe('CommandOrControl+Shift+Space');
+    expect(defaultGlobalCmdbarAccelerator('win32')).toBe('CommandOrControl+Shift+Space');
+  });
+
+
   it('keeps shortcuts platform-neutral until renderer normalization', () => {
     expect(shortcutToRenderer('CommandOrControl+,', 'darwin')).toBe('Cmd+,');
     expect(shortcutToRenderer('CommandOrControl+,', 'linux')).toBe('Ctrl+,');
+    expect(shortcutToRenderer('Meta+Space', 'linux')).toBe('Super+Space');
+    expect(shortcutToRenderer('Meta+Space', 'win32')).toBe('Win+Space');
   });
 
   it('formats all shortcut labels through the same platform policy', () => {
@@ -32,6 +55,7 @@ describe('shortcut platform normalization', () => {
   it('captures keyboard events into renderer shortcut strings', () => {
     const event = {
       key: ' ',
+      code: 'Space',
       metaKey: false,
       ctrlKey: false,
       altKey: true,
@@ -39,5 +63,64 @@ describe('shortcut platform normalization', () => {
     } as KeyboardEvent;
 
     expect(keyboardEventToShortcut(event, 'linux')).toBe('Alt+Space');
+  });
+
+  it('captures macOS option-space as Space instead of a non-breaking-space glyph', () => {
+    const event = {
+      key: '\u00A0',
+      code: 'Space',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: true,
+      shiftKey: false,
+    } as KeyboardEvent;
+
+    const shortcut = keyboardEventToShortcut(event, 'darwin');
+
+    expect(shortcut).toBe('Cmd+Alt+Space');
+    expect(rendererToAccelerator(shortcut ?? '')).toBe('CommandOrControl+Alt+Space');
+  });
+
+  it('keeps shift when capturing space shortcuts', () => {
+    const event = {
+      key: ' ',
+      code: 'Space',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: true,
+    } as KeyboardEvent;
+
+    const shortcut = keyboardEventToShortcut(event, 'darwin');
+
+    expect(shortcut).toBe('Cmd+Shift+Space');
+    expect(rendererToAccelerator(shortcut ?? '')).toBe('CommandOrControl+Shift+Space');
+  });
+
+  it('ignores unidentified keys during shortcut capture', () => {
+    const event = {
+      key: 'Unidentified',
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+    } as KeyboardEvent;
+
+    expect(keyboardEventToShortcut(event, 'linux')).toBeNull();
+  });
+
+  it('captures non-macOS meta shortcuts with platform-native labels', () => {
+    const event = {
+      key: ' ',
+      code: 'Space',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    } as KeyboardEvent;
+
+    expect(keyboardEventToShortcut(event, 'linux')).toBe('Super+Space');
+    expect(keyboardEventToShortcut(event, 'win32')).toBe('Win+Space');
+    expect(rendererToAccelerator('Win+Space')).toBe('Super+Space');
   });
 });

--- a/app/tests/unit/shared/hotkeys.test.ts
+++ b/app/tests/unit/shared/hotkeys.test.ts
@@ -4,6 +4,7 @@ import {
   defaultGlobalCmdbarAccelerator,
   formatShortcutForPlatform,
   keyboardEventToShortcut,
+  normalizeAccelerator,
   normalizeShortcutPlatform,
   rendererToAccelerator,
   shortcutToRenderer,
@@ -79,6 +80,18 @@ describe('shortcut platform normalization', () => {
 
     expect(shortcut).toBe('Cmd+Alt+Space');
     expect(rendererToAccelerator(shortcut ?? '')).toBe('CommandOrControl+Alt+Space');
+  });
+
+  it('normalizes duplicated command modifiers in saved accelerators', () => {
+    expect(normalizeAccelerator('CommandOrControl+CommandOrControl+Alt+Space', 'darwin')).toBe(
+      'CommandOrControl+Alt+Space',
+    );
+  });
+
+  it('preserves a physical Control modifier on macOS when platform is explicit', () => {
+    expect(rendererToAccelerator('Cmd+Ctrl+Alt+Space', 'darwin')).toBe(
+      'CommandOrControl+Control+Alt+Space',
+    );
   });
 
   it('keeps shift when capturing space shortcuts', () => {

--- a/app/tests/unit/shared/hotkeys.test.ts
+++ b/app/tests/unit/shared/hotkeys.test.ts
@@ -32,9 +32,9 @@ describe('shortcut platform normalization', () => {
     expect(normalizeShortcutPlatform('Linux x86_64')).toBe('linux');
   });
 
-  it('uses Alt+Space as the Linux default and keeps the existing default elsewhere', () => {
-    expect(defaultGlobalCmdbarAccelerator('linux')).toBe('Alt+Space');
-    expect(defaultGlobalCmdbarAccelerator('Linux x86_64')).toBe('Alt+Space');
+  it('uses the same global command-bar default on desktop platforms', () => {
+    expect(defaultGlobalCmdbarAccelerator('linux')).toBe('CommandOrControl+Shift+Space');
+    expect(defaultGlobalCmdbarAccelerator('Linux x86_64')).toBe('CommandOrControl+Shift+Space');
     expect(defaultGlobalCmdbarAccelerator('darwin')).toBe('CommandOrControl+Shift+Space');
     expect(defaultGlobalCmdbarAccelerator('win32')).toBe('CommandOrControl+Shift+Space');
   });
@@ -92,6 +92,11 @@ describe('shortcut platform normalization', () => {
     expect(rendererToAccelerator('Cmd+Ctrl+Alt+Space', 'darwin')).toBe(
       'CommandOrControl+Control+Alt+Space',
     );
+  });
+
+  it('keeps renderer Cmd labels ctrl-equivalent on Windows and Linux', () => {
+    expect(rendererToAccelerator('Cmd+Shift+Space', 'linux')).toBe('CommandOrControl+Shift+Space');
+    expect(rendererToAccelerator('Command+Shift+Space', 'win32')).toBe('CommandOrControl+Shift+Space');
   });
 
   it('keeps shift when capturing space shortcuts', () => {

--- a/app/tests/unit/startup/chromiumFeatures.test.ts
+++ b/app/tests/unit/startup/chromiumFeatures.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { mergeChromiumFeature } from '../../../src/main/startup/chromiumFeatures';
+
+describe('mergeChromiumFeature', () => {
+  it('adds a feature when no features are enabled yet', () => {
+    expect(mergeChromiumFeature('', 'GlobalShortcutsPortal')).toBe('GlobalShortcutsPortal');
+  });
+
+  it('preserves existing Chromium feature flags when adding a feature', () => {
+    expect(mergeChromiumFeature('WaylandWindowDecorations,UseOzonePlatform', 'GlobalShortcutsPortal')).toBe(
+      'WaylandWindowDecorations,UseOzonePlatform,GlobalShortcutsPortal',
+    );
+  });
+
+  it('does not duplicate an already-enabled feature', () => {
+    expect(mergeChromiumFeature('WaylandWindowDecorations,GlobalShortcutsPortal', 'GlobalShortcutsPortal')).toBe(
+      'WaylandWindowDecorations,GlobalShortcutsPortal',
+    );
+  });
+
+  it('normalizes spacing and empty feature-list entries', () => {
+    expect(mergeChromiumFeature(' WaylandWindowDecorations, ,UseOzonePlatform ', 'GlobalShortcutsPortal')).toBe(
+      'WaylandWindowDecorations,UseOzonePlatform,GlobalShortcutsPortal',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #384.

This updates shortcut setup so Linux and Windows users do not see macOS-specific modifier glyphs and so the onboarding shortcut recorder does not get stuck in `Press keys...` when a desktop environment swallows or reports a shortcut as `Unidentified`.

The main behavior changes are:

- show platform-appropriate modifier labels (`Alt`, `Ctrl`, `Shift`, `Super`/`Win`) and keep macOS glyphs macOS-only
- use `Alt+Space` as the Linux default instead of `CommandOrControl+Shift+Space`, which was not delivered reliably in the reported Arch/Hyprland setup
- preserve the selected onboarding shortcut when the shortcut step remounts instead of resetting back to the default
- detect failed global shortcut registration by checking `globalShortcut.isRegistered()` after `register()`
- ignore `Unidentified` key captures and time out recording after 8 seconds so the setup UI does not remain stuck
- add a focused onboarding-window fallback that can open the pill while the shortcut setup window is focused, even if the OS-level global shortcut backend does not deliver activation
- enable Chromium's `GlobalShortcutsPortal` feature on Linux so Electron can use the Wayland portal path documented for `globalShortcut`

## Why

The original issue had two visible problems on Linux:

1. `Alt+Space` rendered as `⌥ + Space`, which is a macOS-specific symbol and misleading on Linux/Windows.
2. After setting a shortcut, pressing it to test setup could re-enter capture mode, leaving the user stuck on `Press keys...` instead of opening the pill.

While testing this, `Ctrl+Shift+Space` also proved to be a poor Linux default on the reported environment: it neither triggered the global shortcut nor arrived as a normal focused-window key event. `Alt+Space` did arrive in the renderer and allowed the focused onboarding fallback to validate the setup flow.

## Testing

Automated checks run locally:

- `npm run test -- tests/unit/shared/hotkeys.test.ts`
- `npm run test -- tests/unit/identity/onboardingHandlers.test.ts`
- `npm run typecheck`
- `npm run qa`

Manual testing performed on:

- Arch Linux
- Hyprland / Wayland
- Electron dev build launched with isolated `AGB_USER_DATA_DIR`

Manual results on that setup:

- Linux shortcut setup defaults to `Alt + Space`
- `Alt+Space` records and displays as `Alt + Space`, not `⌥ + Space`
- focused onboarding-window fallback opens the pill with `Alt+Space`
- capture no longer loops back into `Press keys...` after a successful capture
- unsupported/swallowed combinations no longer leave the recorder stuck indefinitely

Important caveat: on this Arch + Hyprland machine, Electron/Hyprland listed global shortcut portal registrations, but activation did not reach Electron when the Browser Use window was unfocused. That appears to be a separate Electron + XDG GlobalShortcutsPortal + Hyprland integration issue rather than the onboarding UI bug fixed here.

## Requested reviewer testing

Please test this PR beyond the reported setup, especially:

- Linux GNOME Wayland
- Linux KDE Wayland
- Linux X11/XWayland
- Windows
- macOS, to confirm the existing glyph/default behavior is unchanged

Specific scenarios to verify:

- initial onboarding shortcut display is platform-appropriate
- Linux default is usable and does not show macOS glyphs
- changing the shortcut does not re-enter capture mode when the user tests it
- unsupported or swallowed shortcuts leave recording with a clear error instead of staying on `Press keys...`
- OS-global activation works from another app where Electron/globalShortcut is supported by the desktop environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux and Windows onboarding shortcut setup and unifies global shortcut registration so onboarding, Settings, and the hub all use the same, verified shortcut. Preserves platform semantics across startup and enables the Linux portal without clobbering existing Chromium flags; macOS behavior is unchanged.

- **Bug Fixes**
  - Route onboarding through the shared hotkey manager. Remove direct `globalShortcut` use, swap callbacks without re-registering, and normalize/repair saved accelerators (e.g., deduped `CommandOrControl`).
  - Use `CommandOrControl+Shift+Space` as the shared default on macOS/Windows/Linux; render platform-native labels (`Win`/`Super`, etc.) and treat renderer `Cmd` as `CommandOrControl` off-mac.
  - Persist the onboarding choice immediately so the hub starts with it, even before the main callback is set.
  - Verify registration with `globalShortcut.isRegistered()`, avoid unregistering unconfirmed shortcuts, roll back on failure, fall back to the default, and persist the effective accelerator.
  - Match capture and UX across onboarding and Settings: normalize Space (including non‑breaking Space), require a modifier for the global shortcut, ignore `Unidentified`, time out after 8s, and show an inline “unavailable” error on rejected saves.
  - Let the command-bar shortcut fire even when inputs are focused, matching onboarding’s focused-window fallback.
  - Enable Chromium `GlobalShortcutsPortal` on Linux and merge `--enable-features` to preserve existing flags.
  - Expand tests for persistence, registration/rollback paths, onboarding handlers, Settings recorder, hub key handling, platform label/capture rules, and Chromium feature merging.

<sup>Written for commit a560c9d55137763508fdb4ac1602d92038d8f2ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

