### PR TITLE
Allow manual browser navigation from the session pane

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -188,6 +188,11 @@ browserPool.setOnGone((sessionId) => {
 browserPool.setOnNavigate((sessionId, url) => {
   sessionManager.updateNavigationFromUrl(sessionId, url);
 });
+browserPool.setOnNavigationState((sessionId, state) => {
+  if (shellWindow && !shellWindow.isDestroyed()) {
+    shellWindow.webContents.send('sessions:navigation-state', sessionId, state);
+  }
+});
 const accountStore = new AccountStore();
 const whatsAppAdapter = new WhatsAppAdapter();
 const channelRouter = new ChannelRouter(sessionManager, whatsAppAdapter);
@@ -1393,6 +1398,32 @@ app.whenReady().then(async () => {
   ipcMain.handle('sessions:get-tabs', async (_event, id: string) => {
     const validatedId = assertString(id, 'id', 100);
     return browserPool.getTabs(validatedId);
+  });
+
+  ipcMain.handle('sessions:get-navigation-state', (_event, id: string) => {
+    const validatedId = assertString(id, 'id', 100);
+    return browserPool.getNavigationState(validatedId);
+  });
+
+  ipcMain.handle('sessions:navigate', async (_event, id: string, input: string) => {
+    const validatedId = assertString(id, 'id', 100);
+    const validatedInput = assertString(input, 'input', 4096);
+    return browserPool.navigate(validatedId, validatedInput);
+  });
+
+  ipcMain.handle('sessions:back', (_event, id: string) => {
+    const validatedId = assertString(id, 'id', 100);
+    return browserPool.goBack(validatedId);
+  });
+
+  ipcMain.handle('sessions:forward', (_event, id: string) => {
+    const validatedId = assertString(id, 'id', 100);
+    return browserPool.goForward(validatedId);
+  });
+
+  ipcMain.handle('sessions:reload', (_event, id: string) => {
+    const validatedId = assertString(id, 'id', 100);
+    return browserPool.reload(validatedId);
   });
 
   ipcMain.handle('sessions:pool-stats', () => {

--- a/app/src/main/sessions/BrowserPool.ts
+++ b/app/src/main/sessions/BrowserPool.ts
@@ -1,6 +1,7 @@
 import { WebContentsView, type BrowserWindow, type WebContents } from 'electron';
 import { browserLogger } from '../logger';
 import type { TabInfo } from './types';
+import { normalizeBrowserNavigationInput } from '../../shared/browser-navigation';
 
 const DEFAULT_BROWSER_WIDTH = 1280;
 const DEFAULT_BROWSER_HEIGHT = 800;
@@ -28,12 +29,25 @@ interface PoolEntry {
   emulatedWidth: number;
 }
 
+export interface BrowserNavigationState {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+}
+
+export type BrowserNavigationResult =
+  | { ok: true; url?: string }
+  | { ok: false; error: string };
+
 export class BrowserPool {
   private entries: Map<string, PoolEntry> = new Map();
   private maxConcurrent: number;
   private queue: string[] = [];
   private onGone?: (sessionId: string) => void;
   private onNavigate?: (sessionId: string, url: string) => void;
+  private onNavigationState?: (sessionId: string, state: BrowserNavigationState) => void;
 
   constructor(maxConcurrent = DEFAULT_MAX_CONCURRENT) {
     this.maxConcurrent = maxConcurrent;
@@ -54,6 +68,10 @@ export class BrowserPool {
     this.onNavigate = listener;
   }
 
+  setOnNavigationState(listener: (sessionId: string, state: BrowserNavigationState) => void): void {
+    this.onNavigationState = listener;
+  }
+
   private notifyGone(sessionId: string): void {
     try { this.onGone?.(sessionId); } catch (err) {
       browserLogger.warn('BrowserPool.notifyGone.listenerError', { sessionId, error: (err as Error).message });
@@ -63,6 +81,15 @@ export class BrowserPool {
   private notifyNavigate(sessionId: string, url: string): void {
     try { this.onNavigate?.(sessionId, url); } catch (err) {
       browserLogger.warn('BrowserPool.notifyNavigate.listenerError', { sessionId, error: (err as Error).message });
+    }
+  }
+
+  private notifyNavigationState(sessionId: string): void {
+    try {
+      const state = this.getNavigationState(sessionId);
+      if (state) this.onNavigationState?.(sessionId, state);
+    } catch (err) {
+      browserLogger.warn('BrowserPool.notifyNavigationState.listenerError', { sessionId, error: (err as Error).message });
     }
   }
 
@@ -316,6 +343,7 @@ export class BrowserPool {
         pid: wc.getOSProcessId(),
         wcId: wc.id,
       });
+      this.notifyNavigationState(sessionId);
     });
     wc.on('did-redirect-navigation', (_event, url, isInPlace, isMainFrame, frameProcessId, frameRoutingId) => {
       if (!isMainFrame) return;
@@ -357,6 +385,7 @@ export class BrowserPool {
         wcId: wc.id,
       });
       this.notifyNavigate(sessionId, url);
+      this.notifyNavigationState(sessionId);
     });
     wc.on('did-finish-load', () => {
       if (!currentNavigation) return;
@@ -375,6 +404,7 @@ export class BrowserPool {
         wcId: wc.id,
       });
       currentNavigation = null;
+      this.notifyNavigationState(sessionId);
     });
     wc.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
       if (!isMainFrame) return;
@@ -395,6 +425,13 @@ export class BrowserPool {
         wcId: wc.id,
       });
       if (errorCode !== -3) currentNavigation = null;
+      this.notifyNavigationState(sessionId);
+    });
+    wc.on('did-stop-loading', () => {
+      this.notifyNavigationState(sessionId);
+    });
+    wc.on('page-title-updated', () => {
+      this.notifyNavigationState(sessionId);
     });
     // SPA/hash navigation — pushState, replaceState, hash changes. Many
     // sites (x.com, linkedin, gmail) never fire did-navigate after the
@@ -414,6 +451,7 @@ export class BrowserPool {
           wcId: wc.id,
         });
         this.notifyNavigate(sessionId, url);
+        this.notifyNavigationState(sessionId);
       }
     });
 
@@ -436,6 +474,72 @@ export class BrowserPool {
   getView(sessionId: string): WebContentsView | null {
     const entry = this.entries.get(sessionId);
     return entry?.view ?? null;
+  }
+
+  getNavigationState(sessionId: string): BrowserNavigationState | null {
+    const wc = this.getWebContents(sessionId);
+    if (!wc) return null;
+
+    const readable = wc as WebContents & {
+      canGoBack?: () => boolean;
+      canGoForward?: () => boolean;
+      isLoadingMainFrame?: () => boolean;
+      isLoading?: () => boolean;
+    };
+    return {
+      url: wc.getURL() || 'about:blank',
+      title: wc.getTitle() || 'New Tab',
+      canGoBack: Boolean(readable.canGoBack?.()),
+      canGoForward: Boolean(readable.canGoForward?.()),
+      isLoading: Boolean(readable.isLoadingMainFrame?.() ?? readable.isLoading?.() ?? false),
+    };
+  }
+
+  async navigate(sessionId: string, input: string): Promise<BrowserNavigationResult> {
+    const wc = this.getWebContents(sessionId);
+    if (!wc) return { ok: false, error: 'Browser is not available.' };
+
+    const normalized = normalizeBrowserNavigationInput(input);
+    if (!normalized.ok) return normalized;
+
+    try {
+      await wc.loadURL(normalized.url);
+      this.notifyNavigationState(sessionId);
+      return { ok: true, url: normalized.url };
+    } catch (err) {
+      const error = (err as Error).message || 'Navigation failed.';
+      browserLogger.warn('BrowserPool.navigate.failed', { sessionId, url: normalized.url, error });
+      this.notifyNavigationState(sessionId);
+      return { ok: false, error };
+    }
+  }
+
+  goBack(sessionId: string): BrowserNavigationResult {
+    const wc = this.getWebContents(sessionId);
+    if (!wc) return { ok: false, error: 'Browser is not available.' };
+    const nav = wc as WebContents & { canGoBack?: () => boolean; goBack?: () => void };
+    if (!nav.canGoBack?.()) return { ok: false, error: 'No page to go back to.' };
+    nav.goBack?.();
+    this.notifyNavigationState(sessionId);
+    return { ok: true };
+  }
+
+  goForward(sessionId: string): BrowserNavigationResult {
+    const wc = this.getWebContents(sessionId);
+    if (!wc) return { ok: false, error: 'Browser is not available.' };
+    const nav = wc as WebContents & { canGoForward?: () => boolean; goForward?: () => void };
+    if (!nav.canGoForward?.()) return { ok: false, error: 'No page to go forward to.' };
+    nav.goForward?.();
+    this.notifyNavigationState(sessionId);
+    return { ok: true };
+  }
+
+  reload(sessionId: string): BrowserNavigationResult {
+    const wc = this.getWebContents(sessionId);
+    if (!wc) return { ok: false, error: 'Browser is not available.' };
+    wc.reload();
+    this.notifyNavigationState(sessionId);
+    return { ok: true };
   }
 
   /** Center + shrink the view rect inside the hub box if the emulated

--- a/app/src/preload/shell.ts
+++ b/app/src/preload/shell.ts
@@ -270,6 +270,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
       const raw = await ipcRenderer.invoke('sessions:get-tabs', id);
       return validateTabs(raw);
     },
+    getNavigationState: (id: string): Promise<{
+      url: string;
+      title: string;
+      canGoBack: boolean;
+      canGoForward: boolean;
+      isLoading: boolean;
+    } | null> => ipcRenderer.invoke('sessions:get-navigation-state', id),
+    navigate: (id: string, input: string): Promise<{ ok: boolean; url?: string; error?: string }> =>
+      ipcRenderer.invoke('sessions:navigate', id, input),
+    back: (id: string): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke('sessions:back', id),
+    forward: (id: string): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke('sessions:forward', id),
+    reload: (id: string): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke('sessions:reload', id),
     poolStats: async (): Promise<BrowserPoolStats> => {
       const raw = await ipcRenderer.invoke('sessions:pool-stats');
       return validatePoolStats(raw);
@@ -355,6 +370,41 @@ contextBridge.exposeInMainWorld('electronAPI', {
       };
       ipcRenderer.on('sessions:browser-gone', handler);
       return () => ipcRenderer.removeListener('sessions:browser-gone', handler);
+    },
+    sessionNavigationState: (cb: (id: string, state: {
+      url: string;
+      title: string;
+      canGoBack: boolean;
+      canGoForward: boolean;
+      isLoading: boolean;
+    }) => void): (() => void) => {
+      const handler = (_event: unknown, id: string, state: unknown) => {
+        if (typeof id !== 'string' || !state || typeof state !== 'object') return;
+        const raw = state as {
+          url?: unknown;
+          title?: unknown;
+          canGoBack?: unknown;
+          canGoForward?: unknown;
+          isLoading?: unknown;
+        };
+        if (
+          typeof raw.url === 'string' &&
+          typeof raw.title === 'string' &&
+          typeof raw.canGoBack === 'boolean' &&
+          typeof raw.canGoForward === 'boolean' &&
+          typeof raw.isLoading === 'boolean'
+        ) {
+          cb(id, {
+            url: raw.url,
+            title: raw.title,
+            canGoBack: raw.canGoBack,
+            canGoForward: raw.canGoForward,
+            isLoading: raw.isLoading,
+          });
+        }
+      };
+      ipcRenderer.on('sessions:navigation-state', handler);
+      return () => ipcRenderer.removeListener('sessions:navigation-state', handler);
     },
     sessionOutput: (cb: (id: string, event: HlEvent) => void): (() => void) => {
       const handler = (_event: unknown, id: string, raw: unknown) => {

--- a/app/src/renderer/globals.d.ts
+++ b/app/src/renderer/globals.d.ts
@@ -71,9 +71,22 @@ interface ElectronSessionAPI {
   viewsSetVisible: (visible: boolean) => Promise<void>;
   viewsDetachAll: () => Promise<void>;
   getTabs: (id: string) => Promise<unknown[]>;
+  getNavigationState: (id: string) => Promise<BrowserNavigationState | null>;
+  navigate: (id: string, input: string) => Promise<{ ok: boolean; url?: string; error?: string }>;
+  back: (id: string) => Promise<{ ok: boolean; error?: string }>;
+  forward: (id: string) => Promise<{ ok: boolean; error?: string }>;
+  reload: (id: string) => Promise<{ ok: boolean; error?: string }>;
   poolStats: () => Promise<unknown>;
   memory: () => Promise<{ totalMb: number; sessions: Array<{ id: string; mb: number; status: string }>; processes: Array<{ label: string; type: string; mb: number; sessionId?: string }>; processCount: number }>;
   getTermReplay: (id: string) => Promise<string>;
+}
+
+interface BrowserNavigationState {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
 }
 
 interface ElectronChannelsAPI {
@@ -142,6 +155,7 @@ interface ElectronChromeImportAPI {
 interface ElectronOnAPI {
   sessionUpdated: (cb: (session: import('./hub/types').AgentSession) => void) => () => void;
   sessionBrowserGone: (cb: (id: string) => void) => () => void;
+  sessionNavigationState: (cb: (id: string, state: BrowserNavigationState) => void) => () => void;
   sessionOutput: (cb: (id: string, event: import('./hub/types').HlEvent) => void) => () => void;
   sessionOutputTerm: (cb: (id: string, bytes: string) => void) => () => void;
   openSettings?: (cb: (payload?: { focusBrowserCodeProvider?: string }) => void) => () => void;

--- a/app/src/renderer/hub/AgentPane.tsx
+++ b/app/src/renderer/hub/AgentPane.tsx
@@ -572,6 +572,31 @@ function ResumeIcon(): React.ReactElement {
   );
 }
 
+function BackIcon(): React.ReactElement {
+  return (
+    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M8.5 3.5L5 7l3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ForwardIcon(): React.ReactElement {
+  return (
+    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M5.5 3.5L9 7l-3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ReloadIcon(): React.ReactElement {
+  return (
+    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M11 5.5A4.5 4.5 0 104.8 11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <path d="M11 2.5v3H8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 interface FollowUpAttachment { idx: number; name: string; mime: string; bytes: Uint8Array }
 
 async function fileToAttachment(file: File, idx: number): Promise<FollowUpAttachment> {
@@ -741,6 +766,116 @@ function CloseIcon(): React.ReactElement {
   );
 }
 
+function BrowserAddressBar({
+  sessionId,
+  disabled,
+  state,
+}: {
+  sessionId: string;
+  disabled: boolean;
+  state: BrowserNavigationState | null;
+}): React.ReactElement {
+  const [value, setValue] = useState(state?.url ?? '');
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editing) setValue(state?.url ?? '');
+  }, [editing, state?.url]);
+
+  const runNavigationCommand = useCallback(async (command: 'back' | 'forward' | 'reload') => {
+    const api = window.electronAPI?.sessions;
+    if (!api) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const result = await api[command](sessionId);
+      if (!result.ok) setError(result.error ?? 'Navigation failed.');
+    } catch (err) {
+      setError((err as Error).message || 'Navigation failed.');
+    } finally {
+      setBusy(false);
+    }
+  }, [sessionId]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    const api = window.electronAPI?.sessions;
+    if (!api) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const result = await api.navigate(sessionId, value);
+      if (!result.ok) {
+        setError(result.error ?? 'Navigation failed.');
+      } else if (result.url) {
+        setValue(result.url);
+      }
+    } catch (err) {
+      setError((err as Error).message || 'Navigation failed.');
+    } finally {
+      setBusy(false);
+    }
+  }, [sessionId, value]);
+
+  return (
+    <form
+      className={`pane__address${error ? ' pane__address--error' : ''}`}
+      onSubmit={handleSubmit}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        className="pane__address-btn"
+        disabled={disabled || busy || !state?.canGoBack}
+        aria-label="Back"
+        title="Back"
+        onClick={() => { void runNavigationCommand('back'); }}
+      >
+        <BackIcon />
+      </button>
+      <button
+        type="button"
+        className="pane__address-btn"
+        disabled={disabled || busy || !state?.canGoForward}
+        aria-label="Forward"
+        title="Forward"
+        onClick={() => { void runNavigationCommand('forward'); }}
+      >
+        <ForwardIcon />
+      </button>
+      <button
+        type="button"
+        className="pane__address-btn"
+        disabled={disabled || busy}
+        aria-label="Reload"
+        title="Reload"
+        onClick={() => { void runNavigationCommand('reload'); }}
+      >
+        <ReloadIcon />
+      </button>
+      <label className="pane__address-field">
+        <span className="pane__address-title">{state?.title || 'New Tab'}</span>
+        <input
+          className="pane__address-input"
+          value={value}
+          disabled={disabled || busy}
+          onFocus={() => setEditing(true)}
+          onBlur={() => setEditing(false)}
+          onChange={(e) => setValue(e.target.value)}
+          aria-label="Address and search"
+          placeholder="Search or enter address"
+          spellCheck={false}
+        />
+      </label>
+      {busy || state?.isLoading ? <span className="pane__address-loading" aria-label="Loading" /> : null}
+      {error && <span className="pane__address-error" role="alert">{error}</span>}
+    </form>
+  );
+}
+
 interface AgentPaneProps {
   session: AgentSession;
   focused?: boolean;
@@ -763,6 +898,7 @@ export function AgentPane({ session, focused, onRerun, onResume, onFollowUp, onD
   const [browserDead, setBrowserDead] = useState(false);
   const [browserMissing, setBrowserMissing] = useState(false);
   const [frameRect, setFrameRect] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
+  const [navigationState, setNavigationState] = useState<BrowserNavigationState | null>(null);
   // Logs overlay is a separate window (see logsPill.ts). The pane tracks
   // visibility only to reflect it in the Logs button's active state.
   const [logsOpen, setLogsOpen] = useState(false);
@@ -802,6 +938,28 @@ export function AgentPane({ session, focused, onRerun, onResume, onFollowUp, onD
       setBrowserDead(false);
     }
   }, [session.id, session.status]);
+
+  useEffect(() => {
+    setNavigationState(null);
+    const api = window.electronAPI;
+    if (!api?.sessions?.getNavigationState) return;
+    let cancelled = false;
+    void api.sessions.getNavigationState(session.id).then((state) => {
+      if (!cancelled) setNavigationState(state);
+    }).catch(() => {
+      if (!cancelled) setNavigationState(null);
+    });
+    return () => { cancelled = true; };
+  }, [session.id]);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.on?.sessionNavigationState) return;
+    const off = api.on.sessionNavigationState((id, state) => {
+      if (id === session.id) setNavigationState(state);
+    });
+    return off;
+  }, [session.id]);
 
   useEffect(() => {
     const api = window.electronAPI;
@@ -1167,6 +1325,14 @@ export function AgentPane({ session, focused, onRerun, onResume, onFollowUp, onD
       <div className="pane__progress" aria-hidden="true">
         {session.status === 'running' && <div className="pane__progress-bar" />}
       </div>
+
+      {session.status !== 'draft' && (
+        <BrowserAddressBar
+          sessionId={session.id}
+          disabled={browserDead || browserMissing}
+          state={navigationState}
+        />
+      )}
 
       {frameRect && (showErrorUi || browserDead || browserMissing || session.status === 'draft' || session.status === 'stopped' || session.status === 'idle' || session.status === 'stuck') && (() => {
         const isStarting = !showErrorUi && !browserDead && !browserMissing && session.status === 'draft';

--- a/app/src/renderer/hub/hub.css
+++ b/app/src/renderer/hub/hub.css
@@ -1192,6 +1192,111 @@ button:focus:not(:focus-visible) {
   animation: progress-slide 2.2s ease-in-out infinite;
 }
 
+.pane__address {
+  display: grid;
+  grid-template-columns: 28px 28px 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background-color: var(--color-bg-base);
+  flex-shrink: 0;
+}
+
+.pane__address-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-tertiary);
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    background-color var(--duration-fast) var(--ease-out);
+}
+
+.pane__address-btn:hover:not(:disabled) {
+  color: var(--color-fg-primary);
+  background-color: var(--color-surface-interactive-hover);
+}
+
+.pane__address-btn:disabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
+.pane__address-field {
+  min-width: 0;
+  height: 32px;
+  display: grid;
+  grid-template-columns: minmax(80px, max-content) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-sunken);
+}
+
+.pane__address-field:focus-within {
+  border-color: var(--color-border-default);
+  background-color: var(--color-bg-elevated);
+}
+
+.pane__address-title {
+  min-width: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-2xs);
+  color: var(--color-fg-tertiary);
+}
+
+.pane__address-input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--color-fg-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+}
+
+.pane__address-input::placeholder {
+  color: var(--color-fg-disabled);
+}
+
+.pane__address-input:disabled {
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
+.pane__address-loading {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--color-border-subtle);
+  border-top-color: var(--color-fg-tertiary);
+  border-radius: var(--radius-full);
+  animation: spin 0.9s linear infinite;
+}
+
+.pane__address-error {
+  grid-column: 4 / 6;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-2xs);
+  color: var(--color-status-error);
+}
+
+.pane__address--error .pane__address-field {
+  border-color: var(--color-status-error);
+}
+
 @keyframes progress-slide {
   0% { transform: translateX(-100%); }
   100% { transform: translateX(500%); }

--- a/app/src/shared/browser-navigation.ts
+++ b/app/src/shared/browser-navigation.ts
@@ -1,0 +1,55 @@
+export type NormalizedNavigation =
+  | { ok: true; url: string; kind: 'url' | 'search' }
+  | { ok: false; error: string };
+
+const SUPPORTED_PROTOCOLS = new Set(['http:', 'https:', 'file:']);
+const SEARCH_URL = 'https://www.google.com/search?q=';
+
+function hasScheme(input: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(input);
+}
+
+function isLikelyHost(input: string): boolean {
+  if (/\s/.test(input)) return false;
+  if (/^localhost(?::\d+)?(?:[/?#].*)?$/i.test(input)) return true;
+  if (/^\[[0-9a-f:]+\](?::\d+)?(?:[/?#].*)?$/i.test(input)) return true;
+  if (/^\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:[/?#].*)?$/.test(input)) return true;
+  return /^[a-z0-9-]+(?:\.[a-z0-9-]+)+(?::\d+)?(?:[/?#].*)?$/i.test(input);
+}
+
+function validateUrl(raw: string): NormalizedNavigation {
+  try {
+    const parsed = new URL(raw);
+    if (!SUPPORTED_PROTOCOLS.has(parsed.protocol)) {
+      return { ok: false, error: `Unsupported URL scheme: ${parsed.protocol.replace(':', '')}` };
+    }
+    if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') && !parsed.hostname) {
+      return { ok: false, error: 'Enter a valid web address.' };
+    }
+    return { ok: true, url: parsed.toString(), kind: 'url' };
+  } catch {
+    return { ok: false, error: 'Enter a valid web address.' };
+  }
+}
+
+export function normalizeBrowserNavigationInput(input: string): NormalizedNavigation {
+  const trimmed = input.trim();
+  if (!trimmed) return { ok: false, error: 'Enter a URL or search query.' };
+
+  if (isLikelyHost(trimmed)) {
+    const scheme = /^localhost(?::|[/?#]|$)/i.test(trimmed) || /^\d{1,3}(?:\.\d{1,3}){3}/.test(trimmed)
+      ? 'http://'
+      : 'https://';
+    return validateUrl(`${scheme}${trimmed}`);
+  }
+
+  if (hasScheme(trimmed)) {
+    return validateUrl(trimmed);
+  }
+
+  return {
+    ok: true,
+    url: `${SEARCH_URL}${encodeURIComponent(trimmed)}`,
+    kind: 'search',
+  };
+}

--- a/app/tests/fixtures/electron-mock.ts
+++ b/app/tests/fixtures/electron-mock.ts
@@ -244,14 +244,40 @@ let webContentsIdCounter = 1;
 
 function createMockWebContents() {
   const id = webContentsIdCounter++;
+  let currentUrl = 'about:blank';
+  let title = 'New Tab';
+  let canGoBack = false;
+  let canGoForward = false;
+  let loadError: Error | null = null;
   return {
     id,
-    getURL: (): string => 'about:blank',
-    getTitle: (): string => 'New Tab',
+    getURL: (): string => currentUrl,
+    getTitle: (): string => title,
     getOSProcessId: (): number => 10000 + id,
+    canGoBack: (): boolean => canGoBack,
+    canGoForward: (): boolean => canGoForward,
+    goBack: (): void => { canGoForward = true; },
+    goForward: (): void => { canGoBack = true; },
+    reload: (): void => undefined,
+    isLoadingMainFrame: (): boolean => false,
+    isDestroyed: (): boolean => false,
     setFrameRate: (_fps: number): void => undefined,
     setBackgroundThrottling: (_throttle: boolean): void => undefined,
-    loadURL: (_url: string): Promise<void> => Promise.resolve(),
+    loadURL: (url: string): Promise<void> => {
+      if (loadError) return Promise.reject(loadError);
+      currentUrl = url;
+      title = url === 'about:blank' ? 'New Tab' : url;
+      canGoBack = true;
+      canGoForward = false;
+      return Promise.resolve();
+    },
+    __setNavigationState: (next: { url?: string; title?: string; canGoBack?: boolean; canGoForward?: boolean; loadError?: Error | null }): void => {
+      if (next.url !== undefined) currentUrl = next.url;
+      if (next.title !== undefined) title = next.title;
+      if (next.canGoBack !== undefined) canGoBack = next.canGoBack;
+      if (next.canGoForward !== undefined) canGoForward = next.canGoForward;
+      if ('loadError' in next) loadError = next.loadError ?? null;
+    },
     close: (): void => undefined,
     on: (): void => undefined,
     off: (): void => undefined,

--- a/app/tests/unit/hub/AgentPane.spec.tsx
+++ b/app/tests/unit/hub/AgentPane.spec.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentPane } from '../../../src/renderer/hub/AgentPane';
+import type { AgentSession } from '../../../src/renderer/hub/types';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = class {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+};
+
+vi.mock('../../../src/renderer/hub/useSessionsQuery', () => ({
+  useHydrateSession: vi.fn(),
+}));
+
+function makeSession(): AgentSession {
+  return {
+    id: 'session-1',
+    createdAt: Date.now(),
+    status: 'idle',
+    prompt: 'Browse manually',
+    output: [],
+    hasBrowser: true,
+  };
+}
+
+function installApi(overrides?: Partial<ElectronSessionAPI>): {
+  navigate: ReturnType<typeof vi.fn>;
+  back: ReturnType<typeof vi.fn>;
+  forward: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  emitNavigation: (state: BrowserNavigationState) => void;
+} {
+  let navigationHandler: ((id: string, state: BrowserNavigationState) => void) | null = null;
+  const navigate = vi.fn(async () => ({ ok: true, url: 'https://example.com/' }));
+  const back = vi.fn(async () => ({ ok: true }));
+  const forward = vi.fn(async () => ({ ok: true }));
+  const reload = vi.fn(async () => ({ ok: true }));
+
+  (window as unknown as { electronAPI: Partial<ElectronAPI> }).electronAPI = {
+    sessions: {
+      get: vi.fn(async () => null),
+      viewDetach: vi.fn(async () => true),
+      getNavigationState: vi.fn(async () => ({
+        url: 'https://start.example/',
+        title: 'Start',
+        canGoBack: false,
+        canGoForward: true,
+        isLoading: false,
+      })),
+      navigate,
+      back,
+      forward,
+      reload,
+      ...overrides,
+    } as Partial<ElectronSessionAPI> as ElectronSessionAPI,
+    on: {
+      sessionNavigationState: (cb: (id: string, state: BrowserNavigationState) => void) => {
+        navigationHandler = cb;
+        return () => { navigationHandler = null; };
+      },
+    } as Partial<ElectronOnAPI> as ElectronOnAPI,
+  };
+
+  return {
+    navigate,
+    back,
+    forward,
+    reload,
+    emitNavigation: (state) => navigationHandler?.('session-1', state),
+  };
+}
+
+function renderPane(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<AgentPane session={makeSession()} />);
+  });
+  return { container, root };
+}
+
+function setInput(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  if (!setter) throw new Error('Missing input value setter');
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('AgentPane browser address bar', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('renders navigation state and submits manual navigation input', async () => {
+    const api = installApi();
+    const { container, root } = renderPane();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.pane__address-input');
+    if (!input) throw new Error('Missing address input');
+    expect(input.value).toBe('https://start.example/');
+
+    await act(async () => {
+      setInput(input, 'example.com');
+      input.form?.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(api.navigate).toHaveBeenCalledWith('session-1', 'example.com');
+
+    act(() => root.unmount());
+  });
+
+  it('updates address, title, and history controls from browser state events', async () => {
+    const api = installApi();
+    const { container, root } = renderPane();
+
+    await act(async () => {
+      await Promise.resolve();
+      api.emitNavigation({
+        url: 'https://next.example/page',
+        title: 'Next Page',
+        canGoBack: true,
+        canGoForward: false,
+        isLoading: false,
+      });
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.pane__address-input');
+    const back = container.querySelector<HTMLButtonElement>('button[aria-label="Back"]');
+    const forward = container.querySelector<HTMLButtonElement>('button[aria-label="Forward"]');
+    const title = container.querySelector<HTMLElement>('.pane__address-title');
+
+    expect(input?.value).toBe('https://next.example/page');
+    expect(title?.textContent).toBe('Next Page');
+    expect(back?.disabled).toBe(false);
+    expect(forward?.disabled).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it('shows invalid navigation feedback from the IPC result', async () => {
+    installApi({
+      navigate: vi.fn(async () => ({ ok: false, error: 'Unsupported URL scheme: javascript' })),
+    });
+    const { container, root } = renderPane();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.pane__address-input');
+    if (!input) throw new Error('Missing address input');
+
+    await act(async () => {
+      setInput(input, 'javascript:alert(1)');
+      input.form?.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('Unsupported URL scheme: javascript');
+
+    act(() => root.unmount());
+  });
+});

--- a/app/tests/unit/sessions/BrowserPool.test.ts
+++ b/app/tests/unit/sessions/BrowserPool.test.ts
@@ -198,6 +198,70 @@ describe('BrowserPool — getTabs', () => {
   });
 });
 
+describe('BrowserPool — manual navigation', () => {
+  let pool: BrowserPool;
+
+  beforeEach(() => { pool = new BrowserPool(5); });
+  afterEach(() => { pool.destroyAll(); });
+
+  it('normalizes and dispatches typed URLs to the active browser', async () => {
+    pool.create('s1');
+
+    const result = await pool.navigate('s1', 'example.com/docs');
+    const state = pool.getNavigationState('s1');
+
+    expect(result).toMatchObject({ ok: true, url: 'https://example.com/docs' });
+    expect(state).toMatchObject({
+      url: 'https://example.com/docs',
+      title: 'https://example.com/docs',
+      canGoBack: true,
+      canGoForward: false,
+    });
+  });
+
+  it('normalizes plain text into search navigation', async () => {
+    pool.create('s1');
+
+    const result = await pool.navigate('s1', 'browser use desktop');
+
+    expect(result).toMatchObject({
+      ok: true,
+      url: 'https://www.google.com/search?q=browser%20use%20desktop',
+    });
+  });
+
+  it('returns clear errors for invalid input and navigation failures', async () => {
+    pool.create('s1');
+    const wc = pool.getWebContents('s1') as unknown as {
+      __setNavigationState: (state: { loadError?: Error | null }) => void;
+    };
+
+    expect(await pool.navigate('s1', 'javascript:alert(1)')).toMatchObject({
+      ok: false,
+      error: 'Unsupported URL scheme: javascript',
+    });
+
+    wc.__setNavigationState({ loadError: new Error('DNS failed') });
+    expect(await pool.navigate('s1', 'https://example.com')).toMatchObject({
+      ok: false,
+      error: 'DNS failed',
+    });
+  });
+
+  it('dispatches history and reload controls', async () => {
+    pool.create('s1');
+    const wc = pool.getWebContents('s1') as unknown as {
+      __setNavigationState: (state: { canGoBack?: boolean; canGoForward?: boolean }) => void;
+    };
+
+    wc.__setNavigationState({ canGoBack: true, canGoForward: true });
+
+    expect(pool.goBack('s1')).toMatchObject({ ok: true });
+    expect(pool.goForward('s1')).toMatchObject({ ok: true });
+    expect(pool.reload('s1')).toMatchObject({ ok: true });
+  });
+});
+
 describe('BrowserPool — fitted resize', () => {
   let pool: BrowserPool;
   let win: any;

--- a/app/tests/unit/shared/browser-navigation.test.ts
+++ b/app/tests/unit/shared/browser-navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBrowserNavigationInput } from '../../../src/shared/browser-navigation';
+
+describe('normalizeBrowserNavigationInput', () => {
+  it('preserves explicit http and https URLs', () => {
+    expect(normalizeBrowserNavigationInput('https://example.com/docs').ok).toBe(true);
+    expect(normalizeBrowserNavigationInput('http://localhost:3000/path')).toMatchObject({
+      ok: true,
+      url: 'http://localhost:3000/path',
+      kind: 'url',
+    });
+  });
+
+  it('adds a web scheme to host-like input', () => {
+    expect(normalizeBrowserNavigationInput('example.com')).toMatchObject({
+      ok: true,
+      url: 'https://example.com/',
+      kind: 'url',
+    });
+    expect(normalizeBrowserNavigationInput('localhost:5173')).toMatchObject({
+      ok: true,
+      url: 'http://localhost:5173/',
+      kind: 'url',
+    });
+  });
+
+  it('turns non-url text into a search URL', () => {
+    expect(normalizeBrowserNavigationInput('browser use desktop')).toMatchObject({
+      ok: true,
+      url: 'https://www.google.com/search?q=browser%20use%20desktop',
+      kind: 'search',
+    });
+  });
+
+  it('rejects empty and unsupported URL inputs', () => {
+    expect(normalizeBrowserNavigationInput('')).toMatchObject({ ok: false });
+    expect(normalizeBrowserNavigationInput('javascript:alert(1)')).toMatchObject({
+      ok: false,
+      error: 'Unsupported URL scheme: javascript',
+    });
+    expect(normalizeBrowserNavigationInput('http://')).toMatchObject({ ok: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a session-pane browser address bar for manual browsing, including typed URLs, pasted/full URLs, search-query fallback, page title display, loading state, and navigation error feedback.
- Wires manual navigation through main/preload IPC into the existing `BrowserPool` and session navigation state flow so agent-driven and manual browsing share the same browser source of truth.
- Adds back, forward, and reload controls backed by WebContents history APIs.
- Adds focused coverage for URL normalization, navigation dispatch/failure handling, and renderer UI behavior.

## Details
Manual navigation now flows through `BrowserPool.navigate()`, which normalizes the input with a shared helper before calling `webContents.loadURL()`. BrowserPool also emits live navigation state updates (`url`, `title`, `canGoBack`, `canGoForward`, `isLoading`) on navigation, load, title, and in-page route events. The existing `setOnNavigate` path still updates `SessionManager.updateNavigationFromUrl()`, so manual browsing keeps `primarySite` and `lastUrl` coherent for session resume and agent context.

The renderer subscribes to those navigation-state events in `AgentPane` and renders a compact browser chrome above the embedded browser. Invalid schemes and load failures are surfaced inline without tearing down the session.

## Manual testing
Tested manually on Linux/Hyprland with:
- typed URLs
- pasted/full URLs
- search-query fallback
- invalid scheme feedback
- back/forward/reload after manual navigation

## Automated testing
- `npm run typecheck`
- `npm run lint` (passes with existing repository warnings)
- `npm run test` (45 files, 345 tests passed; 1 file and 3 tests skipped)

Closes #409


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact browser address bar to the session pane with manual navigation and history controls. Aligns with #409 by letting users type or paste URLs, search from the bar, and keep navigation state in sync with agent-driven browsing.

- New Features
  - Address bar with typed/pasted URLs, search fallback, page title, loading, and inline error feedback.
  - Back, forward, and reload using `WebContents` history APIs.
  - Live navigation state (`url`, `title`, `canGoBack`, `canGoForward`, `isLoading`) emitted from main and rendered in the pane.
  - New IPC: `sessions:get-navigation-state`, `sessions:navigate`, `sessions:back`, `sessions:forward`, `sessions:reload`, and `sessions:navigation-state` event.

- Refactors
  - All manual input flows through `BrowserPool.navigate()` using a shared normalizer in `shared/browser-navigation`.
  - Keeps `SessionManager.updateNavigationFromUrl()` updates so `primarySite`/`lastUrl` stay correct for resume and context.

<sup>Written for commit 31804c630bf3bf44b0fe634f34585dae23d73ced. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

