### PR TITLE
fix(mac): find bundled Codex app CLI

### DIFF
--- a/app/src/main/hl/engines/pathEnrich.ts
+++ b/app/src/main/hl/engines/pathEnrich.ts
@@ -58,6 +58,8 @@ const POSIX_EXTRA_DIRS_FNS: Array<(home: string, platform: Platform, pathMod: ty
   () => '/opt/homebrew/sbin',
   () => '/usr/local/bin',
   () => '/usr/local/sbin',
+  (_home, platform) => platform === 'darwin' ? '/Applications/Codex.app/Contents/Resources' : null,
+  (home, platform, pathMod) => platform === 'darwin' ? pathMod.join(home, 'Applications', 'Codex.app', 'Contents', 'Resources') : null,
   (home, _platform, pathMod) => pathMod.join(home, '.npm-global', 'bin'),
   (home, _platform, pathMod) => pathMod.join(home, '.volta', 'bin'),
   (home, _platform, pathMod) => pathMod.join(home, '.nvm', 'versions', 'node'),

--- a/app/tests/unit/pathEnrich.test.ts
+++ b/app/tests/unit/pathEnrich.test.ts
@@ -30,4 +30,16 @@ describe('pathEnrich', () => {
     expect(parts).toContain('/home/ada/.local/bin');
     expect(parts).toContain('/home/ada/.cargo/bin');
   });
+
+  it('adds bundled Codex.app CLI locations on macOS', () => {
+    const result = enrichedPath('/usr/bin:/bin', {
+      platform: 'darwin',
+      homedir: '/Users/ada',
+      env: {},
+    });
+
+    const parts = result.split(':');
+    expect(parts).toContain('/Applications/Codex.app/Contents/Resources');
+    expect(parts).toContain('/Users/ada/Applications/Codex.app/Contents/Resources');
+  });
 });


### PR DESCRIPTION
## Summary

Adds the bundled Codex.app CLI locations to the macOS PATH enrichment fallback list so Browser Use can detect Codex when the Codex desktop app is installed but `codex` is not otherwise discoverable from the Electron app process PATH.

This covers the default app bundle locations:

- `/Applications/Codex.app/Contents/Resources`
- `~/Applications/Codex.app/Contents/Resources`

## Background

On macOS, Browser Use can inherit a GUI-launched PATH that does not include the Codex desktop app bundle resources. In that case the Codex install probe fails with `codex not found on PATH`, even though Codex.app is installed and `~/.codex/auth.json` is present.

I hit this locally with Browser Use 0.0.30. The app log showed the split clearly:

```json
{
  "install": { "installed": false, "error": "codex not found on PATH" },
  "auth": { "authed": true }
}
```

Adding a local `~/.local/bin/codex` symlink to `/Applications/Codex.app/Contents/Resources/codex` made the probe succeed, confirming the issue was CLI discovery rather than auth. This patch makes that fallback built in for the installed Codex.app layout.

## Test

```sh
npm run test -- tests/unit/pathEnrich.test.ts
```

Result: 3 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Codex.app bundled CLI paths to macOS PATH enrichment so the app can find Codex when the desktop app is installed but `codex` isn’t on PATH. Fixes the “codex not found on PATH” issue for GUI-launched sessions.

- **Bug Fixes**
  - Adds `/Applications/Codex.app/Contents/Resources` and `~/Applications/Codex.app/Contents/Resources` as macOS fallback dirs.
  - Adds a unit test to verify both paths are appended on `darwin`.

<sup>Written for commit d5e0937139baa4c8a92841195e5af8ee3dc182ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

