### PR TITLE
Add Windows Arm64 release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,29 +466,61 @@ jobs:
         working-directory: app
         env:
           WINDOWS_SIGN_WITH_PARAMS: ${{ secrets.WINDOWS_SIGN_WITH_PARAMS }}
-        run: yarn run make -- --platform=win32 --arch=x64
+        shell: pwsh
+        run: |
+          foreach ($arch in @('x64', 'arm64')) {
+            "Building Windows Squirrel ($arch)"
+            $env:BROWSER_USE_WINDOWS_ARCH = $arch
+            yarn run make -- --platform=win32 "--arch=$arch"
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
 
       - name: Collect Windows release assets
         shell: pwsh
         run: |
           $assetDir = 'release-assets-windows'
-          $sourceDir = 'app/out/make/squirrel.windows/x64'
-          New-Item -ItemType Directory -Force $assetDir | Out-Null
-          if (-not (Test-Path $sourceDir)) {
-            Write-Error "No Squirrel.Windows output found at $sourceDir"
-            exit 1
-          }
-          Copy-Item -Path "$sourceDir/*" -Destination $assetDir -Force
+          $architectures = @('x64', 'arm64')
+          $releaseLines = @()
 
-          if (-not (Test-Path "$assetDir/RELEASES")) {
-            Write-Error 'No RELEASES file produced by Squirrel.Windows'
+          New-Item -ItemType Directory -Force $assetDir | Out-Null
+
+          foreach ($arch in $architectures) {
+            $sourceDir = "app/out/make/squirrel.windows/$arch"
+            if (-not (Test-Path $sourceDir)) {
+              Write-Error "No Squirrel.Windows output found at $sourceDir"
+              exit 1
+            }
+
+            $releasePath = Join-Path $sourceDir 'RELEASES'
+            if (-not (Test-Path $releasePath)) {
+              Write-Error "No RELEASES file produced by Squirrel.Windows for $arch"
+              exit 1
+            }
+
+            $releaseLines += Get-Content $releasePath | Where-Object { $_.Trim() }
+            Copy-Item -Path "$sourceDir/*.nupkg" -Destination $assetDir -Force
+            Copy-Item -Path "$sourceDir/*.exe" -Destination $assetDir -Force
+          }
+
+          if (@($releaseLines).Count -eq 0) {
+            Write-Error 'No package entries found in Windows RELEASES files'
             exit 1
           }
-          if (@(Get-ChildItem $assetDir -Filter '*.nupkg' -File).Count -eq 0) {
-            Write-Error 'No .nupkg file produced by Squirrel.Windows'
+          Set-Content -Path "$assetDir/RELEASES" -Value $releaseLines -Encoding utf8NoBOM
+
+          if (@(Get-ChildItem $assetDir -Filter '*.nupkg' -File).Count -lt $architectures.Count) {
+            Write-Error 'Expected one .nupkg file per Windows architecture'
             exit 1
           }
-          if (@(Get-ChildItem $assetDir -Filter '*.exe' -File).Count -eq 0) {
+          foreach ($setupExe in @('Browser-Use-Setup.exe', 'Browser-Use-Setup-arm64.exe')) {
+            if (-not (Test-Path (Join-Path $assetDir $setupExe))) {
+              Write-Error "Missing Windows setup asset: $setupExe"
+              exit 1
+            }
+          }
+          if (@(Get-ChildItem $assetDir -Filter '*.exe' -File).Count -lt $architectures.Count) {
             Write-Error 'No setup .exe produced by Squirrel.Windows'
             exit 1
           }
@@ -565,6 +597,21 @@ jobs:
                 exit 1
               }
               "Waiting for $package to become publicly downloadable (attempt $attempt/12)"
+              Start-Sleep -Seconds 5
+            }
+          }
+          foreach ($setup in @('Browser-Use-Setup.exe', 'Browser-Use-Setup-arm64.exe')) {
+            "Verifying $baseUrl/$setup"
+            for ($attempt = 1; $attempt -le 12; $attempt++) {
+              curl.exe -fsIL "$baseUrl/$setup" | Out-Null
+              if ($LASTEXITCODE -eq 0) {
+                break
+              }
+              if ($attempt -eq 12) {
+                Write-Error "$setup is not publicly downloadable at $baseUrl/$setup. The README download link would 404."
+                exit 1
+              }
+              "Waiting for $setup to become publicly downloadable (attempt $attempt/12)"
               Start-Sleep -Seconds 5
             }
           }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Built on [Browser Harness](https://github.com/browser-use/browser-harness).
 
 **Windows (x64):** [Browser-Use-Setup.exe](https://github.com/browser-use/desktop/releases/latest/download/Browser-Use-Setup.exe)
 
+**Windows (Arm64):** [Browser-Use-Setup-arm64.exe](https://github.com/browser-use/desktop/releases/latest/download/Browser-Use-Setup-arm64.exe)
+
 **Linux:** [Browser-Use-x64.AppImage](https://github.com/browser-use/desktop/releases/latest/download/Browser-Use-x64.AppImage) supports in-app auto-updates. `.deb` and `.rpm` packages are also published on GitHub Releases for manual installs.
 
 The buttons and links always point to the latest release.

--- a/app/docs/CI.md
+++ b/app/docs/CI.md
@@ -104,13 +104,13 @@ The workflow flips `prerelease: true` based on substring match.
   publishing fails partway.
 
 **Auto-update feed.** The workflow publishes `latest-mac.yml` plus
-`Browser-Use-<arch>-mac.zip` for macOS, and `latest-linux.yml` plus
-`Browser-Use-<version>-x64.AppImage` for Linux. The app's `electron-updater`
-integration reads those feeds from GitHub Releases, downloads the update in
-the background, and applies it on restart or next quit. The DMG remains the
-macOS first-install/manual-download artifact; Linux `.deb` and `.rpm` builds
-remain manual install artifacts while AppImage is the self-updating Linux
-channel.
+`Browser-Use-<arch>-mac.zip` for macOS, a combined Squirrel.Windows `RELEASES`
+feed with x64 and Arm64 packages for Windows, and `latest-linux.yml` plus
+`Browser-Use-<version>-x64.AppImage` for Linux. The app's update integration
+reads those feeds from GitHub Releases, downloads the update in the background,
+and applies it on restart or next quit. The DMG remains the macOS
+first-install/manual-download artifact; Linux `.deb` and `.rpm` builds remain
+manual install artifacts while AppImage is the self-updating Linux channel.
 
 **Version field.** `app/package.json`'s `version` is consumed by Forge
 when it names the DMG (`app-<version>-arm64.dmg`) and by

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -36,6 +36,24 @@ const SHOULD_SIGN = IS_MAC && !SKIP_SIGNING && SIGNING_IDENTITY !== '';
 const WINDOWS_ICON_PATH = path.resolve(__dirname, 'assets/icon.ico');
 const LINUX_ICON_PATH = path.resolve(__dirname, 'assets/icon.png');
 
+const cliArgValue = (name: string): string | undefined => {
+  const eqPrefix = `--${name}=`;
+  for (let i = 0; i < process.argv.length; i += 1) {
+    const arg = process.argv[i];
+    if (arg.startsWith(eqPrefix)) return arg.slice(eqPrefix.length);
+    if (arg === `--${name}`) return process.argv[i + 1];
+  }
+  return undefined;
+};
+
+const WINDOWS_BUILD_ARCH = process.env.BROWSER_USE_WINDOWS_ARCH
+  ?? process.env.npm_config_arch
+  ?? cliArgValue('arch')
+  ?? process.arch;
+const WINDOWS_IS_ARM64 = WINDOWS_BUILD_ARCH === 'arm64';
+const WINDOWS_PACKAGE_NAME = WINDOWS_IS_ARM64 ? 'browser_use_desktop_arm64' : 'browser_use_desktop';
+const WINDOWS_SETUP_EXE = WINDOWS_IS_ARM64 ? 'Browser-Use-Setup-arm64.exe' : 'Browser-Use-Setup.exe';
+
 const findNpmCli = (): string | null => {
   const nodeDir = path.dirname(process.execPath);
   const candidates = [
@@ -46,13 +64,13 @@ const findNpmCli = (): string | null => {
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
 };
 
-const runNpm = (args: string[], cwd: string): void => {
+const runNpm = (args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void => {
   const npmCli = findNpmCli();
   if (npmCli) {
-    execFileSync(process.execPath, [npmCli, ...args], { cwd, stdio: 'inherit' });
+    execFileSync(process.execPath, [npmCli, ...args], { cwd, stdio: 'inherit', env });
     return;
   }
-  execFileSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, { cwd, stdio: 'inherit' });
+  execFileSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, { cwd, stdio: 'inherit', env });
 };
 
 // ---------------------------------------------------------------------------
@@ -136,17 +154,24 @@ const config: ForgeConfig = {
     // better-sqlite3, keytar, etc.) are missing at runtime and main.js
     // crashes on first require('dotenv'). Re-install production deps into
     // the packaged dir so externals resolve.
-    packageAfterPrune: async (_config, buildPath, electronVersion) => {
+    packageAfterPrune: async (_config, buildPath, electronVersion, platform, arch) => {
       const pkgPath = path.join(buildPath, 'package.json');
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
       const prodDeps = Object.keys(pkg.dependencies ?? {});
       if (prodDeps.length === 0) return;
-      runNpm(['install', '--omit=dev', '--no-package-lock', '--no-save', '--legacy-peer-deps', ...prodDeps], buildPath);
-      // npm install just built native modules against the host Node ABI.
+      const targetEnv = {
+        ...process.env,
+        npm_config_platform: platform,
+        npm_config_arch: arch,
+        npm_config_target_platform: platform,
+        npm_config_target_arch: arch,
+      };
+      runNpm(['install', '--omit=dev', '--no-package-lock', '--no-save', '--legacy-peer-deps', ...prodDeps], buildPath, targetEnv);
+      // npm install just built native modules for the target platform/arch.
       // Electron uses a different NODE_MODULE_VERSION, so rebuild them
       // against Electron's headers before asar packaging.
       const { rebuild } = await import('@electron/rebuild');
-      await rebuild({ buildPath, electronVersion, arch: process.arch });
+      await rebuild({ buildPath, electronVersion, arch });
       // npm (like yarn) drops the executable bit off node-pty's spawn-helper.
       // Restore it on the packaged tree so `codex login` doesn't crash with
       // `posix_spawnp failed` the first time a user opens onboarding.
@@ -188,9 +213,9 @@ const config: ForgeConfig = {
     // native Windows autoUpdater. Authenticode signing is optional and injected
     // by CI via WINDOWS_SIGN_WITH_PARAMS when a certificate pipeline exists.
     new MakerSquirrel({
-      name: 'browser_use_desktop',
+      name: WINDOWS_PACKAGE_NAME,
       title: 'Browser Use',
-      setupExe: 'Browser-Use-Setup.exe',
+      setupExe: WINDOWS_SETUP_EXE,
       setupIcon: WINDOWS_ICON_PATH,
       noMsi: true,
       ...(WINDOWS_SIGN_WITH_PARAMS ? { signWithParams: WINDOWS_SIGN_WITH_PARAMS } : {}),


### PR DESCRIPTION
## Summary

- Build Windows Squirrel release assets for both x64 and Arm64 in `release.yml`.
- Make Forge install and rebuild packaged production dependencies against the target platform/arch instead of the host arch.
- Give the Arm64 Squirrel package and setup executable distinct names, then publish a combined Windows `RELEASES` feed plus both setup links.
- Document the new `Browser-Use-Setup-arm64.exe` download.

## Validation

- `npx --yes yarn@1.22.22 install --frozen-lockfile`
- `npx --yes yarn@1.22.22 typecheck`
- `npx --yes yarn@1.22.22 lint` (0 errors, existing warnings only)
- `git diff --check`
- Attempted `BROWSER_USE_WINDOWS_ARCH=arm64 npx --yes yarn@1.22.22 make -- --platform=win32 --arch=arm64`; Forge/Vite reached native dependency rebuild, then local `node-gyp` failed to find a supported Visual Studio install because this machine has VS 18 preview. CI `windows-latest` with Node 22/VS2022 should be the meaningful package validator.

## Known local test noise

- `npx --yes yarn@1.22.22 test` currently fails on this Windows machine in two existing path expectation tests unrelated to this change: `tests/unit/pathEnrich.test.ts` and `tests/unit/chrome-import/paths.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows Arm64 packaging and publishing. CI now builds Squirrel packages for x64 and Arm64, publishes a combined Windows `RELEASES` feed, and provides separate setup installers.

- **New Features**
  - CI: build x64 and Arm64 in `release.yml`, collect assets, merge `RELEASES`, and verify both setup links are live.
  - Forge: pick target arch via `BROWSER_USE_WINDOWS_ARCH`/`--arch`, install production deps for the target platform/arch, rebuild natives with `@electron/rebuild`, and set distinct package/setup names (`Browser-Use-Setup-arm64.exe`).
  - Docs: add Arm64 download link in README and note the combined Windows feed in CI docs.

<sup>Written for commit 4d5a5997d741aaa770e0fac79b35d5cfc18715c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

