### PR TITLE
Make Ctrl+C pause before canceling sessions

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -179,7 +179,7 @@ const sessionManager = new SessionManager(path.join(app.getPath('userData'), 'se
 // to <userData>/harness/ on first run, preserves user edits on subsequent runs.
 bootstrapHarness();
 const browserPool = new BrowserPool();
-let cancelBrowserSessionFromShortcut: ((sessionId: string) => boolean) | null = null;
+let interruptBrowserSessionFromShortcut: ((sessionId: string) => boolean) | null = null;
 const resourceMonitorContext: ResourceMonitorContext = {
   browserSessions: () => browserPool.getStats().sessions,
   sessionInfo: (sessionId) => sessionManager.getResourceInfo(sessionId),
@@ -201,8 +201,8 @@ browserPool.setOnGone((sessionId) => {
 browserPool.setOnNavigate((sessionId, url) => {
   sessionManager.updateNavigationFromUrl(sessionId, url);
 });
-browserPool.setOnCancelShortcut((sessionId) => {
-  return cancelBrowserSessionFromShortcut?.(sessionId) ?? false;
+browserPool.setOnInterruptShortcut((sessionId) => {
+  return interruptBrowserSessionFromShortcut?.(sessionId) ?? false;
 });
 const accountStore = new AccountStore();
 const whatsAppAdapter = new WhatsAppAdapter();
@@ -794,11 +794,11 @@ app.whenReady().then(async () => {
 
   function pauseSessionFromMain(
     id: string,
-    source: 'button' | 'queued-follow-up',
+    source: 'button' | 'browser-ctrl-c' | 'logs-ctrl-c' | 'queued-follow-up',
     opts: { notify?: boolean } = {},
   ): { paused?: boolean; error?: string } {
     const status = sessionManager.getSessionStatus(id);
-    if (status !== 'running' && status !== 'stuck' && status !== 'paused') {
+    if (status !== 'running' && status !== 'stuck') {
       return { error: `Session ${id} is ${status ?? 'unknown'}, expected running or stuck` };
     }
     const active = activeRunControls.get(id);
@@ -858,9 +858,17 @@ app.whenReady().then(async () => {
     return { cancelled: true };
   }
 
-  cancelBrowserSessionFromShortcut = (sessionId) => {
-    const result = cancelSessionFromMain(sessionId, 'browser-ctrl-c');
-    return result.cancelled === true;
+  interruptBrowserSessionFromShortcut = (sessionId) => {
+    const status = sessionManager.getSessionStatus(sessionId);
+    if (status === 'paused') {
+      const result = cancelSessionFromMain(sessionId, 'browser-ctrl-c');
+      return result.cancelled === true;
+    }
+    if (status === 'running' || status === 'stuck') {
+      const result = pauseSessionFromMain(sessionId, 'browser-ctrl-c');
+      return result.paused === true;
+    }
+    return false;
   };
 
   function queueFollowUpAfterNextTool(id: string, prompt: string, attachments: ValidatedAttachment[]): { queued?: boolean; error?: string } {
@@ -1326,9 +1334,11 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('sessions:pause', (_event, payload: string | { id?: unknown; source?: unknown }) => {
     const idRaw = typeof payload === 'string' ? payload : payload?.id;
+    const sourceRaw = typeof payload === 'string' ? 'button' : payload?.source;
     const validatedId = assertString(idRaw, 'id', 100);
-    mainLogger.info('main.sessions:pause', { id: validatedId, source: 'button' });
-    return pauseSessionFromMain(validatedId, 'button');
+    const source = sourceRaw === 'logs-ctrl-c' ? 'logs-ctrl-c' : 'button';
+    mainLogger.info('main.sessions:pause', { id: validatedId, source });
+    return pauseSessionFromMain(validatedId, source);
   });
 
   ipcMain.handle('sessions:cancel', (_event, payload: string | { id?: unknown; source?: unknown }) => {

--- a/app/src/main/sessions/BrowserPool.ts
+++ b/app/src/main/sessions/BrowserPool.ts
@@ -48,7 +48,7 @@ export class BrowserPool {
   private queue: string[] = [];
   private onGone?: (sessionId: string) => void;
   private onNavigate?: (sessionId: string, url: string) => void;
-  private onCancelShortcut?: (sessionId: string) => boolean | void;
+  private onInterruptShortcut?: (sessionId: string) => boolean | void;
   private idleFreezeDelayMs: number;
 
   constructor(maxConcurrent = DEFAULT_MAX_CONCURRENT, opts: { idleFreezeDelayMs?: number } = {}) {
@@ -73,8 +73,8 @@ export class BrowserPool {
 
   /** Register a listener for Ctrl+C inside an attached browser view. Returning
    *  true means the keypress was handled and should not continue into the page. */
-  setOnCancelShortcut(listener: (sessionId: string) => boolean | void): void {
-    this.onCancelShortcut = listener;
+  setOnInterruptShortcut(listener: (sessionId: string) => boolean | void): void {
+    this.onInterruptShortcut = listener;
   }
 
   private notifyGone(sessionId: string): void {
@@ -89,9 +89,9 @@ export class BrowserPool {
     }
   }
 
-  private notifyCancelShortcut(sessionId: string): boolean {
-    try { return this.onCancelShortcut?.(sessionId) === true; } catch (err) {
-      browserLogger.warn('BrowserPool.notifyCancelShortcut.listenerError', { sessionId, error: (err as Error).message });
+  private notifyInterruptShortcut(sessionId: string): boolean {
+    try { return this.onInterruptShortcut?.(sessionId) === true; } catch (err) {
+      browserLogger.warn('BrowserPool.notifyInterruptShortcut.listenerError', { sessionId, error: (err as Error).message });
       return false;
     }
   }
@@ -203,7 +203,7 @@ export class BrowserPool {
         !input.meta &&
         !input.alt
       ) {
-        const handled = this.notifyCancelShortcut(sessionId);
+        const handled = this.notifyInterruptShortcut(sessionId);
         if (handled) event.preventDefault();
       }
     });

--- a/app/src/preload/logs.ts
+++ b/app/src/preload/logs.ts
@@ -31,7 +31,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     cancel: (id: string): Promise<void> =>
       ipcRenderer.invoke('sessions:cancel', { id, source: 'logs-ctrl-c' }),
     pause: (id: string): Promise<{ paused?: boolean; error?: string }> =>
-      ipcRenderer.invoke('sessions:pause', id),
+      ipcRenderer.invoke('sessions:pause', { id, source: 'logs-ctrl-c' }),
     listEditors: (): Promise<Array<{ id: string; name: string }>> =>
       ipcRenderer.invoke('sessions:list-editors'),
     openInEditor: (editorId: string, filePath: string): Promise<{ opened: boolean }> =>

--- a/app/src/renderer/hub/AgentPane.tsx
+++ b/app/src/renderer/hub/AgentPane.tsx
@@ -1013,16 +1013,20 @@ export function AgentPane({ session, focused, onRerun, onResume, onPause, onFoll
   );
 
   useEffect(() => {
-    if (!focused || (!isRunningLike && !isPaused) || !onCancel) return;
+    if (!focused || (!isRunningLike && !isPaused) || (!onPause && !onCancel)) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented || e.key.toLowerCase() !== 'c' || !e.ctrlKey || e.metaKey || e.altKey) return;
       e.preventDefault();
       e.stopPropagation();
-      onCancel(session.id);
+      if (isPaused) {
+        onCancel?.(session.id);
+      } else {
+        onPause?.(session.id);
+      }
     };
     window.addEventListener('keydown', onKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true });
-  }, [focused, isPaused, isRunningLike, onCancel, session.id]);
+  }, [focused, isPaused, isRunningLike, onCancel, onPause, session.id]);
 
   return (
     <div

--- a/app/src/renderer/logs/LogsApp.tsx
+++ b/app/src/renderer/logs/LogsApp.tsx
@@ -372,11 +372,15 @@ export function LogsApp(): React.ReactElement {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      const sessionIsCancellable = sessionStatus === 'running' || sessionStatus === 'stuck' || sessionStatus === 'paused';
-      if (e.key.toLowerCase() === 'c' && e.ctrlKey && !e.metaKey && !e.altKey && sessionId && sessionIsCancellable) {
+      const sessionIsRunning = sessionStatus === 'running' || sessionStatus === 'stuck';
+      const sessionIsPaused = sessionStatus === 'paused';
+      if (e.key.toLowerCase() === 'c' && e.ctrlKey && !e.metaKey && !e.altKey && sessionId && (sessionIsRunning || sessionIsPaused)) {
         e.preventDefault();
-        void window.electronAPI?.sessions.cancel(sessionId).catch((err) => {
-          console.error('[LogsApp] cancel failed', err);
+        const action = sessionIsPaused
+          ? window.electronAPI?.sessions.cancel(sessionId)
+          : window.electronAPI?.sessions.pause(sessionId);
+        void action?.catch((err) => {
+          console.error(`[LogsApp] ${sessionIsPaused ? 'cancel' : 'pause'} failed`, err);
         });
         return;
       }

--- a/app/tests/unit/LogsApp.spec.tsx
+++ b/app/tests/unit/LogsApp.spec.tsx
@@ -141,7 +141,35 @@ describe('LogsApp focus behavior', () => {
     act(() => root.unmount());
   });
 
-  it('cancels the active session on Ctrl+C instead of minimizing logs', async () => {
+  it('pauses the active running session on Ctrl+C instead of minimizing logs', async () => {
+    const { root } = renderLogsApp();
+
+    await act(async () => {
+      activeSessionChangedHandler?.('session-1');
+      await Promise.resolve();
+    });
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }));
+    });
+
+    expect(window.electronAPI.sessions.pause).toHaveBeenCalledWith('session-1');
+    expect(window.electronAPI.sessions.cancel).not.toHaveBeenCalled();
+    expect(window.logsAPI.setMode).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  it('cancels the active session on Ctrl+C when it is already paused', async () => {
+    vi.mocked(window.electronAPI.sessions.get).mockResolvedValueOnce({
+      id: 'session-1',
+      prompt: 'paused',
+      status: 'paused',
+      engine: 'codex',
+      output: [],
+      createdAt: Date.now(),
+      canResume: true,
+    });
     const { root } = renderLogsApp();
 
     await act(async () => {

--- a/app/tests/unit/sessions/BrowserPool.test.ts
+++ b/app/tests/unit/sessions/BrowserPool.test.ts
@@ -75,9 +75,9 @@ describe('BrowserPool — creation', () => {
 
   it('notifies when Ctrl+C is pressed inside a browser view and prevents the page keypress when handled', () => {
     const view = pool.create('s1');
-    const onCancelShortcut = vi.fn(() => true);
+    const onInterruptShortcut = vi.fn(() => true);
     const preventDefault = vi.fn();
-    pool.setOnCancelShortcut(onCancelShortcut);
+    pool.setOnInterruptShortcut(onInterruptShortcut);
 
     (view!.webContents as unknown as { emit: (event: string, ...args: unknown[]) => boolean }).emit(
       'before-input-event',
@@ -85,14 +85,14 @@ describe('BrowserPool — creation', () => {
       { type: 'keyDown', key: 'c', control: true, meta: false, alt: false },
     );
 
-    expect(onCancelShortcut).toHaveBeenCalledWith('s1');
+    expect(onInterruptShortcut).toHaveBeenCalledWith('s1');
     expect(preventDefault).toHaveBeenCalled();
   });
 
   it('lets Ctrl+C through to the page when the app does not handle it', () => {
     const view = pool.create('s1');
     const preventDefault = vi.fn();
-    pool.setOnCancelShortcut(() => false);
+    pool.setOnInterruptShortcut(() => false);
 
     (view!.webContents as unknown as { emit: (event: string, ...args: unknown[]) => boolean }).emit(
       'before-input-event',
@@ -103,11 +103,11 @@ describe('BrowserPool — creation', () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
-  it('does not treat Escape as the browser-view cancel shortcut', () => {
+  it('does not treat Escape as the browser-view interrupt shortcut', () => {
     const view = pool.create('s1');
-    const onCancelShortcut = vi.fn(() => true);
+    const onInterruptShortcut = vi.fn(() => true);
     const preventDefault = vi.fn();
-    pool.setOnCancelShortcut(onCancelShortcut);
+    pool.setOnInterruptShortcut(onInterruptShortcut);
 
     (view!.webContents as unknown as { emit: (event: string, ...args: unknown[]) => boolean }).emit(
       'before-input-event',
@@ -115,7 +115,7 @@ describe('BrowserPool — creation', () => {
       { type: 'keyDown', key: 'Escape', control: false, meta: false, alt: false },
     );
 
-    expect(onCancelShortcut).not.toHaveBeenCalled();
+    expect(onInterruptShortcut).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- make Ctrl+C act as a pause-first interrupt for running/stuck sessions
- cancel only when Ctrl+C is pressed while the session is already paused
- keep Esc as logs/window dismissal and preserve Ctrl+C copy behavior for non-cancellable sessions

## Verification
- task typecheck
- task lint (existing warnings only)
- cd app && npm run test -- --run tests/unit/LogsApp.spec.tsx tests/unit/sessions/BrowserPool.test.ts tests/unit/sessions/SessionManager.persistence.test.ts tests/unit/hl/runEngineHarnessWatcher.test.ts
- cd app && npm run test -- --run
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Ctrl+C a pause-first interrupt for sessions. Ctrl+C pauses running/stuck sessions; pressing it again while paused cancels. Esc still dismisses logs/windows, and copy via Ctrl+C is unaffected outside active sessions.

- **Bug Fixes**
  - Handle Ctrl+C in browser views, `AgentPane`, and `LogsApp`, routing to pause or cancel based on session status.
  - Rename `BrowserPool` shortcut hook to `onInterruptShortcut` and prevent page keypress when handled.
  - Add `browser-ctrl-c`/`logs-ctrl-c` sources; preload now passes source for pause IPC.
  - Update tests for pause-first behavior and interrupt handling.

<sup>Written for commit 89f4ca59e47804a4320ee1d3706250a0c53c4a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

