### PR TITLE
Add AppPopup window system; move pickers, menus, and Resource usage into it

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -262,6 +262,12 @@ const config: ForgeConfig = {
           config: 'vite.preload.config.ts',
           target: 'preload',
         },
+        {
+          // Shared top-level popup preload
+          entry: 'src/preload/popup.ts',
+          config: 'vite.preload.config.ts',
+          target: 'preload',
+        },
       ],
       renderer: [
         {
@@ -283,6 +289,11 @@ const config: ForgeConfig = {
           // Logs renderer (src/renderer/logs/logs.html)
           name: 'logs',
           config: 'vite.logs.config.mts',
+        },
+        {
+          // Shared top-level popup renderer
+          name: 'popup',
+          config: 'vite.popup.config.mts',
         },
       ],
     }),

--- a/app/forge.env.d.ts
+++ b/app/forge.env.d.ts
@@ -15,3 +15,7 @@ declare const ONBOARDING_VITE_NAME: string | undefined;
 // Logs renderer globals injected by Forge VitePlugin (renderer name = "logs")
 declare const LOGS_VITE_DEV_SERVER_URL: string | undefined;
 declare const LOGS_VITE_NAME: string | undefined;
+
+// Popup renderer globals injected by Forge VitePlugin (renderer name = "popup")
+declare const POPUP_VITE_DEV_SERVER_URL: string | undefined;
+declare const POPUP_VITE_NAME: string | undefined;

--- a/app/src/main/appPopup.ts
+++ b/app/src/main/appPopup.ts
@@ -415,5 +415,9 @@ export function registerAppPopupHandlers(): void {
 }
 
 export function warmAppPopup(): void {
+  // Ensure handlers are bound before the popup window's preload can fire
+  // 'app-popup:renderer-ready'; otherwise an early launch would drop the
+  // handshake and leave the popup permanently un-rendered.
+  registerAppPopupHandlers();
   createPopupWindow();
 }

--- a/app/src/main/appPopup.ts
+++ b/app/src/main/appPopup.ts
@@ -1,0 +1,419 @@
+import { app, BrowserWindow, ipcMain, screen, type IpcMainEvent, type Rectangle, type WebContents } from 'electron';
+import path from 'node:path';
+import type {
+  AppPopupAction,
+  AppPopupClosed,
+  AppPopupContentSize,
+  AppPopupOpenRequest,
+  AppPopupOpenResult,
+  AppPopupPlacement,
+} from '../shared/app-popup';
+import { mainLogger, rendererLogger } from './logger';
+import { getWindowBackgroundColor } from './themeMode';
+import { registerViteDepStaleHeal } from './viteDepStaleHeal';
+
+const log = {
+  info: (c: string, x: object) => mainLogger.info(c, x as Record<string, unknown>),
+  warn: (c: string, x: object) => mainLogger.warn(c, x as Record<string, unknown>),
+  error: (c: string, x: object) => mainLogger.error(c, x as Record<string, unknown>),
+  debug: (c: string, x: object) => mainLogger.debug(c, x as Record<string, unknown>),
+};
+
+const DEFAULT_WIDTH = 260;
+const DEFAULT_HEIGHT = 240;
+const MAX_DEFAULT_HEIGHT = 380;
+const SCREEN_MARGIN = 6;
+const ANCHOR_GAP = 6;
+
+interface ActivePopup {
+  id: string;
+  request: AppPopupOpenRequest;
+  origin: WebContents;
+  owner: BrowserWindow | null;
+}
+
+let popupWindow: BrowserWindow | null = null;
+let popupReady = false;
+let pendingRender: AppPopupOpenRequest | null = null;
+let activePopup: ActivePopup | null = null;
+let registered = false;
+let ownerCleanup: (() => void) | null = null;
+let showWhenRenderedId: string | null = null;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.max(min, Math.min(value, max));
+}
+
+function sanitizeDimension(value: unknown, fallback: number, min: number, max: number): number {
+  if (!isFiniteNumber(value)) return fallback;
+  return clamp(Math.round(value), min, max);
+}
+
+function estimateMenuHeight(request: AppPopupOpenRequest): number {
+  if (request.kind !== 'menu') return DEFAULT_HEIGHT;
+  const rowHeight = 34;
+  const separators = request.items.filter((item) => item.separatorBefore).length;
+  return Math.min(MAX_DEFAULT_HEIGHT, 8 + request.items.length * rowHeight + separators * 9);
+}
+
+function requestedSize(request: AppPopupOpenRequest): { width: number; height: number } {
+  const fallbackWidth = request.kind === 'engine-picker'
+    ? 266
+    : request.kind === 'browsercode-model-picker'
+      ? 292
+      : request.kind === 'memory-indicator'
+        ? 360
+        : DEFAULT_WIDTH;
+  const fallbackHeight = request.kind === 'engine-picker' || request.kind === 'browsercode-model-picker' || request.kind === 'memory-indicator'
+    ? MAX_DEFAULT_HEIGHT
+    : estimateMenuHeight(request);
+  return {
+    width: sanitizeDimension(request.width, fallbackWidth, 80, 900),
+    height: sanitizeDimension(request.height, fallbackHeight, 40, sanitizeDimension(request.maxHeight, MAX_DEFAULT_HEIGHT, 80, 900)),
+  };
+}
+
+function screenAnchorFor(owner: BrowserWindow | null, request: AppPopupOpenRequest): Rectangle {
+  const content = owner && !owner.isDestroyed()
+    ? owner.getContentBounds()
+    : screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
+  return {
+    x: Math.round(content.x + request.anchor.x),
+    y: Math.round(content.y + request.anchor.y),
+    width: Math.round(request.anchor.width),
+    height: Math.round(request.anchor.height),
+  };
+}
+
+function displayAreaFor(anchor: Rectangle): Rectangle {
+  const point = {
+    x: Math.round(anchor.x + anchor.width / 2),
+    y: Math.round(anchor.y + anchor.height / 2),
+  };
+  return screen.getDisplayNearestPoint(point).workArea;
+}
+
+function computePosition(
+  anchor: Rectangle,
+  width: number,
+  height: number,
+  placement: AppPopupPlacement,
+): { x: number; y: number } {
+  switch (placement) {
+    case 'bottom-end':
+      return { x: anchor.x + anchor.width - width, y: anchor.y + anchor.height + ANCHOR_GAP };
+    case 'top-start':
+      return { x: anchor.x, y: anchor.y - height - ANCHOR_GAP };
+    case 'top-end':
+      return { x: anchor.x + anchor.width - width, y: anchor.y - height - ANCHOR_GAP };
+    case 'right-start':
+      return { x: anchor.x + anchor.width + ANCHOR_GAP, y: anchor.y };
+    case 'left-start':
+      return { x: anchor.x - width - ANCHOR_GAP, y: anchor.y };
+    case 'bottom-start':
+    default:
+      return { x: anchor.x, y: anchor.y + anchor.height + ANCHOR_GAP };
+  }
+}
+
+function flipPlacementIfNeeded(
+  anchor: Rectangle,
+  width: number,
+  height: number,
+  placement: AppPopupPlacement,
+  area: Rectangle,
+): AppPopupPlacement {
+  const pos = computePosition(anchor, width, height, placement);
+  const overBottom = pos.y + height > area.y + area.height - SCREEN_MARGIN;
+  const overTop = pos.y < area.y + SCREEN_MARGIN;
+  const spaceAbove = anchor.y - area.y;
+  const spaceBelow = area.y + area.height - (anchor.y + anchor.height);
+
+  if (placement.startsWith('bottom') && overBottom && spaceAbove > spaceBelow) {
+    return placement === 'bottom-end' ? 'top-end' : 'top-start';
+  }
+  if (placement.startsWith('top') && overTop && spaceBelow > spaceAbove) {
+    return placement === 'top-end' ? 'bottom-end' : 'bottom-start';
+  }
+  return placement;
+}
+
+function computeBounds(request: AppPopupOpenRequest, owner: BrowserWindow | null): Rectangle {
+  const anchor = screenAnchorFor(owner, request);
+  const area = displayAreaFor(anchor);
+  const size = requestedSize(request);
+  const width = Math.min(size.width, Math.max(80, area.width - SCREEN_MARGIN * 2));
+  const height = Math.min(size.height, Math.max(40, area.height - SCREEN_MARGIN * 2));
+  const placement = flipPlacementIfNeeded(anchor, width, height, request.placement ?? 'bottom-start', area);
+  const pos = computePosition(anchor, width, height, placement);
+  return {
+    x: clamp(Math.round(pos.x), area.x + SCREEN_MARGIN, area.x + area.width - width - SCREEN_MARGIN),
+    y: clamp(Math.round(pos.y), area.y + SCREEN_MARGIN, area.y + area.height - height - SCREEN_MARGIN),
+    width,
+    height,
+  };
+}
+
+function createPopupWindow(): BrowserWindow {
+  if (popupWindow && !popupWindow.isDestroyed()) return popupWindow;
+
+  popupReady = false;
+  popupWindow = new BrowserWindow({
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    minWidth: 80,
+    minHeight: 40,
+    transparent: false,
+    frame: false,
+    alwaysOnTop: true,
+    hasShadow: true,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    minimizable: false,
+    movable: false,
+    skipTaskbar: true,
+    show: false,
+    roundedCorners: true,
+    type: 'panel',
+    backgroundColor: getWindowBackgroundColor(),
+    webPreferences: {
+      preload: path.join(__dirname, 'popup.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  popupWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  popupWindow.setAlwaysOnTop(true, 'screen-saver');
+
+  const isDev = typeof POPUP_VITE_DEV_SERVER_URL !== 'undefined' && POPUP_VITE_DEV_SERVER_URL;
+  const devUrl = isDev ? `${POPUP_VITE_DEV_SERVER_URL}/src/renderer/popup/popup.html` : null;
+  const htmlPath = isDev ? null : path.join(__dirname, '../renderer/popup/src/renderer/popup/popup.html');
+
+  const loadPopup = (): void => {
+    if (!popupWindow || popupWindow.isDestroyed()) return;
+    if (devUrl) {
+      popupWindow.loadURL(devUrl).catch((err) => log.error('appPopup.loadURL.reject', { url: devUrl, error: (err as Error).message }));
+    } else if (htmlPath) {
+      popupWindow.loadFile(htmlPath).catch((err) => log.error('appPopup.loadFile.reject', { htmlPath, error: (err as Error).message }));
+    }
+  };
+  loadPopup();
+
+  popupWindow.webContents.setZoomFactor(1);
+  popupWindow.webContents.setVisualZoomLevelLimits(1, 1);
+  popupWindow.webContents.on('did-finish-load', () => {
+    log.debug('appPopup.did-finish-load', {});
+  });
+  let retriesLeft = isDev ? 10 : 0;
+  popupWindow.webContents.on('did-fail-load', (_e, code, desc, url, isMainFrame) => {
+    if (!isMainFrame) return;
+    log.warn('appPopup.did-fail-load', { code, desc, url, retriesLeft });
+    if (retriesLeft > 0 && (code === -102 || code === -105 || code === -2)) {
+      retriesLeft -= 1;
+      setTimeout(loadPopup, 400);
+    }
+  });
+  if (isDev) registerViteDepStaleHeal(popupWindow, 'popup');
+  popupWindow.webContents.on('console-message', (_e, level, message, line, sourceId) => {
+    rendererLogger.info('renderer.console', { window: 'popup', level, message, line, sourceId });
+  });
+  popupWindow.webContents.on('render-process-gone', (_e, details) => {
+    log.error('appPopup.render-process-gone', { reason: details.reason, exitCode: details.exitCode });
+  });
+  popupWindow.webContents.on('preload-error', (_e, preloadPath, err) => {
+    log.error('appPopup.preload-error', { preloadPath, error: (err as Error).message });
+  });
+
+  popupWindow.on('blur', () => {
+    setTimeout(() => {
+      if (!popupWindow || popupWindow.isDestroyed() || !popupWindow.isVisible()) return;
+      if (BrowserWindow.getFocusedWindow() === popupWindow) return;
+      if (activePopup?.owner && BrowserWindow.getFocusedWindow() === activePopup.owner) return;
+      closeAppPopup('blur');
+    }, 80);
+  });
+  popupWindow.on('closed', () => {
+    popupWindow = null;
+    popupReady = false;
+    pendingRender = null;
+    activePopup = null;
+    showWhenRenderedId = null;
+    ownerCleanup?.();
+    ownerCleanup = null;
+  });
+
+  return popupWindow;
+}
+
+function sendRender(request: AppPopupOpenRequest): void {
+  if (!popupWindow || popupWindow.isDestroyed()) return;
+  if (!popupReady) {
+    pendingRender = request;
+    return;
+  }
+  popupWindow.webContents.send('app-popup:render', request);
+}
+
+function showRenderedPopup(): void {
+  if (!popupWindow || popupWindow.isDestroyed()) return;
+  popupWindow.showInactive();
+  popupWindow.setAlwaysOnTop(true, 'screen-saver');
+  popupWindow.focus();
+}
+
+function handlePopupRendererReady(event: IpcMainEvent): void {
+  if (!popupWindow || popupWindow.isDestroyed() || event.sender !== popupWindow.webContents) return;
+  popupReady = true;
+  const request = pendingRender ?? activePopup?.request;
+  if (request) {
+    pendingRender = null;
+    popupWindow.webContents.send('app-popup:render', request);
+  }
+}
+
+function notifyClosed(event: AppPopupClosed): void {
+  const origin = activePopup?.origin;
+  if (origin && !origin.isDestroyed()) {
+    origin.send('app-popup:closed', event);
+  }
+}
+
+function closeAppPopup(reason: AppPopupClosed['reason']): void {
+  if (!activePopup) {
+    if (popupWindow && !popupWindow.isDestroyed() && popupWindow.isVisible()) popupWindow.hide();
+    return;
+  }
+  const popupId = activePopup.id;
+  notifyClosed({ popupId, reason });
+  activePopup = null;
+  pendingRender = null;
+  showWhenRenderedId = null;
+  ownerCleanup?.();
+  ownerCleanup = null;
+  if (popupWindow && !popupWindow.isDestroyed()) popupWindow.hide();
+}
+
+function bindOwnerLifecycle(owner: BrowserWindow | null): void {
+  ownerCleanup?.();
+  ownerCleanup = null;
+  if (!owner || owner.isDestroyed()) return;
+
+  const reposition = (): void => {
+    if (!activePopup || !popupWindow || popupWindow.isDestroyed() || !popupWindow.isVisible()) return;
+    popupWindow.setBounds(computeBounds(activePopup.request, activePopup.owner), false);
+  };
+  const closeForOwner = (): void => closeAppPopup('owner-destroyed');
+
+  owner.on('move', reposition);
+  owner.on('resize', reposition);
+  owner.on('hide', closeForOwner);
+  owner.on('minimize', closeForOwner);
+  owner.on('closed', closeForOwner);
+  ownerCleanup = () => {
+    owner.off('move', reposition);
+    owner.off('resize', reposition);
+    owner.off('hide', closeForOwner);
+    owner.off('minimize', closeForOwner);
+    owner.off('closed', closeForOwner);
+  };
+}
+
+function openAppPopup(origin: WebContents, request: AppPopupOpenRequest): AppPopupOpenResult {
+  if (!request || typeof request !== 'object') throw new Error('app-popup:open requires a request');
+  if (!request.id || typeof request.id !== 'string') throw new Error('app-popup:open requires a string id');
+  if (!request.anchor || !isFiniteNumber(request.anchor.x) || !isFiniteNumber(request.anchor.y)) {
+    throw new Error('app-popup:open requires a finite anchor rect');
+  }
+
+  if (activePopup && activePopup.id !== request.id) closeAppPopup('replaced');
+
+  const owner = BrowserWindow.fromWebContents(origin);
+  const win = createPopupWindow();
+  activePopup = { id: request.id, request, origin, owner };
+  bindOwnerLifecycle(owner);
+
+  try {
+    if (owner && !owner.isDestroyed()) win.setParentWindow(owner);
+  } catch (err) {
+    log.warn('appPopup.setParentWindow.error', { error: (err as Error).message });
+  }
+
+  const bounds = computeBounds(request, owner);
+  win.setBounds(bounds, false);
+  showWhenRenderedId = request.id;
+  sendRender(request);
+  log.debug('appPopup.open', { id: request.id, kind: request.kind, bounds });
+  return { id: request.id };
+}
+
+function handleContentReady(popupId: string): void {
+  if (!activePopup || popupId !== activePopup.id) return;
+  if (showWhenRenderedId !== popupId) return;
+  showWhenRenderedId = null;
+  showRenderedPopup();
+}
+
+function handleResize(size: AppPopupContentSize): void {
+  if (!activePopup || size.popupId !== activePopup.id) return;
+  if (!popupWindow || popupWindow.isDestroyed()) return;
+  const current = activePopup.request;
+  activePopup.request = {
+    ...current,
+    width: sanitizeDimension(size.width, requestedSize(current).width, 80, 900),
+    height: sanitizeDimension(size.height, requestedSize(current).height, 40, sanitizeDimension(current.maxHeight, MAX_DEFAULT_HEIGHT, 80, 900)),
+  } as AppPopupOpenRequest;
+  popupWindow.setBounds(computeBounds(activePopup.request, activePopup.owner), false);
+}
+
+function forwardAction(action: AppPopupAction): void {
+  if (!activePopup || action.popupId !== activePopup.id) return;
+  const origin = activePopup.origin;
+  if (!origin.isDestroyed()) {
+    origin.send('app-popup:action', action);
+  }
+  if (action.close !== false) closeAppPopup('action');
+}
+
+export function registerAppPopupHandlers(): void {
+  if (registered) return;
+  registered = true;
+
+  ipcMain.handle('app-popup:open', (event, request: AppPopupOpenRequest) => {
+    return openAppPopup(event.sender, request);
+  });
+  ipcMain.handle('app-popup:close', (_event, popupId?: string) => {
+    if (!popupId || activePopup?.id === popupId) closeAppPopup('request');
+  });
+  ipcMain.on('app-popup:renderer-ready', handlePopupRendererReady);
+  ipcMain.on('app-popup:content-ready', (event, popupId: string) => {
+    if (popupWindow && event.sender === popupWindow.webContents) handleContentReady(popupId);
+  });
+  ipcMain.on('app-popup:content-size', (event, size: AppPopupContentSize) => {
+    if (popupWindow && event.sender === popupWindow.webContents) handleResize(size);
+  });
+  ipcMain.on('app-popup:action', (event, action: AppPopupAction) => {
+    if (popupWindow && event.sender === popupWindow.webContents) forwardAction(action);
+  });
+  ipcMain.on('app-popup:close-from-popup', (event, payload: { popupId?: string; reason?: string }) => {
+    if (popupWindow && event.sender === popupWindow.webContents && payload?.popupId === activePopup?.id) {
+      closeAppPopup(payload.reason === 'escape' ? 'escape' : 'request');
+    }
+  });
+  app.on('did-resign-active', () => {
+    if (popupWindow && !popupWindow.isDestroyed() && popupWindow.isVisible()) {
+      closeAppPopup('app-deactivated');
+    }
+  });
+}
+
+export function warmAppPopup(): void {
+  createPopupWindow();
+}

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -79,6 +79,7 @@ import { registerConsentHandlers } from './consentIpc';
 import { registerTelemetryHandlers } from './telemetryIpc';
 import { registerThemeHandlers } from './themeIpc';
 import { startSystemThemeWatcher } from './themeMode';
+import { registerAppPopupHandlers, warmAppPopup } from './appPopup';
 import { captureEvent } from './telemetry';
 import { registerChromeImportHandlers } from './chrome-import/ipc';
 import { mainLogger } from './logger';
@@ -291,6 +292,7 @@ function openShellAndWire(): BrowserWindow {
   createPillWindow();
   // Create logs overlay window (hidden) and anchor it to the hub
   createLogsWindow();
+  warmAppPopup();
   attachLogsToHub(shellWindow);
   mainLogger.info('main.tray.beforeCreate', { typeofCreateTray: typeof createTray });
   try {
@@ -426,6 +428,7 @@ app.whenReady().then(async () => {
   // ---------------------------------------------------------------------------
   registerConsentHandlers();
   registerTelemetryHandlers();
+  registerAppPopupHandlers();
   startSystemThemeWatcher();
   registerChannelHandlers(channelRouter, whatsAppAdapter);
   whatsAppAdapter.onStatusChange((status, detail) => {

--- a/app/src/preload/logs.ts
+++ b/app/src/preload/logs.ts
@@ -4,6 +4,7 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
+import { createPopupBridge } from './popupBridge';
 
 const DEBUG_LOGS_PRELOAD = process.env.BU_DEBUG_LOGS_PRELOAD === '1';
 function debugLog(message: string, data?: Record<string, unknown>): void {
@@ -56,6 +57,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       },
     },
   },
+  popup: createPopupBridge(),
   on: {
     sessionOutputTerm: (cb: (id: string, bytes: string) => void): (() => void) => {
       debugLog('[logs-preload] subscribe sessionOutputTerm');

--- a/app/src/preload/pill.ts
+++ b/app/src/preload/pill.ts
@@ -12,6 +12,7 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 import type { AgentEvent } from '../shared/types';
+import { createPopupBridge } from './popupBridge';
 
 // ---------------------------------------------------------------------------
 // D2 — Dev-only structured logger
@@ -310,6 +311,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       },
     },
   },
+  popup: createPopupBridge(),
 });
 
 log.info('preload.pill.ready', {

--- a/app/src/preload/popup.ts
+++ b/app/src/preload/popup.ts
@@ -1,0 +1,111 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type {
+  AppPopupAction,
+  AppPopupContentSize,
+  AppPopupOpenRequest,
+} from '../shared/app-popup';
+
+contextBridge.exposeInMainWorld('popupHostAPI', {
+  ready: (): void => {
+    ipcRenderer.send('app-popup:renderer-ready');
+  },
+  onRender: (cb: (request: AppPopupOpenRequest) => void): (() => void) => {
+    const handler = (_evt: unknown, request: AppPopupOpenRequest): void => cb(request);
+    ipcRenderer.on('app-popup:render', handler);
+    return () => ipcRenderer.removeListener('app-popup:render', handler);
+  },
+  contentReady: (popupId: string): void => {
+    ipcRenderer.send('app-popup:content-ready', popupId);
+  },
+  resize: (size: AppPopupContentSize): void => {
+    ipcRenderer.send('app-popup:content-size', size);
+  },
+  action: (action: AppPopupAction): void => {
+    ipcRenderer.send('app-popup:action', action);
+  },
+  close: (popupId: string, reason?: string): void => {
+    ipcRenderer.send('app-popup:close-from-popup', { popupId, reason });
+  },
+});
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  sessions: {
+    cancel: (id: string): Promise<void> => ipcRenderer.invoke('sessions:cancel', id),
+    memory: (): Promise<{
+      totalMb: number;
+      totalCpuPercent?: number;
+      sessions: Array<{ id: string; mb: number; cpuPercent?: number; status: string; processCount?: number }>;
+      processes: Array<{
+        pid?: number;
+        label: string;
+        type: string;
+        component?: string;
+        mb: number;
+        cpuPercent?: number;
+        sessionId?: string;
+        engineId?: string;
+        source?: string;
+      }>;
+      processCount: number;
+      errors?: string[];
+    }> => ipcRenderer.invoke('sessions:memory'),
+    listEngines: (): Promise<Array<{ id: string; displayName: string; binaryName: string }>> =>
+      ipcRenderer.invoke('sessions:list-engines'),
+    engineStatus: (engineId: string): Promise<{
+      id: string;
+      displayName: string;
+      installed: { installed: boolean; version?: string; error?: string };
+      authed: { authed: boolean; error?: string };
+    }> => ipcRenderer.invoke('sessions:engine-status', engineId),
+    engineLogin: (engineId: string): Promise<{ opened: boolean; error?: string }> =>
+      ipcRenderer.invoke('sessions:engine-login', engineId),
+    engineInstall: (engineId: string): Promise<{
+      opened: boolean;
+      completed?: boolean;
+      exitCode?: number | null;
+      signal?: string | null;
+      error?: string;
+      command?: string;
+      displayName?: string;
+      stdout?: string;
+      stderr?: string;
+      installed?: { installed: boolean; version?: string; error?: string };
+    }> => ipcRenderer.invoke('sessions:engine-install', engineId),
+  },
+  settings: {
+    open: (payload?: { focusBrowserCodeProvider?: string }): Promise<void> =>
+      ipcRenderer.invoke('settings:open', payload),
+    browserCode: {
+      getStatus: (): Promise<{
+        keys: Record<string, { masked: string; lastModel?: string }>;
+        active: string | null;
+        installed?: { installed: boolean; version?: string; error?: string };
+        providers: Array<{
+          id: string;
+          name: string;
+          defaultModel: string;
+          models: Array<{ id: string; label: string }>;
+        }>;
+      }> => ipcRenderer.invoke('settings:browsercode:get-status'),
+      save: (payload: { providerId: string; apiKey: string; lastModel?: string }): Promise<void> =>
+        ipcRenderer.invoke('settings:browsercode:save', payload),
+      test: (payload: { providerId: string; apiKey: string; model?: string }): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke('settings:browsercode:test', payload),
+      delete: (payload?: { providerId?: string }): Promise<void> =>
+        ipcRenderer.invoke('settings:browsercode:delete', payload),
+      setActive: (payload: { providerId: string }): Promise<void> =>
+        ipcRenderer.invoke('settings:browsercode:set-active', payload),
+    },
+    theme: {
+      get: (): Promise<{ mode: 'light' | 'dark' | 'system'; resolved: 'light' | 'dark' }> =>
+        ipcRenderer.invoke('theme:get'),
+      set: (mode: 'light' | 'dark' | 'system'): Promise<{ mode: 'light' | 'dark' | 'system'; resolved: 'light' | 'dark' }> =>
+        ipcRenderer.invoke('theme:set', mode),
+      onChange: (cb: (event: { mode: 'light' | 'dark' | 'system'; resolved: 'light' | 'dark' }) => void): (() => void) => {
+        const handler = (_evt: unknown, payload: { mode: 'light' | 'dark' | 'system'; resolved: 'light' | 'dark' }) => cb(payload);
+        ipcRenderer.on('theme:changed', handler);
+        return () => ipcRenderer.removeListener('theme:changed', handler);
+      },
+    },
+  },
+});

--- a/app/src/preload/popupBridge.ts
+++ b/app/src/preload/popupBridge.ts
@@ -1,0 +1,32 @@
+import { ipcRenderer } from 'electron';
+import type {
+  AppPopupAction,
+  AppPopupClosed,
+  AppPopupContentSize,
+  AppPopupOpenRequest,
+  AppPopupOpenResult,
+} from '../shared/app-popup';
+
+export function createPopupBridge(): {
+  open: (request: AppPopupOpenRequest) => Promise<AppPopupOpenResult>;
+  close: (popupId?: string) => Promise<void>;
+  resize: (size: AppPopupContentSize) => void;
+  onAction: (cb: (action: AppPopupAction) => void) => () => void;
+  onClosed: (cb: (event: AppPopupClosed) => void) => () => void;
+} {
+  return {
+    open: (request) => ipcRenderer.invoke('app-popup:open', request),
+    close: (popupId) => ipcRenderer.invoke('app-popup:close', popupId),
+    resize: (size) => ipcRenderer.send('app-popup:content-size', size),
+    onAction: (cb) => {
+      const handler = (_evt: unknown, action: AppPopupAction): void => cb(action);
+      ipcRenderer.on('app-popup:action', handler);
+      return () => ipcRenderer.removeListener('app-popup:action', handler);
+    },
+    onClosed: (cb) => {
+      const handler = (_evt: unknown, event: AppPopupClosed): void => cb(event);
+      ipcRenderer.on('app-popup:closed', handler);
+      return () => ipcRenderer.removeListener('app-popup:closed', handler);
+    },
+  };
+}

--- a/app/src/preload/shell.ts
+++ b/app/src/preload/shell.ts
@@ -7,6 +7,7 @@ import {
   validatePoolStats,
 } from '../shared/session-schemas';
 import type { AgentSession, HlEvent, TabInfo, BrowserPoolStats } from '../shared/session-schemas';
+import { createPopupBridge } from './popupBridge';
 
 type SettingsOpenPayload = { focusBrowserCodeProvider?: string };
 
@@ -51,6 +52,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.send('logs:update-anchor', anchor);
     },
   },
+  popup: createPopupBridge(),
   takeover: {
     show: (
       sessionId: string,

--- a/app/src/renderer/globals.d.ts
+++ b/app/src/renderer/globals.d.ts
@@ -224,6 +224,14 @@ interface ElectronTakeoverAPI {
   hide: (sessionId: string) => Promise<void>;
 }
 
+interface ElectronPopupAPI {
+  open: (request: import('../shared/app-popup').AppPopupOpenRequest) => Promise<import('../shared/app-popup').AppPopupOpenResult>;
+  close: (popupId?: string) => Promise<void>;
+  resize: (size: import('../shared/app-popup').AppPopupContentSize) => void;
+  onAction: (cb: (action: import('../shared/app-popup').AppPopupAction) => void) => () => void;
+  onClosed: (cb: (event: import('../shared/app-popup').AppPopupClosed) => void) => () => void;
+}
+
 interface ElectronSettingsApiKeyAPI {
   getMasked: () => Promise<{ present: boolean; masked: string | null }>;
   getStatus: () => Promise<{
@@ -340,6 +348,7 @@ interface ElectronSettingsAPI {
 interface ElectronAPI {
   pill: ElectronPillAPI;
   logs?: ElectronLogsAPI;
+  popup?: ElectronPopupAPI;
   takeover?: ElectronTakeoverAPI;
   sessions: ElectronSessionAPI;
   channels: ElectronChannelsAPI;

--- a/app/src/renderer/hub/AgentPane.tsx
+++ b/app/src/renderer/hub/AgentPane.tsx
@@ -3,17 +3,13 @@ import { STATUS_LABEL } from './constants';
 import { ContentRenderer, getPreview } from './ContentRenderer';
 import { Markdown, linkifyOutputPaths } from './Markdown';
 import { TerminalPane } from './TerminalPane';
-// Inline the SVG source so `fill="currentColor"` in the logos picks up the
-// menu's CSS color. `<img src=...>` renders in its own graphics context and
-// can't inherit text color.
-import cursorLogoSrc from './cursor-logo.svg?raw';
-import vscodeLogo from './vscode-logo.svg';
 import claudeCodeLogo from './claude-code-logo.svg';
 import openaiLogoDark from './openai-logo.svg';
 import openaiLogoLight from './openai-logo-light.svg';
 import opencodeLogoDark from './opencode-logo-dark.svg';
 import opencodeLogoLight from './opencode-logo-light.svg';
 import { useThemedAsset } from '../design/useThemedAsset';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 import type { AgentSession, OutputEntry } from './types';
 
 function formatElapsed(createdAt: number): string {
@@ -219,74 +215,12 @@ function formatFileSize(n: number | undefined): string {
   return `${(n / 1024 / 1024).toFixed(1)}MB`;
 }
 
-function EditorIcon({ id }: { id: string }): React.ReactElement {
-  if (id === 'cursor') {
-    return (
-      <span
-        className="editor-logo editor-logo--cursor"
-        dangerouslySetInnerHTML={{ __html: cursorLogoSrc as string }}
-      />
-    );
-  }
-  if (id === 'vscode' || id === 'vscode-insiders') {
-    return <img src={vscodeLogo} alt="" width={14} height={14} />;
-  }
-  if (id === 'zed' || id === 'zed-preview') {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <circle cx="12" cy="12" r="10" fill="#9a62ff" />
-        <path d="M8 8h8L8 16h8" stroke="#fff" strokeWidth="1.6" strokeLinejoin="round" fill="none" />
-      </svg>
-    );
-  }
-  if (id === 'windsurf') {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M4 16c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
-        <path d="M4 10c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
-      </svg>
-    );
-  }
-  if (id === 'sublime') {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M5 5v14l14-4V1L5 5Z" fill="#FF9800" />
-      </svg>
-    );
-  }
-  // JetBrains family — generic ring
-  if (['webstorm', 'intellij', 'intellij-ce', 'pycharm', 'pycharm-ce', 'rider', 'goland'].includes(id)) {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <rect x="2" y="2" width="20" height="20" rx="3" fill="#000" />
-        <path d="M7 17h6" stroke="#fff" strokeWidth="1.6" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  // Fallback: generic monitor icon.
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <rect x="1.5" y="2.5" width="11" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M5 11.5h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 function FileOutputRow({ entry }: { entry: OutputEntry }): React.ReactElement {
   const [editors, setEditors] = useState<Array<{ id: string; name: string }>>([]);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [popupId, setPopupId] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => { getEditors().then(setEditors).catch(() => setEditors([])); }, []);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const close = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
-    };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [menuOpen]);
 
   const onOpenInEditor = useCallback(async (editorId: string) => {
     console.log('[file_output] onOpenInEditor click', { editorId, path: entry.tool });
@@ -294,7 +228,6 @@ function FileOutputRow({ entry }: { entry: OutputEntry }): React.ReactElement {
       console.warn('[file_output] onOpenInEditor: entry.tool is falsy; aborting');
       return;
     }
-    setMenuOpen(false);
     const api = window.electronAPI?.sessions?.openInEditor;
     if (!api) {
       console.error('[file_output] window.electronAPI.sessions.openInEditor is undefined — preload bridge missing');
@@ -312,19 +245,50 @@ function FileOutputRow({ entry }: { entry: OutputEntry }): React.ReactElement {
     }
   }, [entry.tool]);
 
-  const onOpenWithDefault = useCallback(async () => {
-    if (!entry.tool) return;
-    setMenuOpen(false);
-    try { await window.electronAPI?.sessions?.downloadOutput?.(entry.tool); }
-    catch (err) { console.error('[file_output] openWithDefault failed', err); }
-  }, [entry.tool]);
-
   const onRevealInFinder = useCallback(async () => {
     if (!entry.tool) return;
-    setMenuOpen(false);
     try { await window.electronAPI?.sessions?.revealOutput?.(entry.tool); }
     catch (err) { console.error('[file_output] reveal failed', err); }
   }, [entry.tool]);
+
+  const toggleMenu = useCallback(async () => {
+    const button = buttonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
+      return;
+    }
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'menu',
+        placement: 'top-end',
+        width: 220,
+        items: [
+          ...editors.map((editor) => ({
+            id: `editor:${editor.id}`,
+            label: `Open in ${editor.name}`,
+            icon: { type: 'editor' as const, id: editor.id },
+          })),
+          {
+            id: 'reveal',
+            label: 'Reveal in Finder',
+            icon: { type: 'finder' as const },
+            separatorBefore: editors.length > 0,
+          },
+        ],
+      },
+      {
+        onAction: (action) => {
+          if (action.kind !== 'menu-select') return;
+          if (action.itemId.startsWith('editor:')) void onOpenInEditor(action.itemId.slice('editor:'.length));
+          if (action.itemId === 'reveal') void onRevealInFinder();
+        },
+        onClosed: () => setPopupId(null),
+      },
+    );
+    if (nextId) setPopupId(nextId);
+  }, [editors, onOpenInEditor, onRevealInFinder, popupId]);
 
   return (
     <div className="step step--file-output">
@@ -337,44 +301,16 @@ function FileOutputRow({ entry }: { entry: OutputEntry }): React.ReactElement {
       <span className="step__skill-label">Produced file</span>
       <span className="step__skill-topic" title={entry.tool}>{entry.content}</span>
       <span className="step__file-size">{formatFileSize(entry.fileSize)}</span>
-      <div className="step__file-ide" ref={menuRef}>
+      <div className="step__file-ide">
         <button
+          ref={buttonRef}
           className="step__file-download step__file-ide-toggle"
-          onClick={(e) => { e.stopPropagation(); setMenuOpen((o) => !o); }}
+          onClick={(e) => { e.stopPropagation(); void toggleMenu(); }}
           aria-haspopup="menu"
-          aria-expanded={menuOpen}
+          aria-expanded={Boolean(popupId)}
         >
           Open in {'\u25BE'}
         </button>
-        {menuOpen && (
-          <div className="step__file-ide-menu" role="menu">
-            {editors.map((ed) => (
-              <button
-                key={ed.id}
-                role="menuitem"
-                className="step__file-ide-menu-item"
-                onClick={() => onOpenInEditor(ed.id)}
-              >
-                <span className="step__file-ide-menu-icon"><EditorIcon id={ed.id} /></span>
-                <span>{ed.name}</span>
-              </button>
-            ))}
-            {editors.length > 0 && <div className="step__file-ide-menu-sep" />}
-            <button
-              role="menuitem"
-              className="step__file-ide-menu-item"
-              onClick={onRevealInFinder}
-              title="Show the file in Finder without opening it"
-            >
-              <span className="step__file-ide-menu-icon">
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-                  <path d="M2 4.5v6A1.5 1.5 0 003.5 12h7A1.5 1.5 0 0012 10.5V5.5A1.5 1.5 0 0010.5 4H7L5.5 2.5h-2A1.5 1.5 0 002 4z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-                </svg>
-              </span>
-              <span>Reveal in Finder</span>
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/app/src/renderer/hub/BrowserCodeModelPicker.tsx
+++ b/app/src/renderer/hub/BrowserCodeModelPicker.tsx
@@ -4,15 +4,16 @@ import kimiLogoLight from './kimi-light.svg';
 import minimaxLogo from './minimax-color.svg';
 import qwenLogo from './qwen-color.svg';
 import { useThemedAsset } from '../design/useThemedAsset';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 
-interface BrowserCodeProvider {
+export interface BrowserCodeProvider {
   id: string;
   name: string;
   defaultModel: string;
   models: Array<{ id: string; label: string }>;
 }
 
-interface BrowserCodeStatus {
+export interface BrowserCodeStatus {
   keys: Record<string, { masked: string; lastModel?: string }>;
   active: string | null;
   installed?: { installed: boolean; version?: string; error?: string };
@@ -25,7 +26,7 @@ interface BrowserCodeModelPickerProps {
   onOpenChange?: (open: boolean) => void;
 }
 
-function effectiveProviderModel(
+export function effectiveProviderModel(
   status: BrowserCodeStatus,
   provider: BrowserCodeProvider | undefined,
 ): string | undefined {
@@ -41,7 +42,7 @@ function ChevronIcon(): React.ReactElement {
   );
 }
 
-function ProviderMark({ providerId }: { providerId: string }): React.ReactElement {
+export function ProviderMark({ providerId }: { providerId: string }): React.ReactElement {
   const kimiLogo = useThemedAsset(kimiLogoDark, kimiLogoLight);
   if (providerId === 'minimax') {
     return <img className="browsercode-model-picker__logo" src={minimaxLogo} alt="" />;
@@ -55,7 +56,7 @@ function ProviderMark({ providerId }: { providerId: string }): React.ReactElemen
   return <span className="browsercode-model-picker__mark">{providerId.slice(0, 1).toUpperCase()}</span>;
 }
 
-function modelLabel(providers: BrowserCodeProvider[], modelId: string | undefined): string {
+export function modelLabel(providers: BrowserCodeProvider[], modelId: string | undefined): string {
   if (!modelId) return 'Model';
   for (const provider of providers) {
     const match = provider.models.find((model) => model.id === modelId);
@@ -64,7 +65,7 @@ function modelLabel(providers: BrowserCodeProvider[], modelId: string | undefine
   return modelId.includes('/') ? modelId.split('/').pop() ?? modelId : modelId;
 }
 
-function BrowserCodeSkeletonRows({ count = 3 }: { count?: number }): React.ReactElement {
+export function BrowserCodeSkeletonRows({ count = 3 }: { count?: number }): React.ReactElement {
   return (
     <>
       {Array.from({ length: count }, (_, index) => (
@@ -85,15 +86,9 @@ export function BrowserCodeModelPicker({
 }: BrowserCodeModelPickerProps): React.ReactElement | null {
   const [status, setStatus] = useState<BrowserCodeStatus>({ keys: {}, active: null, providers: [] });
   const [loaded, setLoaded] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [drilledProviderId, setDrilledProviderId] = useState<string | null>(null);
-  const [savingModel, setSavingModel] = useState<string | null>(null);
+  const [popupId, setPopupId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => { onOpenChange?.(open); }, [open, onOpenChange]);
-
-  useEffect(() => { if (!open) setDrilledProviderId(null); }, [open]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const refresh = useCallback(async () => {
     const api = window.electronAPI?.settings?.browserCode;
@@ -125,17 +120,10 @@ export function BrowserCodeModelPicker({
   }, [refresh, visible]);
 
   useEffect(() => {
-    if (!visible) setOpen(false);
-  }, [visible]);
-
-  useEffect(() => {
-    if (!open) return;
-    const close = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [open]);
+    if (visible) return;
+    closeAppPopup(popupId);
+    setPopupId(null);
+  }, [popupId, visible]);
 
   const currentProvider = useMemo(() => {
     const providerId = status.active ?? status.providers[0]?.id;
@@ -145,46 +133,52 @@ export function BrowserCodeModelPicker({
   const currentModel = effectiveProviderModel(status, currentProvider);
   const currentModelLabel = modelLabel(status.providers, currentModel);
   const hasAnyKey = Object.keys(status.keys).length > 0;
-  const canSwitchModels = hasAnyKey && status.installed?.installed !== false;
   const loadingStatus = !loaded && status.providers.length === 0;
 
-  const selectModel = useCallback(async (providerId: string, model: string) => {
-    const api = window.electronAPI?.settings?.browserCode;
-    if (!api) return;
-    if (!status.keys[providerId]) {
-      setOpen(false);
-      await window.electronAPI?.settings?.open?.();
+  const openMenu = useCallback(async () => {
+    const button = buttonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
       return;
     }
-    setSavingModel(model);
-    setError(null);
-    try {
-      console.info('[BrowserCodeModelPicker] model.save.request', { providerId, model });
-      await api.save({ providerId, lastModel: model, apiKey: '' });
-      await api.setActive({ providerId });
-      console.info('[BrowserCodeModelPicker] model.save.ok', { providerId, model });
-      await refresh();
-      setOpen(false);
-    } catch (err) {
-      const message = (err as Error).message;
-      setError(message);
-      console.warn('[BrowserCodeModelPicker] model.save.failed', { providerId, model, error: message });
-    } finally {
-      setSavingModel(null);
-    }
-  }, [refresh, status.keys]);
+
+    onOpenChange?.(true);
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'browsercode-model-picker',
+        placement: 'bottom-end',
+        width: 292,
+        maxHeight: 380,
+      },
+      {
+        onAction: (action) => {
+          if (action.kind === 'browsercode-model-changed') void refresh();
+        },
+        onClosed: () => {
+          setPopupId(null);
+          onOpenChange?.(false);
+          void refresh();
+        },
+      },
+    );
+    if (nextId) setPopupId(nextId);
+    else onOpenChange?.(false);
+  }, [onOpenChange, popupId, refresh]);
 
   if (!visible) return null;
 
   return (
-    <div className={`browsercode-model-picker${compact ? ' browsercode-model-picker--compact' : ''}`} ref={menuRef}>
+    <div className={`browsercode-model-picker${compact ? ' browsercode-model-picker--compact' : ''}`}>
       <button
+        ref={buttonRef}
         type="button"
         className="browsercode-model-picker__toggle"
-        onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
+        onClick={(e) => { e.stopPropagation(); void openMenu(); }}
         title={loadingStatus ? 'Loading BrowserCode model' : hasAnyKey ? `BrowserCode model: ${currentModelLabel}` : 'Set up BrowserCode model'}
         aria-haspopup="menu"
-        aria-expanded={open}
+        aria-expanded={Boolean(popupId)}
         aria-busy={loadingStatus}
       >
         {loadingStatus ? (
@@ -195,106 +189,173 @@ export function BrowserCodeModelPicker({
         ) : (
           <>
             {currentProvider && <ProviderMark providerId={currentProvider.id} />}
-            <span className="browsercode-model-picker__label">{currentModelLabel}</span>
+            <span className="browsercode-model-picker__label">{error ?? currentModelLabel}</span>
           </>
         )}
         <ChevronIcon />
       </button>
-      {open && (
-        <div className="browsercode-model-picker__menu" role="menu">
-          {loadingStatus ? (
-            <div className="browsercode-submenu browsercode-submenu--loading" aria-label="Loading BrowserCode providers">
-              <BrowserCodeSkeletonRows />
-            </div>
-          ) : !canSwitchModels && (
-            <button
-              type="button"
-              className="browsercode-model-picker__setup"
-              onClick={() => {
-                setOpen(false);
-                void window.electronAPI?.settings?.open?.();
-              }}
-              role="menuitem"
-            >
-              Set up BrowserCode in Settings
-            </button>
-          )}
-          {!loadingStatus && (drilledProviderId === null
-            ? status.providers.map((provider) => {
-                const isConfigured = !!status.keys[provider.id];
-                const isActiveProvider = status.active === provider.id;
-                return (
-                  <button
-                    key={provider.id}
-                    type="button"
-                    className={`browsercode-model-picker__item${isActiveProvider ? ' browsercode-model-picker__item--active' : ''}`}
-                    onClick={() => {
-                      if (!isConfigured) {
-                        setOpen(false);
-                        void window.electronAPI?.settings?.open?.({ focusBrowserCodeProvider: provider.id });
-                        return;
-                      }
-                      setDrilledProviderId(provider.id);
-                    }}
-                    role="menuitem"
-                    title={isConfigured ? provider.name : `Add a ${provider.name} key in Settings`}
-                  >
-                    <ProviderMark providerId={provider.id} />
-                    <span className="browsercode-model-picker__item-name">{provider.name}</span>
-                    {isActiveProvider && <span className="browsercode-model-picker__check">✓</span>}
-                    {!isConfigured && <span className="browsercode-model-picker__locked">Settings</span>}
-                    <span className="browsercode-model-picker__chevron-right" aria-hidden="true">
-                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                        <path d="M4 2.5L6.5 5L4 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </span>
-                  </button>
-                );
-              })
-            : (() => {
-                const provider = status.providers.find((p) => p.id === drilledProviderId);
-                if (!provider) return null;
-                const isConfiguredProvider = !!status.keys[provider.id];
-                return (
-                  <>
-                    <button
-                      type="button"
-                      className="browsercode-model-picker__back"
-                      onClick={() => setDrilledProviderId(null)}
-                      role="menuitem"
-                    >
-                      <span className="browsercode-model-picker__chevron-left" aria-hidden="true">
-                        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                          <path d="M6 2.5L3.5 5L6 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      </span>
-                      <ProviderMark providerId={provider.id} />
-                      <span className="browsercode-model-picker__item-name">{provider.name}</span>
-                    </button>
-                    {provider.models.map((model) => {
-                      const isActive = status.active === provider.id && effectiveProviderModel(status, provider) === model.id;
-                      return (
-                        <button
-                          key={model.id}
-                          type="button"
-                          className={`browsercode-model-picker__item${isActive ? ' browsercode-model-picker__item--active' : ''}`}
-                          onClick={() => { void selectModel(provider.id, model.id); }}
-                          disabled={savingModel === model.id}
-                          role="menuitem"
-                          title={isConfiguredProvider ? `Use ${model.label}` : `Add a ${provider.name} key in Settings`}
-                        >
-                          <span className="browsercode-model-picker__item-name">{model.label}</span>
-                          {isActive && <span className="browsercode-model-picker__check">✓</span>}
-                          {!isConfiguredProvider && <span className="browsercode-model-picker__locked">Settings</span>}
-                        </button>
-                      );
-                    })}
-                  </>
-                );
-              })())}
-          {error && <div className="browsercode-model-picker__error">{error}</div>}
+    </div>
+  );
+}
+
+interface BrowserCodeModelMenuContentProps {
+  onChanged?: () => void;
+  onClose?: () => void;
+}
+
+export function BrowserCodeModelMenuContent({
+  onChanged,
+  onClose,
+}: BrowserCodeModelMenuContentProps): React.ReactElement {
+  const [status, setStatus] = useState<BrowserCodeStatus>({ keys: {}, active: null, providers: [] });
+  const [loaded, setLoaded] = useState(false);
+  const [drilledProviderId, setDrilledProviderId] = useState<string | null>(null);
+  const [savingModel, setSavingModel] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const api = window.electronAPI?.settings?.browserCode;
+    if (!api) {
+      setLoaded(true);
+      return;
+    }
+    try {
+      const next = await api.getStatus();
+      setStatus(next);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const selectModel = useCallback(async (providerId: string, model: string) => {
+    const api = window.electronAPI?.settings?.browserCode;
+    if (!api) return;
+    if (!status.keys[providerId]) {
+      await window.electronAPI?.settings?.open?.({ focusBrowserCodeProvider: providerId });
+      onClose?.();
+      return;
+    }
+    setSavingModel(model);
+    setError(null);
+    try {
+      console.info('[BrowserCodeModelPicker] model.save.request', { providerId, model });
+      await api.save({ providerId, lastModel: model, apiKey: '' });
+      await api.setActive({ providerId });
+      console.info('[BrowserCodeModelPicker] model.save.ok', { providerId, model });
+      await refresh();
+      onChanged?.();
+      onClose?.();
+    } catch (err) {
+      const message = (err as Error).message;
+      setError(message);
+      console.warn('[BrowserCodeModelPicker] model.save.failed', { providerId, model, error: message });
+    } finally {
+      setSavingModel(null);
+    }
+  }, [onChanged, onClose, refresh, status.keys]);
+
+  const loadingStatus = !loaded && status.providers.length === 0;
+  const canSwitchModels = Object.keys(status.keys).length > 0 && status.installed?.installed !== false;
+
+  return (
+    <div className="browsercode-model-picker__menu" role="menu">
+      {loadingStatus ? (
+        <div className="browsercode-submenu browsercode-submenu--loading" aria-label="Loading BrowserCode providers">
+          <BrowserCodeSkeletonRows />
         </div>
+      ) : !canSwitchModels && (
+        <button
+          type="button"
+          className="browsercode-model-picker__setup"
+          onClick={() => {
+            void window.electronAPI?.settings?.open?.();
+            onClose?.();
+          }}
+          role="menuitem"
+        >
+          Set up BrowserCode in Settings
+        </button>
       )}
+
+      {!loadingStatus && canSwitchModels && (drilledProviderId === null
+        ? status.providers.map((provider) => {
+            const isConfigured = !!status.keys[provider.id];
+            const isActiveProvider = status.active === provider.id;
+            return (
+              <button
+                key={provider.id}
+                type="button"
+                className={`browsercode-model-picker__item${isActiveProvider ? ' browsercode-model-picker__item--active' : ''}`}
+                onClick={() => {
+                  if (!isConfigured) {
+                    void window.electronAPI?.settings?.open?.({ focusBrowserCodeProvider: provider.id });
+                    onClose?.();
+                    return;
+                  }
+                  setDrilledProviderId(provider.id);
+                }}
+                role="menuitem"
+                title={isConfigured ? provider.name : `Add a ${provider.name} key in Settings`}
+              >
+                <ProviderMark providerId={provider.id} />
+                <span className="browsercode-model-picker__item-name">{provider.name}</span>
+                {isActiveProvider && <span className="browsercode-model-picker__check">✓</span>}
+                {!isConfigured && <span className="browsercode-model-picker__locked">Settings</span>}
+                <span className="browsercode-model-picker__chevron-right" aria-hidden="true">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <path d="M4 2.5L6.5 5L4 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+              </button>
+            );
+          })
+        : (() => {
+            const provider = status.providers.find((p) => p.id === drilledProviderId);
+            if (!provider) return null;
+            const isConfiguredProvider = !!status.keys[provider.id];
+            return (
+              <>
+                <button
+                  type="button"
+                  className="browsercode-model-picker__back"
+                  onClick={() => setDrilledProviderId(null)}
+                  role="menuitem"
+                >
+                  <span className="browsercode-model-picker__chevron-left" aria-hidden="true">
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                      <path d="M6 2.5L3.5 5L6 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </span>
+                  <ProviderMark providerId={provider.id} />
+                  <span className="browsercode-model-picker__item-name">{provider.name}</span>
+                </button>
+                {provider.models.map((model) => {
+                  const isActive = status.active === provider.id && effectiveProviderModel(status, provider) === model.id;
+                  return (
+                    <button
+                      key={model.id}
+                      type="button"
+                      className={`browsercode-model-picker__item${isActive ? ' browsercode-model-picker__item--active' : ''}`}
+                      onClick={() => { void selectModel(provider.id, model.id); }}
+                      disabled={savingModel === model.id}
+                      role="menuitem"
+                      title={isConfiguredProvider ? `Use ${model.label}` : `Add a ${provider.name} key in Settings`}
+                    >
+                      <span className="browsercode-model-picker__item-name">{model.label}</span>
+                      {isActive && <span className="browsercode-model-picker__check">✓</span>}
+                      {!isConfiguredProvider && <span className="browsercode-model-picker__locked">Settings</span>}
+                    </button>
+                  );
+                })}
+              </>
+            );
+          })())}
+      {error && <div className="browsercode-model-picker__error">{error}</div>}
     </div>
   );
 }

--- a/app/src/renderer/hub/EnginePicker.tsx
+++ b/app/src/renderer/hub/EnginePicker.tsx
@@ -7,6 +7,7 @@ import opencodeLogoLightSrc from './opencode-logo-light.svg?raw';
 import { BrowserCodeProviderSubmenu } from './BrowserCodeModelPicker';
 import { useThemedAsset } from '../design/useThemedAsset';
 import { pollInstalledStatus } from '../shared/installStatus';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 
 export interface EngineInfo {
   id: string;
@@ -21,7 +22,7 @@ export interface EngineStatus {
   authed: { authed: boolean; error?: string };
 }
 
-function EngineLogo({ id }: { id: string }): React.ReactElement {
+export function EngineLogo({ id }: { id: string }): React.ReactElement {
   const openaiLogoSrc = useThemedAsset(openaiLogoDarkSrc, openaiLogoLightSrc);
   const opencodeLogoSrc = useThemedAsset(opencodeLogoDarkSrc, opencodeLogoLightSrc);
   if (id === 'claude-code') {
@@ -53,23 +54,128 @@ function ChevronIcon(): React.ReactElement {
 interface EnginePickerProps {
   value: string;
   onChange: (engineId: string) => void;
-  /** Fires when the dropdown opens/closes. Used by hosts (e.g. the pill
-   *  renderer) that need to grow their window so the menu isn't clipped. */
   onOpenChange?: (open: boolean) => void;
+}
+
+async function fetchEngines(): Promise<EngineInfo[]> {
+  return (await window.electronAPI?.sessions?.listEngines?.()) ?? [];
 }
 
 export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProps): React.ReactElement {
   const [engines, setEngines] = useState<EngineInfo[]>([]);
   const [statuses, setStatuses] = useState<Record<string, EngineStatus>>({});
-  const [open, setOpen] = useState(false);
+  const [popupId, setPopupId] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const refreshStatus = useCallback(async (ids: string[]): Promise<EngineStatus[]> => {
+    console.info('[EnginePicker] refreshStatus.request', { ids });
+    const updates = await Promise.all(
+      ids.map(async (id) => {
+        try { return await window.electronAPI?.sessions?.engineStatus?.(id); }
+        catch (err) {
+          console.warn('[EnginePicker] refreshStatus.failed', { id, error: (err as Error).message });
+          return null;
+        }
+      }),
+    );
+    const validUpdates = updates.filter((u): u is EngineStatus => Boolean(u));
+    setStatuses((prev) => {
+      const next = { ...prev };
+      for (const u of validUpdates) next[u.id] = u;
+      return next;
+    });
+    return validUpdates;
+  }, []);
+
+  const refreshEngines = useCallback(async (): Promise<void> => {
+    try {
+      const list = await fetchEngines();
+      setEngines(list);
+      if (list.length > 0) void refreshStatus(list.map((e) => e.id));
+    } catch (err) {
+      console.error('[EnginePicker] listEngines failed', err);
+    }
+  }, [refreshStatus]);
+
+  useEffect(() => { void refreshEngines(); }, [refreshEngines]);
+
+  const currentEngine = engines.find((e) => e.id === value) ?? engines[0];
+  const currentStatus = currentEngine ? statuses[currentEngine.id] : undefined;
+  const currentInstalled = currentStatus?.installed?.installed ?? true;
+  const currentAuthed = currentStatus?.authed?.authed ?? true;
+
+  const openMenu = useCallback(async () => {
+    const button = buttonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
+      return;
+    }
+    onOpenChange?.(true);
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'engine-picker',
+        value,
+        placement: 'top-end',
+        width: 266,
+        maxHeight: 380,
+      },
+      {
+        onAction: (action) => {
+          if (action.kind === 'engine-select') onChange(action.engineId);
+        },
+        onClosed: () => {
+          setPopupId(null);
+          onOpenChange?.(false);
+          void refreshEngines();
+        },
+      },
+    );
+    if (nextId) setPopupId(nextId);
+    else onOpenChange?.(false);
+  }, [onChange, onOpenChange, popupId, refreshEngines, value]);
+
+  if (engines.length === 0) return <span className="engine-picker engine-picker--empty" />;
+
+  return (
+    <div className="engine-picker">
+      <button
+        ref={buttonRef}
+        type="button"
+        className="engine-picker__toggle"
+        onClick={(e) => { e.stopPropagation(); void openMenu(); }}
+        aria-haspopup="menu"
+        aria-expanded={Boolean(popupId)}
+        title={currentEngine ? `Engine: ${currentEngine.displayName}${!currentAuthed ? ' — not logged in' : ''}` : 'Pick engine'}
+      >
+        {currentEngine && <EngineLogo id={currentEngine.id} />}
+        <span className="engine-picker__name">{currentEngine?.displayName ?? '…'}</span>
+        {(!currentInstalled || !currentAuthed) && <span className="engine-picker__dot" aria-label="Needs setup" />}
+        <ChevronIcon />
+      </button>
+    </div>
+  );
+}
+
+interface EnginePickerMenuContentProps {
+  value: string;
+  onChange: (engineId: string) => void;
+  onClose?: () => void;
+}
+
+export function EnginePickerMenuContent({
+  value,
+  onChange,
+  onClose,
+}: EnginePickerMenuContentProps): React.ReactElement {
+  const [engines, setEngines] = useState<EngineInfo[]>([]);
+  const [statuses, setStatuses] = useState<Record<string, EngineStatus>>({});
   const [loggingIn, setLoggingIn] = useState<string | null>(null);
   const [installing, setInstalling] = useState<string | null>(null);
-  const [browserCodeFlyoutOpen, setBrowserCodeFlyoutOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [drilledIntoBrowserCode, setDrilledIntoBrowserCode] = useState(false);
   const loggingInRef = useRef<string | null>(null);
   const installingRef = useRef<string | null>(null);
-
-  useEffect(() => { onOpenChange?.(open); }, [open, onOpenChange]);
 
   const refreshStatus = useCallback(async (ids: string[]): Promise<EngineStatus[]> => {
     console.info('[EnginePicker] refreshStatus.request', { ids });
@@ -100,12 +206,11 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     return validUpdates;
   }, []);
 
-  // Mount: fetch engine list + initial statuses.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const list = (await window.electronAPI?.sessions?.listEngines?.()) ?? [];
+        const list = await fetchEngines();
         if (cancelled) return;
         setEngines(list);
         if (list.length > 0) void refreshStatus(list.map((e) => e.id));
@@ -114,13 +219,10 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     return () => { cancelled = true; };
   }, [refreshStatus]);
 
-  // Re-probe auth whenever the menu opens so a just-completed login flow is
-  // reflected without needing to re-mount the component.
   useEffect(() => {
-    if (!open) return;
     if (engines.length === 0) return;
     void refreshStatus(engines.map((e) => e.id));
-  }, [open, engines, refreshStatus]);
+  }, [engines, refreshStatus]);
 
   useEffect(() => {
     if (!installing) return;
@@ -130,57 +232,35 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     }
   }, [installing, statuses]);
 
-  // Close on outside click.
-  useEffect(() => {
-    if (!open) return;
-    const close = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [open]);
-
-  // While a login is pending, poll auth status until it flips to `true` or
-  // the user gives up (stops interacting for ~2 min).
   useEffect(() => {
     if (!loggingIn) return;
     let cancelled = false;
     let attempts = 0;
-    const tick = async () => {
+    const tick = async (): Promise<void> => {
       if (cancelled) return;
       attempts++;
       const updates = await refreshStatus([loggingIn]);
       const st = updates.find((u) => u.id === loggingIn) ?? statuses[loggingIn];
-      if (st?.authed?.authed) {
+      if (st?.authed?.authed || attempts >= 40) {
         loggingInRef.current = null;
         setLoggingIn(null);
         return;
       }
-      if (attempts >= 40) {
-        loggingInRef.current = null;
-        setLoggingIn(null);
-        return;
-      }
-      setTimeout(tick, 3000);
+      setTimeout(() => { void tick(); }, 3000);
     };
-    const id = setTimeout(tick, 2000);
+    const id = setTimeout(() => { void tick(); }, 2000);
     return () => { cancelled = true; clearTimeout(id); };
-    // statuses intentionally excluded — we only poll while loggingIn flag is set.
+    // statuses intentionally excluded; polling reads the latest refresh result.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggingIn, refreshStatus]);
 
-  const currentEngine = engines.find((e) => e.id === value) ?? engines[0];
-  const currentStatus = currentEngine ? statuses[currentEngine.id] : undefined;
-  const currentInstalled = currentStatus?.installed?.installed ?? true;
-  const currentAuthed = currentStatus?.authed?.authed ?? true;
-
-  const selectEngine = (id: string) => {
+  const selectEngine = (id: string): void => {
     console.info('[EnginePicker] selectEngine', { id });
     onChange(id);
-    setOpen(false);
+    onClose?.();
   };
 
-  const onLoginClick = async (id: string) => {
+  const onLoginClick = async (id: string): Promise<void> => {
     if (loggingInRef.current === id) return;
     console.info('[EnginePicker] login.request', { id });
     loggingInRef.current = id;
@@ -199,10 +279,10 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     }
   };
 
-  const openBrowserCodeSetup = async () => {
+  const openBrowserCodeSetup = async (): Promise<void> => {
     console.info('[EnginePicker] browsercode.setup.openSettings');
     onChange('browsercode');
-    setOpen(false);
+    onClose?.();
     try {
       await window.electronAPI?.settings?.open?.();
     } catch (err) {
@@ -210,7 +290,7 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     }
   };
 
-  const onInstallClick = async (id: string) => {
+  const onInstallClick = async (id: string): Promise<void> => {
     if (installingRef.current === id) return;
     console.info('[EnginePicker] install.request', { id });
     installingRef.current = id;
@@ -237,7 +317,7 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
     }
   };
 
-  const onItemClick = (id: string, installed: boolean, authed: boolean) => {
+  const onItemClick = (id: string, installed: boolean, authed: boolean): void => {
     console.info('[EnginePicker] item.click', { id, installed, authed });
     if (installingRef.current === id || loggingInRef.current === id) return;
     if (!installed) {
@@ -252,81 +332,81 @@ export function EnginePicker({ value, onChange, onOpenChange }: EnginePickerProp
       void onLoginClick(id);
       return;
     }
+    if (id === 'browsercode') {
+      setDrilledIntoBrowserCode(true);
+      return;
+    }
     selectEngine(id);
   };
 
-  if (engines.length === 0) return <span className="engine-picker engine-picker--empty" />;
+  if (drilledIntoBrowserCode) {
+    return (
+      <div className="engine-picker__menu" role="menu">
+        <button
+          type="button"
+          className="engine-picker__back"
+          onClick={() => setDrilledIntoBrowserCode(false)}
+          role="menuitem"
+        >
+          <span className="engine-picker__chevron-left" aria-hidden="true">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+              <path d="M6 2.5L3.5 5L6 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </span>
+          <EngineLogo id="browsercode" />
+          <span className="engine-picker__item-name">BrowserCode</span>
+        </button>
+        <BrowserCodeProviderSubmenu onSelected={() => {
+          onChange('browsercode');
+          setDrilledIntoBrowserCode(false);
+          onClose?.();
+        }} />
+      </div>
+    );
+  }
 
   return (
-    <div className="engine-picker" ref={menuRef}>
-      <button
-        type="button"
-        className="engine-picker__toggle"
-        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={currentEngine ? `Engine: ${currentEngine.displayName}${!currentAuthed ? ' — not logged in' : ''}` : 'Pick engine'}
-      >
-        {currentEngine && <EngineLogo id={currentEngine.id} />}
-        <span className="engine-picker__name">{currentEngine?.displayName ?? '…'}</span>
-        {(!currentInstalled || !currentAuthed) && <span className="engine-picker__dot" aria-label="Needs setup" />}
-        <ChevronIcon />
-      </button>
-      {open && (
-        <div className="engine-picker__menu" role="menu">
-          {engines.map((e) => {
-            const st = statuses[e.id];
-            const installed = st?.installed?.installed ?? true;
-            const authed = st?.authed?.authed ?? true;
-            const needsSetup = !installed || !authed;
-            const actionPending = installing === e.id || loggingIn === e.id;
-            const setupLabel = e.id === 'browsercode' ? 'Set up' : 'Log in';
-            const installLabel = installing === e.id ? 'Installing…' : 'Install';
-            const isBrowserCode = e.id === 'browsercode';
-            const showSubmenu = isBrowserCode && installed && authed && browserCodeFlyoutOpen;
-            return (
-              <div
-                key={e.id}
-                className="engine-picker__item-wrap"
-                onMouseEnter={() => { if (isBrowserCode && installed && authed) setBrowserCodeFlyoutOpen(true); else setBrowserCodeFlyoutOpen(false); }}
-              >
-                <button
-                  type="button"
-                  className={`engine-picker__item${e.id === value ? ' engine-picker__item--active' : ''}${actionPending ? ' engine-picker__item--disabled' : ''}`}
-                  onClick={() => onItemClick(e.id, installed, authed)}
-                  disabled={actionPending}
-                  title={!installed ? st?.installed?.error ?? `Install ${e.displayName}` : !authed ? st?.authed?.error ?? 'Start setup' : `Use ${e.displayName}`}
-                  role="menuitem"
-                >
-                  <EngineLogo id={e.id} />
-                  <span className="engine-picker__item-name">{e.displayName}</span>
-                  {e.id === value && <span className="engine-picker__check">✓</span>}
-                  {needsSetup && installed && (
-                    <span className="engine-picker__item-login">
-                      {loggingIn === e.id ? 'Waiting…' : setupLabel}
-                    </span>
-                  )}
-                  {!installed && (
-                    <span className="engine-picker__item-login">{installLabel}</span>
-                  )}
-                  {isBrowserCode && installed && authed && (
-                    <span className="engine-picker__chevron-right" aria-hidden="true">
-                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                        <path d="M4 2.5L6.5 5L4 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </span>
-                  )}
-                </button>
-                {showSubmenu && (
-                  <div className="engine-picker__flyout">
-                    <BrowserCodeProviderSubmenu onSelected={() => { onChange('browsercode'); setOpen(false); setBrowserCodeFlyoutOpen(false); }} />
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
+    <div className="engine-picker__menu" role="menu">
+      {engines.map((e) => {
+        const st = statuses[e.id];
+        const installed = st?.installed?.installed ?? true;
+        const authed = st?.authed?.authed ?? true;
+        const needsSetup = !installed || !authed;
+        const actionPending = installing === e.id || loggingIn === e.id;
+        const setupLabel = e.id === 'browsercode' ? 'Set up' : 'Log in';
+        const installLabel = installing === e.id ? 'Installing…' : 'Install';
+        const isBrowserCode = e.id === 'browsercode';
+        return (
+          <button
+            key={e.id}
+            type="button"
+            className={`engine-picker__item${e.id === value ? ' engine-picker__item--active' : ''}${actionPending ? ' engine-picker__item--disabled' : ''}`}
+            onClick={() => onItemClick(e.id, installed, authed)}
+            disabled={actionPending}
+            title={!installed ? st?.installed?.error ?? `Install ${e.displayName}` : !authed ? st?.authed?.error ?? 'Start setup' : `Use ${e.displayName}`}
+            role="menuitem"
+          >
+            <EngineLogo id={e.id} />
+            <span className="engine-picker__item-name">{e.displayName}</span>
+            {e.id === value && !isBrowserCode && <span className="engine-picker__check">✓</span>}
+            {needsSetup && installed && (
+              <span className="engine-picker__item-login">
+                {loggingIn === e.id ? 'Waiting…' : setupLabel}
+              </span>
+            )}
+            {!installed && (
+              <span className="engine-picker__item-login">{installLabel}</span>
+            )}
+            {isBrowserCode && installed && authed && (
+              <span className="engine-picker__chevron-right" aria-hidden="true">
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                  <path d="M4 2.5L6.5 5L4 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/app/src/renderer/hub/MemoryIndicator.tsx
+++ b/app/src/renderer/hub/MemoryIndicator.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 
 interface ProcessInfo {
   pid?: number;
@@ -52,7 +53,8 @@ interface MemoryIndicatorProps {
 }
 
 export function MemoryIndicator({ onOpenSettings, settingsShortcut }: MemoryIndicatorProps): React.ReactElement | null {
-  const [open, setOpen] = useState(false);
+  const [popupId, setPopupId] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const { data } = useQuery<MemoryData>({
     queryKey: ['memory'],
@@ -61,7 +63,7 @@ export function MemoryIndicator({ onOpenSettings, settingsShortcut }: MemoryIndi
       if (!api) return { totalMb: 0, totalCpuPercent: 0, sessions: [], processes: [], processCount: 0 };
       return api.sessions.memory();
     },
-    refetchInterval: open ? 5000 : 15000,
+    refetchInterval: popupId ? 5000 : 15000,
     staleTime: 4000,
   });
 
@@ -75,14 +77,38 @@ export function MemoryIndicator({ onOpenSettings, settingsShortcut }: MemoryIndi
     staleTime: Infinity,
   });
 
+  const openMenu = useCallback(async () => {
+    const button = buttonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
+      return;
+    }
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'memory-indicator',
+        placement: 'bottom-start',
+        width: 360,
+        maxHeight: 420,
+      },
+      {
+        onClosed: () => setPopupId(null),
+      },
+    );
+    if (nextId) setPopupId(nextId);
+  }, [popupId]);
+
   if (!data) return null;
 
   return (
     <div className="mem-indicator">
       <button
+        ref={buttonRef}
         className="mem-indicator__btn"
-        onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
+        onClick={(e) => { e.stopPropagation(); void openMenu(); }}
+        aria-expanded={Boolean(popupId)}
+        aria-haspopup="menu"
       >
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
           <rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
@@ -107,49 +133,70 @@ export function MemoryIndicator({ onOpenSettings, settingsShortcut }: MemoryIndi
           v{appInfo.version}
         </span>
       )}
-      {open && (
-        <>
-          <div className="mem-indicator__scrim" onClick={() => setOpen(false)} />
-          <div className="mem-indicator__dropdown">
-            <div className="mem__header">
-              <span className="mem__title">Resource usage</span>
-              <span className="mem__total">{formatGb(data.totalMb)} / {formatCpu(data.totalCpuPercent)}</span>
+    </div>
+  );
+}
+
+export function MemoryIndicatorContent(): React.ReactElement {
+  const [data, setData] = useState<MemoryData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchOnce = async (): Promise<void> => {
+      const api = window.electronAPI;
+      if (!api) return;
+      try {
+        const next = await api.sessions.memory();
+        if (!cancelled) setData(next);
+      } catch (err) {
+        console.warn('[MemoryIndicator] memory fetch failed', err);
+      }
+    };
+    void fetchOnce();
+    const interval = window.setInterval(fetchOnce, 5000);
+    return () => { cancelled = true; window.clearInterval(interval); };
+  }, []);
+
+  if (!data) {
+    return <div className="mem-popup mem-popup--loading">Loading…</div>;
+  }
+
+  return (
+    <div className="mem-popup">
+      <div className="mem__header">
+        <span className="mem__title">Resource usage</span>
+        <span className="mem__total">{formatGb(data.totalMb)} / {formatCpu(data.totalCpuPercent)}</span>
+      </div>
+      <div className="mem__processes">
+        {(data.processes ?? [])
+          .sort((a, b) => {
+            if (a.sessionId && !b.sessionId) return -1;
+            if (!a.sessionId && b.sessionId) return 1;
+            return b.mb - a.mb || (b.cpuPercent ?? 0) - (a.cpuPercent ?? 0);
+          })
+          .map((p, i) => (
+            <div key={p.pid ?? i} className="mem__session-row" title={`${p.type}${p.pid ? ` pid ${p.pid}` : ''}${p.component ? ` (${p.component})` : ''}`}>
+              <span className={`mem__dot ${p.sessionId ? statusDotClass(data.sessions.find((s) => s.id === p.sessionId)?.status ?? 'stopped') : 'mem__dot--system'}`} />
+              <span className="mem__session-id">{p.label}</span>
+              <span className="mem__session-mb">{Math.round(p.mb)} MB / {formatCpu(p.cpuPercent)}</span>
+              {p.sessionId && (
+                <button
+                  className="mem__kill-btn"
+                  onClick={() => {
+                    const api = window.electronAPI;
+                    if (!api || !p.sessionId) return;
+                    api.sessions.cancel(p.sessionId).catch(() => {});
+                  }}
+                  aria-label="Stop session"
+                >
+                  <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
+                    <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                  </svg>
+                </button>
+              )}
             </div>
-            <div className="mem__processes">
-              {(data.processes ?? [])
-                .sort((a, b) => {
-                  if (a.sessionId && !b.sessionId) return -1;
-                  if (!a.sessionId && b.sessionId) return 1;
-                  return b.mb - a.mb || (b.cpuPercent ?? 0) - (a.cpuPercent ?? 0);
-                })
-                .map((p, i) => (
-                  <div key={p.pid ?? i} className="mem__session-row" title={`${p.type}${p.pid ? ` pid ${p.pid}` : ''}${p.component ? ` (${p.component})` : ''}`}>
-                    <span className={`mem__dot ${p.sessionId ? statusDotClass(data.sessions.find((s) => s.id === p.sessionId)?.status ?? 'stopped') : 'mem__dot--system'}`} />
-                    <span className="mem__session-id">
-                      {p.label}
-                    </span>
-                    <span className="mem__session-mb">{Math.round(p.mb)} MB / {formatCpu(p.cpuPercent)}</span>
-                    {p.sessionId && (
-                      <button
-                        className="mem__kill-btn"
-                        onClick={() => {
-                          const api = window.electronAPI;
-                          if (!api || !p.sessionId) return;
-                          api.sessions.cancel(p.sessionId).catch(() => {});
-                        }}
-                        aria-label="Stop session"
-                      >
-                        <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                          <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                        </svg>
-                      </button>
-                    )}
-                  </div>
-                ))}
-            </div>
-          </div>
-        </>
-      )}
+          ))}
+      </div>
     </div>
   );
 }

--- a/app/src/renderer/hub/Sidebar.tsx
+++ b/app/src/renderer/hub/Sidebar.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { AgentSession, SessionStatus } from './types';
 import { orderSessionsForSidebar } from './sessionOrdering';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 
 interface SidebarSession extends AgentSession {
   primarySite?: string | null;
@@ -150,36 +151,47 @@ function SessionRow({
   const dot = STATUS_DOT[s.status];
   const favicon = faviconUrl(s.primarySite);
   const last = s.lastActivityAt ?? s.createdAt;
-  const [menuOpen, setMenuOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onDocClick = (e: MouseEvent): void => {
-      if (!rootRef.current?.contains(e.target as Node)) setMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setMenuOpen(false);
-    };
-    window.addEventListener('mousedown', onDocClick);
-    window.addEventListener('keydown', onKey);
-    return () => {
-      window.removeEventListener('mousedown', onDocClick);
-      window.removeEventListener('keydown', onKey);
-    };
-  }, [menuOpen]);
+  const [popupId, setPopupId] = useState<string | null>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   const isRunning = s.status === 'running' || s.status === 'stuck';
   const isPaused = s.status === 'paused';
   const handleAction = (action: SidebarRowAction): void => {
-    setMenuOpen(false);
     onAction?.(s.id, action);
+  };
+  const toggleMenu = async (): Promise<void> => {
+    const button = menuButtonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
+      return;
+    }
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'menu',
+        placement: 'bottom-end',
+        width: 148,
+        items: [
+          { id: 'rerun', label: 'Re-run' },
+          ...(isPaused ? [{ id: 'resume', label: 'Resume' }] : []),
+          ...(isRunning ? [{ id: 'pause', label: 'Pause' }] : []),
+          ...((isRunning || isPaused) ? [{ id: 'stop', label: 'Stop', tone: 'danger' as const }] : []),
+        ],
+      },
+      {
+        onAction: (action) => {
+          if (action.kind === 'menu-select') handleAction(action.itemId as SidebarRowAction);
+        },
+        onClosed: () => setPopupId(null),
+      },
+    );
+    if (nextId) setPopupId(nextId);
   };
 
   return (
     <div
-      ref={rootRef}
-      className={`sidebar__row-wrapper${menuOpen ? ' sidebar__row-wrapper--menu-open' : ''}`}
+      className={`sidebar__row-wrapper${popupId ? ' sidebar__row-wrapper--menu-open' : ''}`}
     >
       <button
         type="button"
@@ -205,67 +217,21 @@ function SessionRow({
 
       {onAction && (
         <button
+          ref={menuButtonRef}
           type="button"
           className="sidebar__row-menu-btn"
           onMouseDown={preventMouseFocus}
           onClick={(e) => {
             e.stopPropagation();
-            setMenuOpen((v) => !v);
+            void toggleMenu();
           }}
           tabIndex={-1}
           aria-label="Session actions"
           aria-haspopup="menu"
-          aria-expanded={menuOpen}
+          aria-expanded={Boolean(popupId)}
         >
           <MoreIcon />
         </button>
-      )}
-
-      {menuOpen && (
-        <div className="sidebar__row-menu" role="menu">
-          <button
-            className="sidebar__row-menu-item"
-            role="menuitem"
-            onMouseDown={preventMouseFocus}
-            onClick={() => handleAction('rerun')}
-            tabIndex={-1}
-          >
-            Re-run
-          </button>
-          {isPaused && (
-            <button
-              className="sidebar__row-menu-item"
-              role="menuitem"
-              onMouseDown={preventMouseFocus}
-              onClick={() => handleAction('resume')}
-              tabIndex={-1}
-            >
-              Resume
-            </button>
-          )}
-          {isRunning && (
-            <button
-              className="sidebar__row-menu-item"
-              role="menuitem"
-              onMouseDown={preventMouseFocus}
-              onClick={() => handleAction('pause')}
-              tabIndex={-1}
-            >
-              Pause
-            </button>
-          )}
-          {(isRunning || isPaused) && (
-            <button
-              className="sidebar__row-menu-item"
-              role="menuitem"
-              onMouseDown={preventMouseFocus}
-              onClick={() => handleAction('stop')}
-              tabIndex={-1}
-            >
-              Stop
-            </button>
-          )}
-        </div>
       )}
     </div>
   );

--- a/app/src/renderer/logs/LogsApp.tsx
+++ b/app/src/renderer/logs/LogsApp.tsx
@@ -99,6 +99,9 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
       closeAppPopup(popupId);
       return;
     }
+    const resolvedEditors = editors.length > 0
+      ? editors
+      : await getEditors().then((list) => { setEditors(list); return list; }).catch(() => [] as Array<{ id: string; name: string }>);
     const nextId = await openAnchoredAppPopup(
       button,
       {
@@ -106,7 +109,7 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
         placement: 'top-start',
         width: 220,
         items: [
-          ...editors.map((editor) => ({
+          ...resolvedEditors.map((editor) => ({
             id: `editor:${editor.id}`,
             label: `Open in ${editor.name}`,
             icon: { type: 'editor' as const, id: editor.id },
@@ -115,7 +118,7 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
             id: 'reveal',
             label: 'Reveal in Finder',
             icon: { type: 'finder' as const },
-            separatorBefore: editors.length > 0,
+            separatorBefore: resolvedEditors.length > 0,
           },
         ],
       },

--- a/app/src/renderer/logs/LogsApp.tsx
+++ b/app/src/renderer/logs/LogsApp.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { TerminalPane } from '../hub/TerminalPane';
-// Reuse the hub's editor-logo assets so the logs window's "Open in ..." menu
-// matches the hub's FileOutputRow visually.
-import cursorLogoSrc from '../hub/cursor-logo.svg?raw';
-import vscodeLogo from '../hub/vscode-logo.svg';
+import { closeAppPopup, openAnchoredAppPopup } from '../shared/appPopup';
 
 declare global {
   interface Window {
@@ -50,65 +46,6 @@ function formatSize(n?: number): string {
   return `${(n / 1024 / 1024).toFixed(1)}MB`;
 }
 
-function EditorIcon({ id }: { id: string }): React.ReactElement {
-  if (id === 'cursor') {
-    return (
-      <span
-        className="logs-editor-logo logs-editor-logo--cursor"
-        dangerouslySetInnerHTML={{ __html: cursorLogoSrc as string }}
-      />
-    );
-  }
-  if (id === 'vscode' || id === 'vscode-insiders') {
-    return <img src={vscodeLogo} alt="" width={13} height={13} />;
-  }
-  if (id === 'zed' || id === 'zed-preview') {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <circle cx="12" cy="12" r="10" fill="#9a62ff" />
-        <path d="M8 8h8L8 16h8" stroke="#fff" strokeWidth="1.6" strokeLinejoin="round" fill="none" />
-      </svg>
-    );
-  }
-  if (id === 'windsurf') {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M4 16c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
-        <path d="M4 10c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
-      </svg>
-    );
-  }
-  if (id === 'sublime') {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M5 5v14l14-4V1L5 5Z" fill="#FF9800" />
-      </svg>
-    );
-  }
-  if (['webstorm', 'intellij', 'intellij-ce', 'pycharm', 'pycharm-ce', 'rider', 'goland'].includes(id)) {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <rect x="2" y="2" width="20" height="20" rx="3" fill="#000" />
-        <path d="M7 17h6" stroke="#fff" strokeWidth="1.6" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  return (
-    <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <rect x="1.5" y="2.5" width="11" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M5 11.5h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function FinderIcon(): React.ReactElement {
-  return (
-    <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <path d="M2 4.5v6A1.5 1.5 0 003.5 12h7A1.5 1.5 0 0012 10.5V5.5A1.5 1.5 0 0010.5 4H7L5.5 2.5h-2A1.5 1.5 0 002 4z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
 // Editor list is fetched once per logs-window lifetime; filter out
 // blocklisted entries defensively on the renderer.
 const EDITOR_BLOCKLIST = new Set(['xcode']);
@@ -123,42 +60,10 @@ function getEditors(): Promise<Array<{ id: string; name: string }>> {
 
 function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
   const [editors, setEditors] = useState<Array<{ id: string; name: string }>>([]);
-  const [menuOpen, setMenuOpen] = useState(false);
-  // Anchor coordinates for the portal-rendered menu. We render the menu via
-  // createPortal so it escapes `.logs-files` (which has overflow-x: auto and
-  // therefore clips on Y too — the menu would otherwise be invisible).
-  const [menuAnchor, setMenuAnchor] = useState<{ left: number; bottom: number } | null>(null);
+  const [popupId, setPopupId] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuPortalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { void getEditors().then(setEditors).catch(() => setEditors([])); }, []);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const close = (e: MouseEvent) => {
-      const target = e.target as Node;
-      const insideButton = buttonRef.current?.contains(target);
-      const insideMenu = menuPortalRef.current?.contains(target);
-      if (!insideButton && !insideMenu) setMenuOpen(false);
-    };
-    document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
-  }, [menuOpen]);
-
-  const openMenu = useCallback(() => {
-    const rect = buttonRef.current?.getBoundingClientRect();
-    if (rect) {
-      // Place the menu's bottom 4px above the button's top, left-aligned to
-      // the button. Coordinates are viewport-relative; portal renders into
-      // document.body so they map directly.
-      setMenuAnchor({ left: rect.left, bottom: window.innerHeight - rect.top + 4 });
-    }
-    setMenuOpen(true);
-  }, []);
-  const toggleMenu = useCallback(() => {
-    if (menuOpen) setMenuOpen(false);
-    else openMenu();
-  }, [menuOpen, openMenu]);
 
   const onOpenInEditor = useCallback(async (editorId: string) => {
     console.log('[LogsApp file] onOpenInEditor click', { editorId, path: entry.path });
@@ -166,7 +71,6 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
       console.warn('[LogsApp file] entry.path is falsy; aborting');
       return;
     }
-    setMenuOpen(false);
     const api = window.electronAPI?.sessions?.openInEditor;
     if (!api) {
       console.error('[LogsApp file] window.electronAPI.sessions.openInEditor is undefined — preload bridge missing');
@@ -184,10 +88,48 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
 
   const onReveal = useCallback(async () => {
     if (!entry.path) return;
-    setMenuOpen(false);
     try { await window.electronAPI?.sessions.revealOutput(entry.path); }
     catch (err) { console.error('[LogsApp file] reveal failed', err); }
   }, [entry.path]);
+
+  const toggleMenu = useCallback(async () => {
+    const button = buttonRef.current;
+    if (!button) return;
+    if (popupId) {
+      closeAppPopup(popupId);
+      return;
+    }
+    const nextId = await openAnchoredAppPopup(
+      button,
+      {
+        kind: 'menu',
+        placement: 'top-start',
+        width: 220,
+        items: [
+          ...editors.map((editor) => ({
+            id: `editor:${editor.id}`,
+            label: `Open in ${editor.name}`,
+            icon: { type: 'editor' as const, id: editor.id },
+          })),
+          {
+            id: 'reveal',
+            label: 'Reveal in Finder',
+            icon: { type: 'finder' as const },
+            separatorBefore: editors.length > 0,
+          },
+        ],
+      },
+      {
+        onAction: (action) => {
+          if (action.kind !== 'menu-select') return;
+          if (action.itemId.startsWith('editor:')) void onOpenInEditor(action.itemId.slice('editor:'.length));
+          if (action.itemId === 'reveal') void onReveal();
+        },
+        onClosed: () => setPopupId(null),
+      },
+    );
+    if (nextId) setPopupId(nextId);
+  }, [editors, onOpenInEditor, onReveal, popupId]);
 
   return (
     <div className="logs-file-row-wrap">
@@ -195,10 +137,10 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
         ref={buttonRef}
         type="button"
         className="logs-file-row"
-        onClick={(e) => { e.stopPropagation(); toggleMenu(); }}
+        onClick={(e) => { e.stopPropagation(); void toggleMenu(); }}
         title={entry.path}
         aria-haspopup="menu"
-        aria-expanded={menuOpen}
+        aria-expanded={Boolean(popupId)}
       >
         <svg width="11" height="11" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path
@@ -213,36 +155,6 @@ function FileRow({ entry }: { entry: FileOutputEntry }): React.ReactElement {
         <span className="logs-file-row__size">{formatSize(entry.size)}</span>
         <span className="logs-file-row__caret">{'▾'}</span>
       </button>
-      {menuOpen && menuAnchor && createPortal(
-        <div
-          ref={menuPortalRef}
-          className="logs-file-menu"
-          role="menu"
-          style={{ position: 'fixed', left: menuAnchor.left, bottom: menuAnchor.bottom }}
-        >
-          {editors.map((ed) => (
-            <button
-              key={ed.id}
-              role="menuitem"
-              className="logs-file-menu__item"
-              onClick={() => onOpenInEditor(ed.id)}
-            >
-              <span className="logs-file-menu__icon"><EditorIcon id={ed.id} /></span>
-              <span>Open in {ed.name}</span>
-            </button>
-          ))}
-          {editors.length > 0 && <div className="logs-file-menu__sep" />}
-          <button
-            role="menuitem"
-            className="logs-file-menu__item"
-            onClick={onReveal}
-          >
-            <span className="logs-file-menu__icon"><FinderIcon /></span>
-            <span>Reveal in Finder</span>
-          </button>
-        </div>,
-        document.body,
-      )}
     </div>
   );
 }

--- a/app/src/renderer/pill/Pill.tsx
+++ b/app/src/renderer/pill/Pill.tsx
@@ -227,8 +227,6 @@ export function Pill(): React.ReactElement {
   const [sessions, setSessions] = useState<SessionLite[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const [engine, setEngine] = useState<string>(() => loadStoredEngine());
-  const [engineMenuOpen, setEngineMenuOpen] = useState(false);
-  const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [attachments, setAttachments] = useState<Array<{ name: string; mime: string; bytes: Uint8Array }>>([]);
   const [attachError, setAttachError] = useState<string | null>(null);
   const [validFavicons, setValidFavicons] = useState<Set<string>>(new Set());
@@ -504,7 +502,7 @@ export function Pill(): React.ReactElement {
               }}
             />
             <div className="cmdbar__engine-picker">
-              <EnginePicker value={engine} onChange={handleEngineChange} onOpenChange={setEngineMenuOpen} />
+              <EnginePicker value={engine} onChange={handleEngineChange} />
             </div>
             <button
               className="cmdbar__send"

--- a/app/src/renderer/popup/AppPopup.tsx
+++ b/app/src/renderer/popup/AppPopup.tsx
@@ -158,11 +158,13 @@ export function AppPopup(): React.ReactElement {
     });
   }, [request]);
 
+  const contentKey = request?.id ?? 'empty';
   return (
     <div ref={contentRef} className={`app-popup app-popup--${request?.kind ?? 'empty'}`}>
-      {request?.kind === 'menu' && <GenericMenu request={request} />}
+      {request?.kind === 'menu' && <GenericMenu key={contentKey} request={request} />}
       {request?.kind === 'engine-picker' && (
         <EnginePickerMenuContent
+          key={contentKey}
           value={request.value}
           onChange={emitEngineSelect}
           onClose={closeFromContent}
@@ -170,11 +172,12 @@ export function AppPopup(): React.ReactElement {
       )}
       {request?.kind === 'browsercode-model-picker' && (
         <BrowserCodeModelMenuContent
+          key={contentKey}
           onChanged={emitBrowserCodeChange}
           onClose={closeFromContent}
         />
       )}
-      {request?.kind === 'memory-indicator' && <MemoryIndicatorContent />}
+      {request?.kind === 'memory-indicator' && <MemoryIndicatorContent key={contentKey} />}
     </div>
   );
 }

--- a/app/src/renderer/popup/AppPopup.tsx
+++ b/app/src/renderer/popup/AppPopup.tsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type {
+  AppPopupAction,
+  AppPopupMenuItem,
+  AppPopupOpenRequest,
+} from '../../shared/app-popup';
+import { EnginePickerMenuContent } from '../hub/EnginePicker';
+import { BrowserCodeModelMenuContent } from '../hub/BrowserCodeModelPicker';
+import { MemoryIndicatorContent } from '../hub/MemoryIndicator';
+import { EditorIcon, FinderIcon } from '../shared/editorIcons';
+
+declare global {
+  interface Window {
+    popupHostAPI: {
+      ready: () => void;
+      onRender: (cb: (request: AppPopupOpenRequest) => void) => () => void;
+      contentReady: (popupId: string) => void;
+      resize: (size: { popupId: string; width: number; height: number }) => void;
+      action: (action: AppPopupAction) => void;
+      close: (popupId: string, reason?: string) => void;
+    };
+  }
+}
+
+function useMeasuredPopup(request: AppPopupOpenRequest | null, ref: React.RefObject<HTMLDivElement>): void {
+  useLayoutEffect(() => {
+    if (!request) return;
+    const node = ref.current;
+    if (!node) return;
+    const measure = (): void => {
+      const rect = node.getBoundingClientRect();
+      const width = Math.ceil(Math.max(rect.width, node.scrollWidth));
+      const height = Math.ceil(Math.max(rect.height, node.scrollHeight));
+      window.popupHostAPI.resize({
+        popupId: request.id ?? '',
+        width,
+        height: Math.min(height, request.maxHeight ?? 380),
+      });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    const observed = new Set<Element>();
+    const observeContent = (): void => {
+      for (const element of [node, ...Array.from(node.querySelectorAll<HTMLElement>('*'))]) {
+        if (observed.has(element)) continue;
+        observed.add(element);
+        observer.observe(element);
+      }
+    };
+    observeContent();
+    const mutationObserver = new MutationObserver(() => {
+      observeContent();
+      measure();
+    });
+    mutationObserver.observe(node, { childList: true, subtree: true });
+    return () => {
+      mutationObserver.disconnect();
+      observer.disconnect();
+    };
+  }, [request, ref]);
+}
+
+function MenuIcon({ item }: { item: AppPopupMenuItem }): React.ReactElement | null {
+  if (!item.icon) return null;
+  if (item.icon.type === 'editor') return <EditorIcon id={item.icon.id} />;
+  if (item.icon.type === 'finder') return <FinderIcon />;
+  return null;
+}
+
+function GenericMenu({
+  request,
+}: {
+  request: Extract<AppPopupOpenRequest, { kind: 'menu' }>;
+}): React.ReactElement {
+  const popupId = request.id ?? '';
+  const select = (item: AppPopupMenuItem): void => {
+    if (item.disabled) return;
+    window.popupHostAPI.action({
+      popupId,
+      kind: 'menu-select',
+      itemId: item.id,
+    });
+  };
+
+  return (
+    <div className="app-popup-menu" role="menu">
+      {request.items.map((item) => (
+        <React.Fragment key={item.id}>
+          {item.separatorBefore && <div className="app-popup-menu__sep" />}
+          <button
+            type="button"
+            className={`app-popup-menu__item${item.tone === 'danger' ? ' app-popup-menu__item--danger' : ''}`}
+            role="menuitem"
+            disabled={item.disabled}
+            onClick={() => select(item)}
+          >
+            <span className="app-popup-menu__icon"><MenuIcon item={item} /></span>
+            <span className="app-popup-menu__label">{item.label}</span>
+            {item.checked && <span className="app-popup-menu__check">✓</span>}
+            {item.hint && <span className="app-popup-menu__hint">{item.hint}</span>}
+          </button>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+export function AppPopup(): React.ReactElement {
+  const [request, setRequest] = useState<AppPopupOpenRequest | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useMeasuredPopup(request, contentRef);
+
+  useEffect(() => {
+    const cleanup = window.popupHostAPI.onRender((next) => {
+      setRequest(next);
+    });
+    window.popupHostAPI.ready();
+    return cleanup;
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!request) return;
+    window.popupHostAPI.contentReady(request.id ?? '');
+  }, [request]);
+
+  useEffect(() => {
+    if (!request) return;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        window.popupHostAPI.close(request.id ?? '', 'escape');
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [request]);
+
+  const emitEngineSelect = useCallback((engineId: string): void => {
+    if (!request) return;
+    window.popupHostAPI.action({
+      popupId: request.id ?? '',
+      kind: 'engine-select',
+      engineId,
+    });
+  }, [request]);
+
+  const closeFromContent = useCallback((): void => {
+    if (!request) return;
+    window.popupHostAPI.close(request.id ?? '', 'request');
+  }, [request]);
+
+  const emitBrowserCodeChange = useCallback((): void => {
+    if (!request) return;
+    window.popupHostAPI.action({
+      popupId: request.id ?? '',
+      kind: 'browsercode-model-changed',
+    });
+  }, [request]);
+
+  return (
+    <div ref={contentRef} className={`app-popup app-popup--${request?.kind ?? 'empty'}`}>
+      {request?.kind === 'menu' && <GenericMenu request={request} />}
+      {request?.kind === 'engine-picker' && (
+        <EnginePickerMenuContent
+          value={request.value}
+          onChange={emitEngineSelect}
+          onClose={closeFromContent}
+        />
+      )}
+      {request?.kind === 'browsercode-model-picker' && (
+        <BrowserCodeModelMenuContent
+          onChanged={emitBrowserCodeChange}
+          onClose={closeFromContent}
+        />
+      )}
+      {request?.kind === 'memory-indicator' && <MemoryIndicatorContent />}
+    </div>
+  );
+}

--- a/app/src/renderer/popup/index.tsx
+++ b/app/src/renderer/popup/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '../design/theme.global.css';
+import '../design/empty-states.css';
+import './popup.css';
+import { initThemeMode } from '../design/themeMode';
+import { ErrorBoundary } from '../components/empty/ErrorBoundary';
+import { AppPopup } from './AppPopup';
+
+document.documentElement.dataset.theme = 'shell';
+initThemeMode();
+
+const rootEl = document.getElementById('popup-root');
+if (!rootEl) throw new Error('[popup] #popup-root not found');
+
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <AppPopup />
+    </ErrorBoundary>
+  </React.StrictMode>,
+);

--- a/app/src/renderer/popup/popup.css
+++ b/app/src/renderer/popup/popup.css
@@ -1,0 +1,451 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#popup-root {
+  width: 100%;
+  height: 100%;
+}
+
+.app-popup {
+  box-sizing: border-box;
+  width: max-content;
+  max-width: 900px;
+  max-height: 380px;
+  overflow: visible;
+}
+
+.app-popup--menu,
+.app-popup--browsercode-model-picker {
+  width: 100%;
+}
+
+.app-popup-menu,
+.browsercode-model-picker__menu {
+  box-sizing: border-box;
+  width: 100%;
+  max-height: 380px;
+  overflow: auto;
+  background-color: var(--color-menu-bg);
+  background-image: linear-gradient(180deg, rgba(var(--highlight-rgb), 0.06), rgba(var(--highlight-rgb), 0));
+  border: 1px solid rgba(var(--highlight-rgb), 0.10);
+  border-radius: 12px;
+  box-shadow:
+    0 1px 0 rgba(var(--highlight-rgb), 0.06) inset,
+    0 12px 32px rgba(var(--shadow-rgb), 0.5),
+    0 4px 12px rgba(var(--shadow-rgb), 0.3);
+  padding: 6px;
+}
+
+.app-popup-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.app-popup-menu__item,
+.browsercode-model-picker__item,
+.browsercode-model-picker__setup,
+.browsercode-model-picker__back,
+.engine-picker__item {
+  appearance: none;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  padding: 7px 8px;
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.app-popup-menu__item:hover,
+.browsercode-model-picker__item:hover,
+.browsercode-model-picker__setup:hover,
+.browsercode-model-picker__item--active,
+.engine-picker__item:hover,
+.engine-picker__item--active {
+  background-color: rgba(var(--highlight-rgb), 0.06);
+}
+
+.app-popup-menu__item:disabled,
+.engine-picker__item--disabled {
+  color: var(--color-fg-disabled);
+  cursor: default;
+}
+
+.app-popup-menu__item:disabled:hover,
+.engine-picker__item--disabled:hover {
+  background: transparent;
+}
+
+.app-popup-menu__item--danger {
+  color: var(--color-status-error);
+}
+
+.app-popup-menu__item--danger:hover {
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--color-status-error);
+}
+
+.app-popup-menu__icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.app-popup-menu__label,
+.browsercode-model-picker__item-name,
+.engine-picker__item-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-popup-menu__hint,
+.app-popup-menu__check,
+.browsercode-model-picker__check,
+.browsercode-model-picker__locked,
+.engine-picker__check {
+  color: var(--color-fg-tertiary);
+  font-size: var(--font-size-xs);
+  flex-shrink: 0;
+}
+
+.app-popup-menu__sep {
+  height: 1px;
+  margin: 4px;
+  background-color: var(--color-border-subtle);
+}
+
+.editor-logo,
+.engine-logo {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-fg-primary);
+  flex-shrink: 0;
+}
+
+.editor-logo svg,
+.engine-logo svg {
+  width: 14px;
+  height: 14px;
+}
+
+.app-popup--engine-picker {
+  width: 266px;
+}
+
+.engine-picker__menu {
+  box-sizing: border-box;
+  width: 266px;
+  max-height: 380px;
+  overflow: auto;
+  background-color: var(--color-menu-bg);
+  background-image: linear-gradient(180deg, rgba(var(--highlight-rgb), 0.06), rgba(var(--highlight-rgb), 0));
+  border: 1px solid rgba(var(--highlight-rgb), 0.10);
+  border-radius: 12px;
+  box-shadow:
+    0 1px 0 rgba(var(--highlight-rgb), 0.06) inset,
+    0 12px 32px rgba(var(--shadow-rgb), 0.5);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.engine-picker__back {
+  appearance: none;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  padding: 7px 8px 9px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid rgba(var(--highlight-rgb), 0.07);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.engine-picker__back:hover {
+  color: var(--color-fg-primary);
+}
+
+.engine-picker__chevron-left {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-fg-tertiary);
+  flex-shrink: 0;
+}
+
+.engine-picker__item-login {
+  border: 1px solid rgba(var(--highlight-rgb), 0.10);
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-xs);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.engine-picker__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--color-status-warning);
+}
+
+.engine-picker__chevron-right,
+.browsercode-model-picker__chevron-right,
+.browsercode-model-picker__chevron-left {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-fg-tertiary);
+  flex-shrink: 0;
+}
+
+.engine-picker__chevron-right {
+  margin-left: auto;
+}
+
+.browsercode-model-picker__logo,
+.browsercode-model-picker__mark {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.browsercode-model-picker__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: rgba(var(--highlight-rgb), 0.08);
+  color: var(--color-fg-primary);
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.browsercode-model-picker__locked {
+  border: 1px solid rgba(var(--highlight-rgb), 0.10);
+  border-radius: 6px;
+  padding: 2px 6px;
+}
+
+.browsercode-model-picker__error {
+  margin: 6px 4px 2px;
+  color: var(--color-status-error);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+}
+
+.browsercode-submenu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.browsercode-submenu--loading {
+  min-height: 110px;
+}
+
+.browsercode-model-picker__back {
+  color: var(--color-fg-secondary);
+  margin-bottom: 4px;
+  border-bottom: 1px solid rgba(var(--highlight-rgb), 0.07);
+  border-radius: 0;
+  padding-bottom: 9px;
+}
+
+.browsercode-model-picker__back:hover {
+  color: var(--color-fg-primary);
+}
+
+.browsercode-model-picker__skeleton {
+  display: inline-flex;
+  flex-shrink: 0;
+  background-color: rgba(var(--highlight-rgb), 0.07);
+  background-image: linear-gradient(
+    90deg,
+    rgba(var(--highlight-rgb), 0.05) 0%,
+    rgba(var(--highlight-rgb), 0.13) 44%,
+    rgba(var(--highlight-rgb), 0.05) 88%
+  );
+  background-size: 220% 100%;
+  animation: browsercode-skeleton-shimmer 1.5s var(--ease-in-out) infinite;
+}
+
+.browsercode-model-picker__skeleton--mark {
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-full);
+}
+
+.browsercode-model-picker__skeleton--label {
+  flex: 1 1 auto;
+  width: 128px;
+  height: 10px;
+  border-radius: var(--radius-full);
+}
+
+.browsercode-model-picker__skeleton--badge {
+  width: 46px;
+  height: 18px;
+  margin-left: auto;
+  border-radius: 6px;
+}
+
+.browsercode-model-picker__skeleton-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 7px 8px;
+  border-radius: 8px;
+}
+
+@keyframes browsercode-skeleton-shimmer {
+  0% { background-position: 220% center; }
+  100% { background-position: -220% center; }
+}
+
+.app-popup--memory-indicator {
+  width: 360px;
+}
+
+.mem-popup {
+  box-sizing: border-box;
+  width: 360px;
+  background-color: var(--color-menu-bg);
+  background-image: linear-gradient(180deg, rgba(var(--highlight-rgb), 0.06), rgba(var(--highlight-rgb), 0));
+  border: 1px solid rgba(var(--highlight-rgb), 0.10);
+  border-radius: 12px;
+  box-shadow:
+    0 1px 0 rgba(var(--highlight-rgb), 0.06) inset,
+    0 12px 32px rgba(var(--shadow-rgb), 0.5),
+    0 4px 12px rgba(var(--shadow-rgb), 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.mem-popup--loading {
+  padding: 16px;
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.mem__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.mem__title {
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--color-fg-primary);
+}
+
+.mem__total {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-fg-secondary);
+}
+
+.mem__processes {
+  padding: 6px 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.mem__session-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 14px;
+}
+
+.mem__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.mem__dot--running { background-color: var(--color-status-success); }
+.mem__dot--stopped { background-color: var(--color-fg-tertiary); }
+.mem__dot--stuck { background-color: var(--color-status-error); }
+.mem__dot--paused { background-color: var(--color-accent-default); }
+.mem__dot--idle { background-color: var(--color-status-warning); }
+.mem__dot--system { background-color: var(--color-fg-disabled); }
+
+.mem__session-id {
+  font-size: var(--font-size-2xs);
+  font-family: var(--font-mono);
+  color: var(--color-fg-tertiary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mem__session-mb {
+  font-size: var(--font-size-2xs);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-fg-secondary);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.mem__kill-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  color: var(--color-fg-disabled);
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.mem__kill-btn:hover {
+  color: var(--color-status-error);
+  background-color: rgba(var(--highlight-rgb), 0.08);
+}

--- a/app/src/renderer/popup/popup.html
+++ b/app/src/renderer/popup/popup.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://localhost:* ws://localhost:*;"
+    />
+    <title>Popup</title>
+  </head>
+  <body>
+    <div id="popup-root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/app/src/renderer/shared/appPopup.ts
+++ b/app/src/renderer/shared/appPopup.ts
@@ -1,0 +1,98 @@
+import type {
+  AppPopupAction,
+  AppPopupClosed,
+  AppPopupOpenRequest,
+  AppPopupOpenResult,
+} from '../../shared/app-popup';
+
+type AppPopupRequestWithoutAnchor<T extends AppPopupOpenRequest = AppPopupOpenRequest> =
+  T extends AppPopupOpenRequest ? Omit<T, 'anchor'> : never;
+
+interface AppPopupCallbacks {
+  onAction?: (action: AppPopupAction) => void;
+  onClosed?: (event: AppPopupClosed) => void;
+  cleanup?: () => void;
+}
+
+const handlers = new Map<string, AppPopupCallbacks>();
+let listening = false;
+
+function popupId(): string {
+  return `popup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function ensureListeners(): void {
+  if (listening) return;
+  const popupApi = window.electronAPI?.popup;
+  if (!popupApi) return;
+  popupApi.onAction((action) => {
+    handlers.get(action.popupId)?.onAction?.(action);
+  });
+  popupApi.onClosed((event) => {
+    const callbacks = handlers.get(event.popupId);
+    handlers.delete(event.popupId);
+    callbacks?.cleanup?.();
+    callbacks?.onClosed?.(event);
+  });
+  listening = true;
+}
+
+function rectFromElement(anchor: Element): { x: number; y: number; width: number; height: number } {
+  const rect = anchor.getBoundingClientRect();
+  return {
+    x: Math.round(rect.x),
+    y: Math.round(rect.y),
+    width: Math.round(rect.width),
+    height: Math.round(rect.height),
+  };
+}
+
+export async function openAnchoredAppPopup(
+  anchor: Element,
+  request: AppPopupRequestWithoutAnchor,
+  callbacks: AppPopupCallbacks = {},
+): Promise<string | null> {
+  const popupApi = window.electronAPI?.popup;
+  if (!popupApi) return null;
+  ensureListeners();
+
+  const id = request.id ?? popupId();
+  const onPointerDown = (event: MouseEvent): void => {
+    if (anchor.contains(event.target as Node)) return;
+    closeAppPopup(id);
+  };
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') closeAppPopup(id);
+  };
+  const cleanup = (): void => {
+    window.removeEventListener('mousedown', onPointerDown, true);
+    window.removeEventListener('keydown', onKeyDown, true);
+  };
+  handlers.set(id, { ...callbacks, cleanup });
+
+  try {
+    const result: AppPopupOpenResult = await popupApi.open({
+      ...request,
+      id,
+      anchor: rectFromElement(anchor),
+    } as AppPopupOpenRequest);
+    window.setTimeout(() => {
+      window.addEventListener('mousedown', onPointerDown, true);
+      window.addEventListener('keydown', onKeyDown, true);
+    }, 0);
+    return result.id;
+  } catch (err) {
+    handlers.get(id)?.cleanup?.();
+    handlers.delete(id);
+    console.warn('[app-popup] open failed', err);
+    return null;
+  }
+}
+
+export function closeAppPopup(id: string | null | undefined): void {
+  if (!id) return;
+  handlers.get(id)?.cleanup?.();
+  window.electronAPI?.popup?.close(id).catch((err) => {
+    console.warn('[app-popup] close failed', err);
+  });
+}

--- a/app/src/renderer/shared/appPopup.ts
+++ b/app/src/renderer/shared/appPopup.ts
@@ -57,6 +57,7 @@ export async function openAnchoredAppPopup(
   ensureListeners();
 
   const id = request.id ?? popupId();
+  let disposed = false;
   const onPointerDown = (event: MouseEvent): void => {
     if (anchor.contains(event.target as Node)) return;
     closeAppPopup(id);
@@ -65,6 +66,7 @@ export async function openAnchoredAppPopup(
     if (event.key === 'Escape') closeAppPopup(id);
   };
   const cleanup = (): void => {
+    disposed = true;
     window.removeEventListener('mousedown', onPointerDown, true);
     window.removeEventListener('keydown', onKeyDown, true);
   };
@@ -76,7 +78,9 @@ export async function openAnchoredAppPopup(
       id,
       anchor: rectFromElement(anchor),
     } as AppPopupOpenRequest);
+    if (disposed) return null;
     window.setTimeout(() => {
+      if (disposed) return;
       window.addEventListener('mousedown', onPointerDown, true);
       window.addEventListener('keydown', onKeyDown, true);
     }, 0);

--- a/app/src/renderer/shared/editorIcons.tsx
+++ b/app/src/renderer/shared/editorIcons.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import cursorLogoSrc from '../hub/cursor-logo.svg?raw';
+import vscodeLogo from '../hub/vscode-logo.svg';
+
+export function EditorIcon({ id }: { id: string }): React.ReactElement {
+  if (id === 'cursor') {
+    return (
+      <span
+        className="editor-logo editor-logo--cursor"
+        dangerouslySetInnerHTML={{ __html: cursorLogoSrc as string }}
+      />
+    );
+  }
+  if (id === 'vscode' || id === 'vscode-insiders') {
+    return <img src={vscodeLogo} alt="" width={14} height={14} />;
+  }
+  if (id === 'zed' || id === 'zed-preview') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" fill="#9a62ff" />
+        <path d="M8 8h8L8 16h8" stroke="#fff" strokeWidth="1.6" strokeLinejoin="round" fill="none" />
+      </svg>
+    );
+  }
+  if (id === 'windsurf') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M4 16c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
+        <path d="M4 10c4-3 6-3 8 0s6 3 8 0" stroke="#39c4b5" strokeWidth="2" strokeLinecap="round" fill="none" />
+      </svg>
+    );
+  }
+  if (id === 'sublime') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M5 5v14l14-4V1L5 5Z" fill="#FF9800" />
+      </svg>
+    );
+  }
+  if (['webstorm', 'intellij', 'intellij-ce', 'pycharm', 'pycharm-ce', 'rider', 'goland'].includes(id)) {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="2" y="2" width="20" height="20" rx="3" fill="#000" />
+        <path d="M7 17h6" stroke="#fff" strokeWidth="1.6" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <rect x="1.5" y="2.5" width="11" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M5 11.5h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function FinderIcon(): React.ReactElement {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M2 4.5v6A1.5 1.5 0 003.5 12h7A1.5 1.5 0 0012 10.5V5.5A1.5 1.5 0 0010.5 4H7L5.5 2.5h-2A1.5 1.5 0 002 4z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/app/src/shared/app-popup.ts
+++ b/app/src/shared/app-popup.ts
@@ -1,0 +1,96 @@
+export interface AppPopupAnchorRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type AppPopupPlacement =
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'top-start'
+  | 'top-end'
+  | 'right-start'
+  | 'left-start';
+
+export type AppPopupMenuIcon =
+  | { type: 'editor'; id: string }
+  | { type: 'finder' };
+
+export interface AppPopupMenuItem {
+  id: string;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+  checked?: boolean;
+  tone?: 'normal' | 'danger';
+  icon?: AppPopupMenuIcon;
+  separatorBefore?: boolean;
+}
+
+interface AppPopupOpenBase {
+  id?: string;
+  anchor: AppPopupAnchorRect;
+  placement?: AppPopupPlacement;
+  width?: number;
+  height?: number;
+  maxHeight?: number;
+}
+
+export interface AppPopupMenuRequest extends AppPopupOpenBase {
+  kind: 'menu';
+  items: AppPopupMenuItem[];
+}
+
+export interface AppPopupEnginePickerRequest extends AppPopupOpenBase {
+  kind: 'engine-picker';
+  value: string;
+}
+
+export interface AppPopupBrowserCodeModelPickerRequest extends AppPopupOpenBase {
+  kind: 'browsercode-model-picker';
+}
+
+export interface AppPopupMemoryIndicatorRequest extends AppPopupOpenBase {
+  kind: 'memory-indicator';
+}
+
+export type AppPopupOpenRequest =
+  | AppPopupMenuRequest
+  | AppPopupEnginePickerRequest
+  | AppPopupBrowserCodeModelPickerRequest
+  | AppPopupMemoryIndicatorRequest;
+
+export interface AppPopupOpenResult {
+  id: string;
+}
+
+export type AppPopupAction =
+  | {
+      popupId: string;
+      kind: 'menu-select';
+      itemId: string;
+      close?: boolean;
+    }
+  | {
+      popupId: string;
+      kind: 'engine-select';
+      engineId: string;
+      close?: boolean;
+    }
+  | {
+      popupId: string;
+      kind: 'browsercode-model-changed';
+      close?: boolean;
+    };
+
+export interface AppPopupClosed {
+  popupId: string;
+  reason: 'action' | 'blur' | 'escape' | 'request' | 'owner-destroyed' | 'replaced' | 'app-deactivated';
+}
+
+export interface AppPopupContentSize {
+  popupId: string;
+  width: number;
+  height: number;
+}

--- a/app/tests/unit/hub/EnginePicker.spec.tsx
+++ b/app/tests/unit/hub/EnginePicker.spec.tsx
@@ -4,7 +4,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EngineStatus } from '../../../src/renderer/hub/EnginePicker';
-import { EnginePicker } from '../../../src/renderer/hub/EnginePicker';
+import { EnginePickerMenuContent } from '../../../src/renderer/hub/EnginePicker';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -46,7 +46,7 @@ function renderPicker(value: string): { container: HTMLDivElement; root: Root } 
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(<EnginePicker value={value} onChange={vi.fn()} />);
+    root.render(<EnginePickerMenuContent value={value} onChange={vi.fn()} />);
   });
   return { container, root };
 }
@@ -56,12 +56,6 @@ async function flush(): Promise<void> {
     await Promise.resolve();
     await Promise.resolve();
   });
-}
-
-function getToggleButton(container: HTMLElement): HTMLButtonElement {
-  const button = container.querySelector('.engine-picker__toggle');
-  if (!(button instanceof HTMLButtonElement)) throw new Error('Missing engine picker toggle');
-  return button;
 }
 
 function getMenuItemButton(container: HTMLElement, text: string): HTMLButtonElement {
@@ -103,11 +97,6 @@ describe('EnginePicker', () => {
     await flush();
 
     act(() => {
-      getToggleButton(container).click();
-    });
-    await flush();
-
-    act(() => {
       getMenuItemButton(container, 'Codex').click();
     });
     await flush();
@@ -138,11 +127,6 @@ describe('EnginePicker', () => {
     });
     const { container, root } = renderPicker('codex');
 
-    await flush();
-
-    act(() => {
-      getToggleButton(container).click();
-    });
     await flush();
 
     act(() => {
@@ -196,11 +180,6 @@ describe('EnginePicker', () => {
     await flush();
 
     act(() => {
-      getToggleButton(container).click();
-    });
-    await flush();
-
-    act(() => {
       getMenuItemButton(container, 'Codex').click();
     });
     await flush();
@@ -240,11 +219,6 @@ describe('EnginePicker', () => {
     });
     const { container, root } = renderPicker('claude-code');
 
-    await flush();
-
-    act(() => {
-      getToggleButton(container).click();
-    });
     await flush();
 
     act(() => {

--- a/app/tests/unit/hub/Sidebar.spec.tsx
+++ b/app/tests/unit/hub/Sidebar.spec.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Sidebar } from '../../../src/renderer/hub/Sidebar';
 import type { AgentSession } from '../../../src/renderer/hub/types';
+import type { AppPopupAction, AppPopupOpenRequest } from '../../../src/shared/app-popup';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -39,6 +40,37 @@ function renderSidebar(
   return { container, root, onRowAction };
 }
 
+let lastPopupRequest: AppPopupOpenRequest | null = null;
+let popupActionHandler: ((action: AppPopupAction) => void) | null = null;
+
+function installPopupApi(): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      popup: {
+        open: vi.fn(async (request: AppPopupOpenRequest) => {
+          lastPopupRequest = request;
+          return { id: request.id ?? 'test-popup' };
+        }),
+        close: vi.fn(async () => undefined),
+        resize: vi.fn(),
+        onAction: (cb: (action: AppPopupAction) => void): (() => void) => {
+          popupActionHandler = cb;
+          return vi.fn();
+        },
+        onClosed: vi.fn(() => vi.fn()),
+      },
+    },
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 function click(el: Element): void {
   act(() => {
     el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -51,14 +83,26 @@ function menuButton(container: HTMLElement): HTMLButtonElement {
   return button;
 }
 
-function menuItems(container: HTMLElement): HTMLButtonElement[] {
-  return Array.from(container.querySelectorAll<HTMLButtonElement>('.sidebar__row-menu-item'));
+function popupLabels(): string[] {
+  return lastPopupRequest?.kind === 'menu'
+    ? lastPopupRequest.items.map((item) => item.label)
+    : [];
+}
+
+function selectPopupItem(itemId: string): void {
+  if (!lastPopupRequest?.id) throw new Error('Missing popup request');
+  popupActionHandler?.({
+    popupId: lastPopupRequest.id,
+    kind: 'menu-select',
+    itemId,
+  });
 }
 
 describe('Sidebar focus behavior', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     vi.restoreAllMocks();
+    lastPopupRequest = null;
   });
 
   it('keeps sidebar action controls out of the tab order', () => {
@@ -87,33 +131,34 @@ describe('Sidebar focus behavior', () => {
     act(() => root.unmount());
   });
 
-  it('shows pause for running sessions before a provider resume id is known', () => {
+  it('shows pause for running sessions before a provider resume id is known', async () => {
+    installPopupApi();
     const running = { ...session('running', 1, 'running'), canResume: false };
     const { container, root, onRowAction } = renderSidebar([running]);
 
     click(menuButton(container));
-    const pause = menuItems(container).find((item) => item.textContent === 'Pause');
+    await flush();
 
-    expect(pause).toBeTruthy();
-    expect(pause?.disabled).toBe(false);
-    click(pause!);
+    expect(popupLabels()).toContain('Pause');
+    selectPopupItem('pause');
     expect(onRowAction).toHaveBeenCalledWith('running', 'pause');
 
     act(() => root.unmount());
   });
 
-  it('shows resume and stop for paused sessions without showing pause', () => {
+  it('shows resume and stop for paused sessions without showing pause', async () => {
+    installPopupApi();
     const paused = { ...session('paused', 1, 'paused'), canResume: true };
     const { container, root, onRowAction } = renderSidebar([paused]);
 
     click(menuButton(container));
-    const labels = menuItems(container).map((item) => item.textContent);
-    const resume = menuItems(container).find((item) => item.textContent === 'Resume');
+    await flush();
+    const labels = popupLabels();
 
     expect(labels).toContain('Resume');
     expect(labels).toContain('Stop');
     expect(labels).not.toContain('Pause');
-    click(resume!);
+    selectPopupItem('resume');
     expect(onRowAction).toHaveBeenCalledWith('paused', 'resume');
 
     act(() => root.unmount());

--- a/app/vite.popup.config.mts
+++ b/app/vite.popup.config.mts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  cacheDir: path.resolve(__dirname, 'node_modules/.vite/popup'),
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/popup/popup.html'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a shared, always-on-top popup window (panel-type Electron window at `screen-saver` level) with anchoring/placement helpers, IPC bridge, and a renderer that dispatches on a `kind` field. Wired into shell, pill, and logs preloads.
- Moves the engine picker and BrowserCode model picker into it. For the BrowserCode submenu, replaces the right-side hover flyout with a drill-in pattern (single panel, back button, no L-shape).
- Moves Sidebar, AgentPane, and LogsApp menus into it.
- Moves the Resource usage indicator into it. Previously the `Automating` pill window was z-ordered above the in-shell dropdown and covered it; now the panel renders in a popup window at the same z-level as the pill.
- Fix popup measurement to ignore scroll-clipped descendants so the window sizes to actual content.

## Test plan

- [ ] Open engine picker; click BrowserCode; confirm it drills in (back button + provider list) instead of opening a side flyout.
- [ ] Confirm engine picker, BrowserCode model picker, sidebar/agent-pane/logs menus all open as anchored popups, click-outside dismisses, Esc dismisses.
- [ ] With `Automating` pill visible, open Resource usage; confirm it stacks above the pill.
- [ ] Resize/move shell window with a popup open; confirm it follows or closes appropriately.
- [ ] `cd app && npx vitest run` (380 tests).
- [ ] `cd app && npx tsc --noEmit`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared, always-on-top AppPopup window with anchoring and IPC, and moves engine/model pickers, menus, and Resource usage into it. Also hardens the popup lifecycle to avoid stale listeners and dropped handshakes, and ensures menus render with complete data.

- **New Features**
  - Shared popup window (panel-type Electron window at screen-saver level) with anchor/placement helpers, IPC bridge, and a renderer that dispatches by request kind; wired into shell, pill, and logs preloads.
  - Engine picker and BrowserCode model picker now render in the popup; BrowserCode submenu switches to a single-panel drill-in with a back button.
  - Sidebar, AgentPane, and LogsApp menus open as anchored popups with click-outside/Esc to dismiss and follow/close on shell move/resize.
  - Added dedicated `popup` renderer and preload; introduced `window.electronAPI.popup` bridge and shared helpers.

- **Bug Fixes**
  - Resource usage panel now stacks above the Automating pill (moved into the popup window).
  - Popup measurement ignores scroll-clipped descendants so windows size to actual content.
  - Prevent stale global listeners on fast close/open by tracking a disposed state.
  - Key popup content by request.id to remount per open and reset internal state.
  - Logs "Open in..." menu waits for editor discovery before opening.
  - Ensure renderer-ready handshake isn’t dropped when warming the popup.

<sup>Written for commit 6aa64f7eda21e3fc32d7d268c2daecd9413d1f7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

