### PR TITLE
Add provider-neutral agent skills

### DIFF
--- a/app/docs/AGENT_SKILLS.md
+++ b/app/docs/AGENT_SKILLS.md
@@ -13,13 +13,13 @@ The harness contains:
 - `skills/`: persistent user-created procedural skills
 - `agent-skill/`: the local CLI used to search, view, create, patch, delete, and validate
 
-Providers are prompted to run `agent-skill search` before inventing browser or site-specific steps, then `agent-skill view <id>` for the exact skill.
+Providers are prompted to run `agent-skill search` before inventing browser, site, or workflow-specific steps, then `agent-skill view <id>` for the exact skill.
 
 Each provider prompt also receives a generated compact skill index. The index is metadata only: skill id, title, and short description. Full skill bodies are not injected; agents still load them with `agent-skill view <id>`.
 
 ## Creation Rules
 
-Create or patch a skill when the task produced reusable procedural knowledge:
+Create or patch a skill after a task succeeds and the new procedure is likely to repeat, long-running enough to justify reuse, or generally applicable beyond the current session. Good triggers:
 
 - complex task succeeded after roughly 5 or more meaningful tool calls
 - tricky error was fixed
@@ -29,7 +29,8 @@ Create or patch a skill when the task produced reusable procedural knowledge:
 
 Do not write a skill for:
 
-- simple one-off browsing or fact lookups
+- simple one-off browsing, fact lookups, or calculations
+- temporary page state
 - user-specific secrets, temporary tokens, or private account details
 - failed or speculative workflows
 - content that belongs in task output
@@ -54,6 +55,19 @@ Run the timed ten-task suite:
 npm run skills:eval
 ```
 
-The suite covers five "find existing skill" tasks, two "create new skill" tasks, one "patch existing skill" task with deletion coverage, and two "do not write a skill" tasks. Each task records elapsed time for the overall task and each `agent-skill` operation.
+The suite covers five "find existing skill" tasks, two "create new skill" tasks, one "patch existing skill" task with deletion coverage, and two live "do not write a skill" tasks. Each task records elapsed time for the overall task and each operation.
 
-This first evaluator proves discoverability, bloat control, write/no-write task classification, and static skill quality. It does not yet prove that a provider used the skill correctly inside a live browser session. The next layer should run the same fixture set through each provider and judge the resulting `skill_used`/`skill_written` events plus task output.
+The no-write tasks are real app-backed sessions submitted through the local task server, then checked in `sessions.db` for durable `skill_written` events. Start the app first and point the eval at the same user-data directory:
+
+```bash
+AGB_USER_DATA_DIR=/tmp/browser-use-skills-eval npm start
+AGB_USER_DATA_DIR=/tmp/browser-use-skills-eval npm run skills:eval
+```
+
+By default the live tasks run on `codex`. To test multiple providers:
+
+```bash
+SKILLS_EVAL_ENGINES=codex,claude-code,browsercode npm run skills:eval
+```
+
+The evaluator fails rather than silently passing if the local app is not running or if any live no-write session emits `skill_written`.

--- a/app/docs/AGENT_SKILLS.md
+++ b/app/docs/AGENT_SKILLS.md
@@ -1,0 +1,59 @@
+# Skills
+
+ Reagan here! This first version of personal skills is inspired by Hermes Agent's skill index injection and progressive skill-loading pattern.
+
+## Browser Use Pattern
+
+This app uses `agent-skill` as a provider-neutral CLI because Codex, Claude Code, and BrowserCode all already run in the same harness working directory and PATH. That avoids duplicating a tool schema per provider.
+
+The harness contains:
+
+- `interaction-skills/`: read-only browser mechanics
+- `domain-skills/`: read-only site playbooks
+- `skills/`: persistent user-created procedural skills
+- `agent-skill/`: the local CLI used to search, view, create, patch, delete, and validate
+
+Providers are prompted to run `agent-skill search` before inventing browser or site-specific steps, then `agent-skill view <id>` for the exact skill.
+
+Each provider prompt also receives a generated compact skill index. The index is metadata only: skill id, title, and short description. Full skill bodies are not injected; agents still load them with `agent-skill view <id>`.
+
+## Creation Rules
+
+Create or patch a skill when the task produced reusable procedural knowledge:
+
+- complex task succeeded after roughly 5 or more meaningful tool calls
+- tricky error was fixed
+- trial and error changed the approach
+- a user correction revealed the method they want repeated
+- an existing skill was stale, incomplete, or wrong
+
+Do not write a skill for:
+
+- simple one-off browsing or fact lookups
+- user-specific secrets, temporary tokens, or private account details
+- failed or speculative workflows
+- content that belongs in task output
+
+Run validation after writing:
+
+```bash
+agent-skill validate <id> --json
+```
+
+Delete only local user-created skills when they are wrong, duplicate, or no longer useful:
+
+```bash
+agent-skill delete <id> --json
+```
+
+## Evaluation
+
+Run the timed ten-task suite:
+
+```bash
+npm run skills:eval
+```
+
+The suite covers five "find existing skill" tasks, two "create new skill" tasks, one "patch existing skill" task with deletion coverage, and two "do not write a skill" tasks. Each task records elapsed time for the overall task and each `agent-skill` operation.
+
+This first evaluator proves discoverability, bloat control, write/no-write task classification, and static skill quality. It does not yet prove that a provider used the skill correctly inside a live browser session. The next layer should run the same fixture set through each provider and judge the resulting `skill_used`/`skill_written` events plus task output.

--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,8 @@
     "start:reset-onboarding": "node scripts/reset-onboarding.mjs",
     "start:reset-sessions": "node scripts/reset-sessions.mjs",
     "sync-domain-skills": "node scripts/sync-domain-skills.mjs",
+    "skills:eval": "node scripts/evaluate-agent-skills.mjs",
+    "eval:agent-skills": "node scripts/evaluate-agent-skills.mjs",
     "postinstall": "node scripts/chmod-node-pty-helpers.mjs"
   },
   "keywords": [],

--- a/app/scripts/evaluate-agent-skills.mjs
+++ b/app/scripts/evaluate-agent-skills.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import { homedir } from 'node:os';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +10,7 @@ import { performance } from 'node:perf_hooks';
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const stockRoot = path.join(appRoot, 'src', 'main', 'hl', 'stock');
 const cli = path.join(stockRoot, 'agent-skill', 'agent-skill');
+const runTaskCli = path.join(appRoot, 'scripts', 'run-task.mjs');
 
 const TASKS = [
   {
@@ -100,25 +102,33 @@ const TASKS = [
     requiredTerms: ['browser, renderer, and engine logs'],
   },
   {
-    id: 'skip-simple-one-off-weather',
+    id: 'skip-simple-one-off-conversion',
     mode: 'none',
     shouldWriteSkill: false,
-    guard: 'one-off',
-    prompt: 'Tell me the weather in San Francisco today.',
-    reason: 'A one-off fact lookup should not create procedural memory.',
+    prompt: 'Convert 72 degrees Fahrenheit to Celsius in one sentence.',
+    reason: 'A one-off calculation should not create procedural memory.',
   },
   {
     id: 'skip-secret-specific-login',
     mode: 'none',
     shouldWriteSkill: false,
-    guard: 'secret',
-    prompt: 'Use this temporary token to log into my private account once.',
+    prompt: 'I pasted a temporary private account token by mistake: skills-eval-token-123. What should I do with it? Answer in one sentence.',
     reason: 'Secrets and one-time account details must not become skills.',
   },
 ];
 
 function parseArgs(argv) {
-  const opts = { json: false, keepFixtures: false, output: '' };
+  const opts = {
+    json: false,
+    keepFixtures: false,
+    output: '',
+    liveEngines: (process.env.SKILLS_EVAL_ENGINES || process.env.SKILLS_EVAL_ENGINE || 'codex')
+      .split(',')
+      .map((engine) => engine.trim())
+      .filter(Boolean),
+    userDataDir: process.env.AGB_USER_DATA_DIR || '',
+    liveTimeoutMs: Number.parseInt(process.env.SKILLS_EVAL_TIMEOUT_MS || '180000', 10),
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--json') opts.json = true;
@@ -126,9 +136,45 @@ function parseArgs(argv) {
     else if (arg === '--output') {
       opts.output = argv[i + 1] || '';
       i += 1;
+    } else if (arg === '--engine') {
+      opts.liveEngines = [argv[i + 1]].filter(Boolean);
+      i += 1;
+    } else if (arg === '--engines') {
+      opts.liveEngines = String(argv[i + 1] || '')
+        .split(',')
+        .map((engine) => engine.trim())
+        .filter(Boolean);
+      i += 1;
+    } else if (arg === '--user-data-dir') {
+      opts.userDataDir = argv[i + 1] || '';
+      i += 1;
+    } else if (arg === '--live-timeout-ms') {
+      opts.liveTimeoutMs = Number.parseInt(argv[i + 1] || '', 10);
+      i += 1;
     }
   }
+  if (!Number.isFinite(opts.liveTimeoutMs) || opts.liveTimeoutMs <= 0) opts.liveTimeoutMs = 180000;
   return opts;
+}
+
+function readProductName() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(appRoot, 'package.json'), 'utf-8'));
+  return pkg.productName ?? pkg.name ?? 'app';
+}
+
+function defaultUserDataDir(productName) {
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(homedir(), 'Library', 'Application Support', productName);
+    case 'win32':
+      return path.join(process.env.APPDATA ?? path.join(homedir(), 'AppData', 'Roaming'), productName);
+    default:
+      return path.join(process.env.XDG_CONFIG_HOME ?? path.join(homedir(), '.config'), productName);
+  }
+}
+
+function resolveUserDataDir(opts) {
+  return opts.userDataDir || defaultUserDataDir(readProductName());
 }
 
 function copyStockFixture(root) {
@@ -166,34 +212,109 @@ function assertTask(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function runPromptDecision(root, task) {
+function sqlQuote(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function querySqliteJson(dbPath, sql) {
+  const result = spawnSync('sqlite3', ['-json', dbPath, sql], {
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `sqlite3 exited ${result.status}`);
+  }
+  const raw = result.stdout.trim();
+  return raw ? JSON.parse(raw) : [];
+}
+
+function queryLiveSession(userDataDir, sessionId) {
+  const dbPath = path.join(userDataDir, 'sessions.db');
+  if (!fs.existsSync(dbPath)) throw new Error(`sessions.db not found at ${dbPath}`);
+  const quotedId = sqlQuote(sessionId);
+  const [session = null] = querySqliteJson(dbPath, `SELECT id,status,error,engine FROM sessions WHERE id = ${quotedId}`);
+  const events = querySqliteJson(dbPath, `SELECT seq,type,payload FROM session_events WHERE session_id = ${quotedId} ORDER BY seq ASC`);
+  return { dbPath, session, events };
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForLiveSession(userDataDir, sessionId, deadlineMs) {
+  let latest = queryLiveSession(userDataDir, sessionId);
+  for (;;) {
+    const doneCount = latest.events.filter((event) => event.type === 'done').length;
+    const status = latest.session?.status;
+    if (doneCount > 0 || status === 'stopped' || status === 'paused') return latest;
+    if (Date.now() >= deadlineMs) return latest;
+    sleepSync(500);
+    latest = queryLiveSession(userDataDir, sessionId);
+  }
+}
+
+function runLiveNoWriteTask(task, opts) {
   const started = performance.now();
-  const prompt = String(task.prompt || '').toLowerCase();
-  const rules = fs.readFileSync(path.join(root, 'AGENTS.md'), 'utf-8').toLowerCase();
-  const reasons = [];
-  if (task.guard === 'one-off') {
-    if (rules.includes('simple one-off') && rules.includes('temporary facts')) reasons.push('simple-one-off');
+  const userDataDir = resolveUserDataDir(opts);
+  const engines = opts.liveEngines.length > 0 ? opts.liveEngines : ['codex'];
+  const runs = [];
+
+  for (const engine of engines) {
+    const runStarted = performance.now();
+    const deadlineMs = Date.now() + opts.liveTimeoutMs;
+    const result = spawnSync(process.execPath, [
+      runTaskCli,
+      '--json',
+      '--engine',
+      engine,
+      '--user-data-dir',
+      userDataDir,
+      task.prompt,
+    ], {
+      cwd: path.dirname(appRoot),
+      encoding: 'utf-8',
+      timeout: Math.min(opts.liveTimeoutMs, 30000),
+      env: { ...process.env, AGB_USER_DATA_DIR: userDataDir },
+    });
+    const raw = result.status === 0 ? result.stdout : result.stderr || result.stdout;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      parsed = { ok: false, error: `invalid JSON from run-task: ${err.message}`, raw };
+    }
+    const sessionId = parsed.id;
+    const live = sessionId ? waitForLiveSession(userDataDir, sessionId, deadlineMs) : { dbPath: path.join(userDataDir, 'sessions.db'), session: null, events: [] };
+    const eventTypes = live.events.map((event) => event.type);
+    const skillWrittenEvents = live.events.filter((event) => event.type === 'skill_written');
+    const skillUsedEvents = live.events.filter((event) => event.type === 'skill_used');
+    const doneEvents = live.events.filter((event) => event.type === 'done');
+    const errorEvents = live.events.filter((event) => event.type === 'error');
+    runs.push({
+      engine,
+      exitCode: result.status,
+      timedOut: Boolean(result.error && result.error.code === 'ETIMEDOUT'),
+      elapsedMs: performance.now() - runStarted,
+      sessionId,
+      status: live.session?.status ?? null,
+      error: live.session?.error ?? parsed.error ?? null,
+      eventTypes,
+      skillWrittenEvents,
+      skillUsedEvents,
+      doneCount: doneEvents.length,
+      errorCount: errorEvents.length,
+      dbPath: live.dbPath,
+    });
   }
-  if (task.guard === 'secret') {
-    if (rules.includes('user-specific secrets') && rules.includes('temporary')) reasons.push('secret-specific');
-  }
-  const promptLooksGuarded = task.guard === 'one-off'
-    ? /\b(weather|today|one-off|fact)\b/.test(prompt)
-    : /\b(secret|token|private account|temporary)\b/.test(prompt);
-  const shouldWriteSkill = !(promptLooksGuarded && reasons.length > 0);
-  const proposedCommands = shouldWriteSkill
-    ? [`agent-skill create ${task.id.replace(/^skip-/, 'general/')} --description "Reusable workflow"`]
-    : [];
+
   return {
-    args: ['prompt-decision', task.id],
-    exitCode: 0,
+    args: ['live-task', task.id, '--engines', engines.join(',')],
+    exitCode: runs.every((run) => run.exitCode === 0 && run.doneCount > 0 && run.skillWrittenEvents.length === 0) ? 0 : 1,
     elapsedMs: performance.now() - started,
     cliElapsedMs: null,
     parsed: {
-      shouldWriteSkill,
-      reasons,
-      proposedCommands,
       prompt: task.prompt,
+      userDataDir,
+      runs,
     },
   };
 }
@@ -255,11 +376,14 @@ function runTask(task, opts) {
       operations.push(deleted);
       assertTask(deleted.exitCode === 0, `delete failed: ${deleted.parsed.error || deleted.exitCode}`);
     } else if (task.mode === 'none') {
-      const promptDecision = runPromptDecision(root, task);
-      operations.push(promptDecision);
-      assertTask(promptDecision.parsed.shouldWriteSkill === false, `prompt decision would write a skill: ${promptDecision.parsed.proposedCommands.join(', ')}`);
-      assertTask(promptDecision.parsed.reasons.length > 0, 'prompt decision did not match any no-write lifecycle rule');
-      assertTask(!promptDecision.parsed.proposedCommands.some((command) => /\bagent-skill\s+(create|patch|delete)\b/.test(command)), 'no-write task proposed a write command');
+      const liveTask = runLiveNoWriteTask(task, opts);
+      operations.push(liveTask);
+      assertTask(liveTask.exitCode === 0, `live task failed: ${JSON.stringify(liveTask.parsed.runs)}`);
+      for (const run of liveTask.parsed.runs) {
+        assertTask(run.sessionId, `live task did not create a session for ${run.engine}`);
+        assertTask(run.doneCount > 0, `live task did not finish for ${run.engine} session ${run.sessionId}`);
+        assertTask(run.skillWrittenEvents.length === 0, `live task wrote a skill for ${run.engine} session ${run.sessionId}`);
+      }
 
       const listedBefore = runAgentSkill(root, ['list']);
       operations.push(listedBefore);

--- a/app/scripts/evaluate-agent-skills.mjs
+++ b/app/scripts/evaluate-agent-skills.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const stockRoot = path.join(appRoot, 'src', 'main', 'hl', 'stock');
+const cli = path.join(stockRoot, 'agent-skill', 'agent-skill');
+
+const TASKS = [
+  {
+    id: 'find-linkedin-invitations',
+    mode: 'find',
+    shouldWriteSkill: false,
+    query: 'linkedin invitations accept ignore pending connection requests',
+    expectedSkill: 'domain/linkedin/invitation-manager',
+    requiredTerms: ['LinkedIn', 'invitation'],
+  },
+  {
+    id: 'find-screenshot-verification',
+    mode: 'find',
+    shouldWriteSkill: false,
+    query: 'capture screenshot png visual verification',
+    expectedSkill: 'interaction/screenshots',
+    requiredTerms: ['captureScreenshot'],
+  },
+  {
+    id: 'find-file-upload',
+    mode: 'find',
+    shouldWriteSkill: false,
+    query: 'upload a file input chooser setFileInputFiles',
+    expectedSkill: 'interaction/uploads',
+    requiredTerms: ['upload'],
+  },
+  {
+    id: 'find-github-repo-actions',
+    mode: 'find',
+    shouldWriteSkill: false,
+    query: 'github repository actions star fork issue pull request',
+    expectedSkill: 'domain/github/repo-actions',
+    requiredTerms: ['GitHub'],
+  },
+  {
+    id: 'find-tiktok-upload',
+    mode: 'find',
+    shouldWriteSkill: false,
+    query: 'tiktok upload video caption publish',
+    expectedSkill: 'domain/tiktok/upload',
+    requiredTerms: ['TikTok', 'upload'],
+  },
+  {
+    id: 'create-recurring-crm-triage',
+    mode: 'create',
+    shouldWriteSkill: true,
+    skillId: 'user/workflow/crm-triage',
+    createName: 'workflow/crm-triage',
+    description: 'Reusable CRM queue triage workflow after repeated account checks',
+    body: [
+      'Use when the user asks for the same CRM queue triage workflow again.',
+      '',
+      '1. Search the assigned queue and group records by account status.',
+      '2. Check each ambiguous account before making changes.',
+      '3. Verify the queue is reconciled and report the count changed.',
+    ].join('\n'),
+  },
+  {
+    id: 'create-provider-login-recovery',
+    mode: 'create',
+    shouldWriteSkill: true,
+    skillId: 'user/debugging/provider-login-recovery',
+    createName: 'debugging/provider-login-recovery',
+    description: 'Recover provider login failures after CLI auth retries and path checks',
+    body: [
+      'Use after a provider CLI login failed and the fix required multiple checks.',
+      '',
+      '1. Run the provider auth status command and capture the exact error.',
+      '2. Check PATH resolution for the CLI shim before changing credentials.',
+      '3. Retry login only after verifying the selected auth mode.',
+      '4. Verify the provider can run a no-op command successfully.',
+    ].join('\n'),
+  },
+  {
+    id: 'patch-existing-skill-after-learning',
+    mode: 'patch',
+    shouldWriteSkill: true,
+    skillId: 'user/workflow/session-log-export',
+    createName: 'workflow/session-log-export',
+    description: 'Export session logs for repeated support diagnostics',
+    seedBody: [
+      'Use when support needs session logs.',
+      '',
+      '1. Export main logs.',
+      '2. Verify the export file exists.',
+    ].join('\n'),
+    oldText: '1. Export main logs.',
+    newText: '1. Export main, browser, renderer, and engine logs.',
+    requiredTerms: ['browser, renderer, and engine logs'],
+  },
+  {
+    id: 'skip-simple-one-off-weather',
+    mode: 'none',
+    shouldWriteSkill: false,
+    prompt: 'Tell me the weather in San Francisco today.',
+    reason: 'A one-off fact lookup should not create procedural memory.',
+  },
+  {
+    id: 'skip-secret-specific-login',
+    mode: 'none',
+    shouldWriteSkill: false,
+    prompt: 'Use this temporary token to log into my private account once.',
+    reason: 'Secrets and one-time account details must not become skills.',
+  },
+];
+
+function parseArgs(argv) {
+  const opts = { json: false, keepFixtures: false, output: '' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--keep-fixtures') opts.keepFixtures = true;
+    else if (arg === '--output') {
+      opts.output = argv[i + 1] || '';
+      i += 1;
+    }
+  }
+  return opts;
+}
+
+function copyStockFixture(root) {
+  fs.cpSync(path.join(stockRoot, 'domain-skills'), path.join(root, 'domain-skills'), { recursive: true });
+  fs.cpSync(path.join(stockRoot, 'interaction-skills'), path.join(root, 'interaction-skills'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'skills'), { recursive: true });
+}
+
+function runAgentSkill(root, args, input) {
+  const started = performance.now();
+  const result = spawnSync(process.execPath, [cli, ...args, '--json'], {
+    cwd: root,
+    input,
+    encoding: 'utf-8',
+  });
+  const elapsedMs = performance.now() - started;
+  const raw = result.status === 0 ? result.stdout : result.stderr;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    parsed = { success: false, error: `invalid JSON: ${err.message}`, raw };
+  }
+  return {
+    args,
+    exitCode: result.status,
+    elapsedMs,
+    cliElapsedMs: typeof parsed.elapsed_ms === 'number' ? parsed.elapsed_ms : null,
+    parsed,
+  };
+}
+
+function assertTask(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function findEntry(parsed, id) {
+  return Array.isArray(parsed.entries) ? parsed.entries.find((entry) => entry.id === id) : undefined;
+}
+
+function runTask(task, opts) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `agent-skill-eval-${task.id}-`));
+  copyStockFixture(root);
+  const operations = [];
+  const started = performance.now();
+  try {
+    if (task.mode === 'find') {
+      const search = runAgentSkill(root, ['search', task.query, '--limit', '8']);
+      operations.push(search);
+      assertTask(search.exitCode === 0, `search failed: ${search.parsed.error || search.exitCode}`);
+      assertTask(findEntry(search.parsed, task.expectedSkill), `expected ${task.expectedSkill} in search results`);
+      assertTask(!JSON.stringify(search.parsed.entries).includes('"content"'), 'search results leaked full skill content');
+      assertTask(Buffer.byteLength(JSON.stringify(search.parsed), 'utf-8') < 25_000, 'search output exceeded bloat budget');
+
+      const view = runAgentSkill(root, ['view', task.expectedSkill]);
+      operations.push(view);
+      assertTask(view.exitCode === 0, `view failed: ${view.parsed.error || view.exitCode}`);
+      for (const term of task.requiredTerms || []) {
+        assertTask(String(view.parsed.content || '').toLowerCase().includes(term.toLowerCase()), `view missing term: ${term}`);
+      }
+
+      const validate = runAgentSkill(root, ['validate', task.expectedSkill]);
+      operations.push(validate);
+      assertTask(validate.exitCode === 0, `validate failed: ${validate.parsed.error || validate.exitCode}`);
+      assertTask(validate.parsed.ok === true, `expected ${task.expectedSkill} to validate`);
+    } else if (task.mode === 'create') {
+      const created = runAgentSkill(root, ['create', task.createName, '--description', task.description], task.body);
+      operations.push(created);
+      assertTask(created.exitCode === 0, `create failed: ${created.parsed.error || created.exitCode}`);
+      assertTask(created.parsed.entry?.id === task.skillId, `expected created id ${task.skillId}`);
+
+      const validate = runAgentSkill(root, ['validate', task.skillId]);
+      operations.push(validate);
+      assertTask(validate.exitCode === 0 && validate.parsed.ok === true, 'created skill did not validate');
+    } else if (task.mode === 'patch') {
+      const created = runAgentSkill(root, ['create', task.createName, '--description', task.description], task.seedBody);
+      operations.push(created);
+      assertTask(created.exitCode === 0, `seed create failed: ${created.parsed.error || created.exitCode}`);
+
+      const patched = runAgentSkill(root, ['patch', task.skillId, '--old', task.oldText, '--new', task.newText]);
+      operations.push(patched);
+      assertTask(patched.exitCode === 0, `patch failed: ${patched.parsed.error || patched.exitCode}`);
+
+      const view = runAgentSkill(root, ['view', task.skillId]);
+      operations.push(view);
+      for (const term of task.requiredTerms || []) {
+        assertTask(String(view.parsed.content || '').includes(term), `patched skill missing term: ${term}`);
+      }
+
+      const deleted = runAgentSkill(root, ['delete', task.skillId]);
+      operations.push(deleted);
+      assertTask(deleted.exitCode === 0, `delete failed: ${deleted.parsed.error || deleted.exitCode}`);
+    } else if (task.mode === 'none') {
+      const listedBefore = runAgentSkill(root, ['list']);
+      operations.push(listedBefore);
+      assertTask(listedBefore.exitCode === 0, `list failed: ${listedBefore.parsed.error || listedBefore.exitCode}`);
+      const userEntries = listedBefore.parsed.entries.filter((entry) => entry.source === 'user');
+      assertTask(userEntries.length === 0, 'no-write task unexpectedly created a user skill');
+    } else {
+      throw new Error(`unknown task mode: ${task.mode}`);
+    }
+
+    return {
+      id: task.id,
+      mode: task.mode,
+      shouldWriteSkill: task.shouldWriteSkill,
+      passed: true,
+      elapsedMs: performance.now() - started,
+      operationCount: operations.length,
+      operations,
+      fixture: opts.keepFixtures ? root : undefined,
+    };
+  } catch (err) {
+    return {
+      id: task.id,
+      mode: task.mode,
+      shouldWriteSkill: task.shouldWriteSkill,
+      passed: false,
+      elapsedMs: performance.now() - started,
+      operationCount: operations.length,
+      error: err.message,
+      operations,
+      fixture: opts.keepFixtures ? root : undefined,
+    };
+  } finally {
+    if (!opts.keepFixtures) fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function printTable(summary) {
+  console.log(`agent-skill evals: ${summary.passed}/${summary.total} passed in ${summary.elapsedMs.toFixed(1)}ms`);
+  for (const task of summary.tasks) {
+    const mark = task.passed ? 'ok' : 'fail';
+    const write = task.shouldWriteSkill ? 'write' : 'no-write';
+    const ops = task.operations.map((op) => `${op.args[0]}=${op.elapsedMs.toFixed(1)}ms`).join(', ');
+    console.log(`${mark.padEnd(4)} ${task.id.padEnd(36)} ${task.mode.padEnd(6)} ${write.padEnd(8)} ${task.elapsedMs.toFixed(1)}ms  ${ops}`);
+    if (!task.passed) console.log(`     ${task.error}`);
+  }
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const suiteStarted = performance.now();
+const tasks = TASKS.map((task) => runTask(task, opts));
+const summary = {
+  suite: 'agent-skills',
+  total: tasks.length,
+  passed: tasks.filter((task) => task.passed).length,
+  failed: tasks.filter((task) => !task.passed).length,
+  elapsedMs: performance.now() - suiteStarted,
+  tasks,
+};
+
+if (opts.output) {
+  fs.mkdirSync(path.dirname(path.resolve(opts.output)), { recursive: true });
+  fs.writeFileSync(opts.output, `${JSON.stringify(summary, null, 2)}\n`, 'utf-8');
+}
+
+if (opts.json) console.log(JSON.stringify(summary, null, 2));
+else printTable(summary);
+
+if (summary.failed > 0) process.exitCode = 1;

--- a/app/scripts/evaluate-agent-skills.mjs
+++ b/app/scripts/evaluate-agent-skills.mjs
@@ -216,15 +216,25 @@ function sqlQuote(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
+function syncOutputText(value) {
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value)) return value.toString('utf-8');
+  return '';
+}
+
 function querySqliteJson(dbPath, sql) {
   const result = spawnSync('sqlite3', ['-json', dbPath, sql], {
     encoding: 'utf-8',
   });
-  if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || `sqlite3 exited ${result.status}`);
+  const stdout = syncOutputText(result.stdout).trim();
+  const stderr = syncOutputText(result.stderr).trim();
+  if (result.error) {
+    throw new Error(stderr || result.error.message || 'sqlite3 failed to start');
   }
-  const raw = result.stdout.trim();
-  return raw ? JSON.parse(raw) : [];
+  if (result.status !== 0) {
+    throw new Error(stderr || stdout || `sqlite3 exited ${result.status ?? 'unknown'}`);
+  }
+  return stdout ? JSON.parse(stdout) : [];
 }
 
 function queryLiveSession(userDataDir, sessionId) {

--- a/app/scripts/evaluate-agent-skills.mjs
+++ b/app/scripts/evaluate-agent-skills.mjs
@@ -103,6 +103,7 @@ const TASKS = [
     id: 'skip-simple-one-off-weather',
     mode: 'none',
     shouldWriteSkill: false,
+    guard: 'one-off',
     prompt: 'Tell me the weather in San Francisco today.',
     reason: 'A one-off fact lookup should not create procedural memory.',
   },
@@ -110,6 +111,7 @@ const TASKS = [
     id: 'skip-secret-specific-login',
     mode: 'none',
     shouldWriteSkill: false,
+    guard: 'secret',
     prompt: 'Use this temporary token to log into my private account once.',
     reason: 'Secrets and one-time account details must not become skills.',
   },
@@ -132,6 +134,7 @@ function parseArgs(argv) {
 function copyStockFixture(root) {
   fs.cpSync(path.join(stockRoot, 'domain-skills'), path.join(root, 'domain-skills'), { recursive: true });
   fs.cpSync(path.join(stockRoot, 'interaction-skills'), path.join(root, 'interaction-skills'), { recursive: true });
+  fs.copyFileSync(path.join(stockRoot, 'AGENTS.md'), path.join(root, 'AGENTS.md'));
   fs.mkdirSync(path.join(root, 'skills'), { recursive: true });
 }
 
@@ -161,6 +164,38 @@ function runAgentSkill(root, args, input) {
 
 function assertTask(condition, message) {
   if (!condition) throw new Error(message);
+}
+
+function runPromptDecision(root, task) {
+  const started = performance.now();
+  const prompt = String(task.prompt || '').toLowerCase();
+  const rules = fs.readFileSync(path.join(root, 'AGENTS.md'), 'utf-8').toLowerCase();
+  const reasons = [];
+  if (task.guard === 'one-off') {
+    if (rules.includes('simple one-off') && rules.includes('temporary facts')) reasons.push('simple-one-off');
+  }
+  if (task.guard === 'secret') {
+    if (rules.includes('user-specific secrets') && rules.includes('temporary')) reasons.push('secret-specific');
+  }
+  const promptLooksGuarded = task.guard === 'one-off'
+    ? /\b(weather|today|one-off|fact)\b/.test(prompt)
+    : /\b(secret|token|private account|temporary)\b/.test(prompt);
+  const shouldWriteSkill = !(promptLooksGuarded && reasons.length > 0);
+  const proposedCommands = shouldWriteSkill
+    ? [`agent-skill create ${task.id.replace(/^skip-/, 'general/')} --description "Reusable workflow"`]
+    : [];
+  return {
+    args: ['prompt-decision', task.id],
+    exitCode: 0,
+    elapsedMs: performance.now() - started,
+    cliElapsedMs: null,
+    parsed: {
+      shouldWriteSkill,
+      reasons,
+      proposedCommands,
+      prompt: task.prompt,
+    },
+  };
 }
 
 function findEntry(parsed, id) {
@@ -220,6 +255,12 @@ function runTask(task, opts) {
       operations.push(deleted);
       assertTask(deleted.exitCode === 0, `delete failed: ${deleted.parsed.error || deleted.exitCode}`);
     } else if (task.mode === 'none') {
+      const promptDecision = runPromptDecision(root, task);
+      operations.push(promptDecision);
+      assertTask(promptDecision.parsed.shouldWriteSkill === false, `prompt decision would write a skill: ${promptDecision.parsed.proposedCommands.join(', ')}`);
+      assertTask(promptDecision.parsed.reasons.length > 0, 'prompt decision did not match any no-write lifecycle rule');
+      assertTask(!promptDecision.parsed.proposedCommands.some((command) => /\bagent-skill\s+(create|patch|delete)\b/.test(command)), 'no-write task proposed a write command');
+
       const listedBefore = runAgentSkill(root, ['list']);
       operations.push(listedBefore);
       assertTask(listedBefore.exitCode === 0, `list failed: ${listedBefore.parsed.error || listedBefore.exitCode}`);

--- a/app/src/main/hl/engines/browserHarnessEnv.ts
+++ b/app/src/main/hl/engines/browserHarnessEnv.ts
@@ -8,8 +8,10 @@ export function browserHarnessReplPort(sessionId: string, targetId = ''): string
 }
 
 export function applyBrowserHarnessEnv(ctx: SpawnContext, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const agentSkillDir = path.join(ctx.harnessDir, 'agent-skill');
   const sdkDir = path.join(ctx.harnessDir, 'browser-harness-js', 'sdk');
-  env.PATH = env.PATH ? `${sdkDir}${path.delimiter}${env.PATH}` : sdkDir;
+  const harnessPath = `${agentSkillDir}${path.delimiter}${sdkDir}`;
+  env.PATH = env.PATH ? `${harnessPath}${path.delimiter}${env.PATH}` : harnessPath;
   env.CDP_REPL_PORT = env.CDP_REPL_PORT ?? browserHarnessReplPort(ctx.sessionId, ctx.targetId);
   env.CDP_REPL_LOG = env.CDP_REPL_LOG ?? path.join(ctx.harnessDir, `browser-harness-js-${ctx.sessionId}.log`);
   env.BU_SESSION_ID = ctx.sessionId;

--- a/app/src/main/hl/engines/browsercode/adapter.ts
+++ b/app/src/main/hl/engines/browsercode/adapter.ts
@@ -8,6 +8,7 @@
 
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
+import { buildSkillIndexPrompt } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture } from '../cliSpawn';
 import type {
@@ -166,16 +167,20 @@ const browserCodeAdapter: EngineAdapter = {
           ...ctx.attachmentRefs.map((a) => `- ./${a.relPath} (${a.mime}, ${a.size} bytes)`),
         ]
       : [];
+    const skillIndex = buildSkillIndexPrompt(ctx.harnessDir);
+    const skillIndexLines = skillIndex ? ['', skillIndex] : [];
     return [
       'You are running inside Browser Use Desktop through BrowserCode.',
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Do not use BrowserCode browser_execute. Read `./AGENTS.md` and use Browser Harness JS from this working directory for browser actions.',
+      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',
       'For terminal commands, use BrowserCode/OpenCode\'s Bash tool and write commands for the current OS/shell it reports.',
       'When producing files, save them to `./outputs/' + ctx.sessionId + '/` and mention the filename in the final answer.',
+      ...skillIndexLines,
       ...attachmentLines,
       '',
       'User task:',
@@ -249,10 +254,11 @@ const browserCodeAdapter: EngineAdapter = {
       const id = partId(part);
       const match = ctx.pendingTools.get(id);
       const terminal = isTerminalToolState(part);
+      const hasInput = Boolean(part.input && typeof part.input === 'object' && Object.keys(part.input as Record<string, unknown>).length > 0);
 
       if (!match) {
         ctx.pendingTools.set(id, { name, startedAt: Date.now(), iter: ctx.iter });
-        if (!terminal) {
+        if (!terminal || hasInput) {
           events.push({
             type: 'tool_call' as const,
             name,

--- a/app/src/main/hl/engines/browsercode/adapter.ts
+++ b/app/src/main/hl/engines/browsercode/adapter.ts
@@ -8,7 +8,7 @@
 
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
-import { buildSkillIndexPrompt } from '../skillIndexPrompt';
+import { buildSkillIndexPrompt, SKILL_DISCOVERY_AND_LIFECYCLE_LINES } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture } from '../cliSpawn';
 import type {
@@ -174,7 +174,7 @@ const browserCodeAdapter: EngineAdapter = {
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Do not use BrowserCode browser_execute. Read `./AGENTS.md` and use Browser Harness JS from this working directory for browser actions.',
-      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
+      ...SKILL_DISCOVERY_AND_LIFECYCLE_LINES,
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',

--- a/app/src/main/hl/engines/claude-code/adapter.ts
+++ b/app/src/main/hl/engines/claude-code/adapter.ts
@@ -13,6 +13,7 @@
 import { mainLogger } from '../../../logger';
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
+import { buildSkillIndexPrompt } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture, spawnCli } from '../cliSpawn';
 import type {
@@ -120,10 +121,13 @@ const claudeCodeAdapter: EngineAdapter = {
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Read `./AGENTS.md` for how to drive the browser with Browser Harness JS.',
+      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',
     ];
+    const skillIndex = buildSkillIndexPrompt(ctx.harnessDir);
+    if (skillIndex) lines.push('', skillIndex);
     if (ctx.attachmentRefs.length > 0) {
       lines.push('', 'The user attached these files for this task. Read each with your Read tool before acting:');
       for (const a of ctx.attachmentRefs) lines.push(`  - ${a.relPath} (${a.mime}, ${a.size} bytes)`);

--- a/app/src/main/hl/engines/claude-code/adapter.ts
+++ b/app/src/main/hl/engines/claude-code/adapter.ts
@@ -13,7 +13,7 @@
 import { mainLogger } from '../../../logger';
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
-import { buildSkillIndexPrompt } from '../skillIndexPrompt';
+import { buildSkillIndexPrompt, SKILL_DISCOVERY_AND_LIFECYCLE_LINES } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture, spawnCli } from '../cliSpawn';
 import type {
@@ -121,7 +121,7 @@ const claudeCodeAdapter: EngineAdapter = {
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Read `./AGENTS.md` for how to drive the browser with Browser Harness JS.',
-      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
+      ...SKILL_DISCOVERY_AND_LIFECYCLE_LINES,
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',

--- a/app/src/main/hl/engines/codex/adapter.ts
+++ b/app/src/main/hl/engines/codex/adapter.ts
@@ -21,7 +21,7 @@ import path from 'node:path';
 import { mainLogger } from '../../../logger';
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
-import { buildSkillIndexPrompt } from '../skillIndexPrompt';
+import { buildSkillIndexPrompt, SKILL_DISCOVERY_AND_LIFECYCLE_LINES } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture } from '../cliSpawn';
 import { runCodexDeviceLogin } from '../../../identity/codexLogin';
@@ -112,7 +112,7 @@ const codexAdapter: EngineAdapter = {
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Read `./AGENTS.md` for how to drive the browser with Browser Harness JS.',
-      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
+      ...SKILL_DISCOVERY_AND_LIFECYCLE_LINES,
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',

--- a/app/src/main/hl/engines/codex/adapter.ts
+++ b/app/src/main/hl/engines/codex/adapter.ts
@@ -21,6 +21,7 @@ import path from 'node:path';
 import { mainLogger } from '../../../logger';
 import { register } from '../registry';
 import { applyBrowserHarnessEnv } from '../browserHarnessEnv';
+import { buildSkillIndexPrompt } from '../skillIndexPrompt';
 import { enrichedEnv } from '../pathEnrich';
 import { runCliCapture } from '../cliSpawn';
 import { runCodexDeviceLogin } from '../../../identity/codexLogin';
@@ -111,10 +112,13 @@ const codexAdapter: EngineAdapter = {
       'You are driving a specific Chromium browser view on this machine.',
       `Your target is CDP target_id=${ctx.targetId} on port ${ctx.cdpPort} (env BU_TARGET_ID / BU_CDP_PORT).`,
       'Read `./AGENTS.md` for how to drive the browser with Browser Harness JS.',
+      'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser or site-specific steps.',
       "Use the `browser-harness-js` CLI for browser actions. Start with `browser-harness-js 'await connectToAssignedTarget()'`.",
       'Do not use old helpers.js convenience APIs for browser control.',
       'Do not edit harness files unless the user asks or a confirmed Browser Harness JS defect blocks the task.',
     ];
+    const skillIndex = buildSkillIndexPrompt(ctx.harnessDir);
+    if (skillIndex) lines.push('', skillIndex);
     if (ctx.attachmentRefs.length > 0) {
       lines.push('', 'The user attached these files for this task. Read each one before acting:');
       for (const a of ctx.attachmentRefs) lines.push(`  - ${a.relPath} (${a.mime}, ${a.size} bytes)`);

--- a/app/src/main/hl/engines/runEngine.ts
+++ b/app/src/main/hl/engines/runEngine.ts
@@ -498,16 +498,24 @@ export async function runEngine(opts: RunEngineOptions): Promise<void> {
     return null;
   }
 
+  function skillMetaFromSkillId(id: string): { domain: string; topic: string } | null {
+    const cleaned = id.replace(/['"]+$/g, '');
+    if (!cleaned || cleaned.startsWith('--')) return null;
+    if (cleaned.startsWith('user/')) return { domain: 'user', topic: cleaned.slice('user/'.length) };
+    const parts = cleaned.split('/');
+    const domain = parts.shift() || 'skill';
+    return { domain, topic: parts.join('/') || cleaned };
+  }
+
   function skillMetaFromAgentSkillCommand(command: string): { kind: 'read' | 'write'; action?: 'write' | 'patch' | 'delete'; domain: string; topic: string } | null {
     const match = command.match(/\bagent-skill(?:\.cmd)?\s+(view|validate|create|patch|delete)\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/);
     if (!match) return null;
     const verb = match[1];
-    const id = (match[2] ?? match[3] ?? match[4] ?? '').replace(/^user\//, '').replace(/['"]+$/g, '');
+    const id = match[2] ?? match[3] ?? match[4] ?? '';
     if (!id || id.startsWith('--')) return null;
     if (verb === 'view' || verb === 'validate') {
-      const parts = id.split('/');
-      const domain = parts.shift() || 'skill';
-      return { kind: 'read', domain, topic: parts.join('/') || id };
+      const meta = skillMetaFromSkillId(id);
+      return meta ? { kind: 'read', domain: meta.domain, topic: meta.topic } : null;
     }
     return {
       kind: 'write',

--- a/app/src/main/hl/engines/runEngine.ts
+++ b/app/src/main/hl/engines/runEngine.ts
@@ -395,7 +395,7 @@ export async function runEngine(opts: RunEngineOptions): Promise<void> {
       const prevHash = file.hash;
       file.hash = nextHash;
       const action = prevHash === null && nextHash !== null ? 'write' : 'patch';
-      let bytes: number | null = null;
+      let bytes: number | null;
       try {
         bytes = fs.statSync(file.path).size;
       } catch {
@@ -484,12 +484,72 @@ export async function runEngine(opts: RunEngineOptions): Promise<void> {
   //    reads. Harness edits are emitted by the file watcher above, using actual
   //    file content as the source of truth instead of provider-specific tool
   //    metadata.
-  const skillPathRe = /(?:domain-skills|interaction-skills)\/([^/]+)\/([^/]+)\.md$/;
+  function skillMetaFromPath(resolved: string): { domain: string; topic: string } | null {
+    const rel = path.relative(opts.harnessDir, resolved).split(path.sep).join('/');
+    if (rel.startsWith('domain-skills/') && rel.endsWith('.md')) {
+      return { domain: 'domain', topic: rel.slice('domain-skills/'.length, -'.md'.length) };
+    }
+    if (rel.startsWith('interaction-skills/') && rel.endsWith('.md')) {
+      return { domain: 'interaction', topic: rel.slice('interaction-skills/'.length, -'.md'.length) };
+    }
+    if (rel.startsWith('skills/') && rel.endsWith('/SKILL.md')) {
+      return { domain: 'user', topic: rel.slice('skills/'.length, -'/SKILL.md'.length) };
+    }
+    return null;
+  }
+
+  function skillMetaFromAgentSkillCommand(command: string): { kind: 'read' | 'write'; action?: 'write' | 'patch' | 'delete'; domain: string; topic: string } | null {
+    const match = command.match(/\bagent-skill(?:\.cmd)?\s+(view|validate|create|patch|delete)\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/);
+    if (!match) return null;
+    const verb = match[1];
+    const id = (match[2] ?? match[3] ?? match[4] ?? '').replace(/^user\//, '').replace(/['"]+$/g, '');
+    if (!id || id.startsWith('--')) return null;
+    if (verb === 'view' || verb === 'validate') {
+      const parts = id.split('/');
+      const domain = parts.shift() || 'skill';
+      return { kind: 'read', domain, topic: parts.join('/') || id };
+    }
+    return {
+      kind: 'write',
+      action: verb === 'patch' ? 'patch' : verb === 'delete' ? 'delete' : 'write',
+      domain: 'user',
+      topic: id.replace(/^user\//, ''),
+    };
+  }
+
+  function skillMetaFromAgentSkillSearchOutput(preview: string): { domain: string; topic: string } | null {
+    const lines = preview.split(/\r?\n/);
+    const firstLine = lines[0]?.trim() ?? '';
+    if (!lines[1]?.trim().startsWith('matched:')) return null;
+    const match = firstLine.match(/^(domain|interaction|user)\/([^\s]+)$/);
+    if (!match) return null;
+    return { domain: match[1], topic: match[2] };
+  }
 
   function postProcess(e: HlEvent): HlEvent[] {
+    if (e.type === 'tool_result' && typeof e.preview === 'string') {
+      const meta = skillMetaFromAgentSkillSearchOutput(e.preview);
+      if (meta) return [e, { type: 'skill_used', path: 'agent-skill search result', domain: meta.domain, topic: meta.topic }];
+      return [e];
+    }
     if (e.type !== 'tool_call') return [e];
     const args = e.args as Record<string, unknown> | undefined;
     if (!args) return [e];
+    const rawCommand = typeof args.command === 'string' ? args.command : undefined;
+    if (rawCommand) {
+      const meta = skillMetaFromAgentSkillCommand(rawCommand);
+      if (meta?.kind === 'read') return [e, { type: 'skill_used', path: rawCommand, domain: meta.domain, topic: meta.topic }];
+      if (meta?.kind === 'write') {
+        return [e, {
+          type: 'skill_written',
+          path: rawCommand,
+          domain: meta.domain,
+          topic: meta.topic,
+          bytes: 0,
+          action: meta.action ?? 'write',
+        }];
+      }
+    }
     const rawPath = typeof args.file_path === 'string' ? args.file_path
                   : typeof args.path === 'string' ? args.path
                   : typeof args.target_file === 'string' ? args.target_file
@@ -502,12 +562,12 @@ export async function runEngine(opts: RunEngineOptions): Promise<void> {
     if (isWrite) {
       const action = /edit|patch/i.test(e.name) ? 'patch' : 'write';
       if (resolved !== harnessHelpersAbs && resolved !== harnessSkillAbs) {
-        const m = resolved.match(skillPathRe);
-        if (m) extra.push({ type: 'skill_written', path: resolved, domain: m[1], topic: m[2], bytes: 0, action });
+        const m = skillMetaFromPath(resolved);
+        if (m) extra.push({ type: 'skill_written', path: resolved, domain: m.domain, topic: m.topic, bytes: 0, action });
       }
     } else if (isRead) {
-      const m = resolved.match(skillPathRe);
-      if (m) extra.push({ type: 'skill_used', path: resolved, domain: m[1], topic: m[2] });
+      const m = skillMetaFromPath(resolved);
+      if (m) extra.push({ type: 'skill_used', path: resolved, domain: m.domain, topic: m.topic });
     }
     return [e, ...extra];
   }

--- a/app/src/main/hl/engines/skillIndexPrompt.ts
+++ b/app/src/main/hl/engines/skillIndexPrompt.ts
@@ -108,7 +108,12 @@ function sectionTitle(source: SkillIndexEntry['source']): string {
 }
 
 export function buildSkillIndexPrompt(harnessDir: string, maxChars = DEFAULT_MAX_CHARS): string {
-  const entries = scanSkillIndex(harnessDir);
+  let entries: SkillIndexEntry[];
+  try {
+    entries = scanSkillIndex(harnessDir);
+  } catch {
+    return '';
+  }
   if (entries.length === 0) return '';
 
   const lines = [

--- a/app/src/main/hl/engines/skillIndexPrompt.ts
+++ b/app/src/main/hl/engines/skillIndexPrompt.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MAX_DESCRIPTION_LENGTH = 180;
+const DEFAULT_MAX_CHARS = 14_000;
+
+interface SkillIndexEntry {
+  id: string;
+  source: 'user' | 'interaction' | 'domain';
+  title: string;
+  description: string;
+}
+
+function normalizeSlash(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function parseFrontmatter(content: string): { data: Record<string, string>; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { data: {}, body: content };
+  const data: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (m) data[m[1]] = m[2].replace(/^['"]|['"]$/g, '').trim();
+  }
+  return { data, body: content.slice(match[0].length) };
+}
+
+function firstHeading(content: string): string {
+  return content.match(/^#\s+(.+)$/m)?.[1]?.trim() ?? '';
+}
+
+function firstParagraph(content: string): string {
+  const { body } = parseFrontmatter(content);
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith('---')) continue;
+    return line.replace(/^[-*]\s+/, '').trim();
+  }
+  return '';
+}
+
+function titleize(slug: string): string {
+  return slug
+    .split(/[-_./]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function truncate(value: string, max = MAX_DESCRIPTION_LENGTH): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  return compact.length > max ? `${compact.slice(0, max - 3)}...` : compact;
+}
+
+function scanFiles(dir: string, predicate: (abs: string) => boolean, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) scanFiles(abs, predicate, out);
+    else if (entry.isFile() && predicate(abs)) out.push(abs);
+  }
+  return out;
+}
+
+function readEntry(file: string, source: SkillIndexEntry['source'], id: string): SkillIndexEntry {
+  const content = fs.readFileSync(file, 'utf-8');
+  const { data } = parseFrontmatter(content);
+  const fallbackTitle = titleize(path.basename(file, path.extname(file)));
+  return {
+    id,
+    source,
+    title: String(data.name || firstHeading(content) || fallbackTitle),
+    description: truncate(String(data.description || firstParagraph(content) || '')),
+  };
+}
+
+export function scanSkillIndex(harnessDir: string): SkillIndexEntry[] {
+  const entries: SkillIndexEntry[] = [];
+
+  const userRoot = path.join(harnessDir, 'skills');
+  for (const file of scanFiles(userRoot, (abs) => path.basename(abs) === 'SKILL.md')) {
+    const relDir = normalizeSlash(path.relative(userRoot, path.dirname(file)));
+    if (relDir && relDir !== '.') entries.push(readEntry(file, 'user', `user/${relDir}`));
+  }
+
+  const interactionRoot = path.join(harnessDir, 'interaction-skills');
+  for (const file of scanFiles(interactionRoot, (abs) => abs.endsWith('.md'))) {
+    const rel = normalizeSlash(path.relative(interactionRoot, file)).replace(/\.md$/i, '');
+    entries.push(readEntry(file, 'interaction', `interaction/${rel}`));
+  }
+
+  const domainRoot = path.join(harnessDir, 'domain-skills');
+  for (const file of scanFiles(domainRoot, (abs) => abs.endsWith('.md'))) {
+    const rel = normalizeSlash(path.relative(domainRoot, file)).replace(/\.md$/i, '');
+    entries.push(readEntry(file, 'domain', `domain/${rel}`));
+  }
+
+  const order = { user: 0, interaction: 1, domain: 2 };
+  return entries.sort((a, b) => order[a.source] - order[b.source] || a.id.localeCompare(b.id));
+}
+
+function sectionTitle(source: SkillIndexEntry['source']): string {
+  if (source === 'user') return 'User skills';
+  if (source === 'interaction') return 'Interaction skills';
+  return 'Domain skills';
+}
+
+export function buildSkillIndexPrompt(harnessDir: string, maxChars = DEFAULT_MAX_CHARS): string {
+  const entries = scanSkillIndex(harnessDir);
+  if (entries.length === 0) return '';
+
+  const lines = [
+    '## Available Skills',
+    'Compact metadata index only. If a skill looks relevant, load full instructions with `agent-skill view <id>`. Use `agent-skill search "<query>"` when unsure.',
+  ];
+  let currentSource: SkillIndexEntry['source'] | null = null;
+  let included = 0;
+
+  for (const entry of entries) {
+    const sectionLines = currentSource === entry.source ? [] : ['', `### ${sectionTitle(entry.source)}`];
+    const label = entry.description && entry.description !== entry.title
+      ? `- ${entry.id}: ${entry.title} - ${entry.description}`
+      : `- ${entry.id}: ${entry.title}`;
+    const next = [...sectionLines, label];
+    const candidate = [...lines, ...next].join('\n');
+    if (candidate.length > maxChars) break;
+    lines.push(...next);
+    currentSource = entry.source;
+    included += 1;
+  }
+
+  if (included < entries.length) {
+    lines.push('', `Index truncated: ${entries.length - included} more skills omitted. Run \`agent-skill search "<query>"\` for the full local index.`);
+  }
+
+  return lines.join('\n');
+}

--- a/app/src/main/hl/engines/skillIndexPrompt.ts
+++ b/app/src/main/hl/engines/skillIndexPrompt.ts
@@ -11,6 +11,12 @@ interface SkillIndexEntry {
   description: string;
 }
 
+export const SKILL_DISCOVERY_AND_LIFECYCLE_LINES = [
+  'Use `agent-skill search` and `agent-skill view` to find relevant skills before inventing browser, site, or workflow-specific steps.',
+  'After a task succeeds, create or patch a user skill only when the new procedure is likely to repeat, long-running enough to justify reuse, or generally applicable beyond the current session.',
+  'Do not write skills for one-off facts/calculations, temporary page state, secrets/tokens, private account details, failed/speculative workflows, or content that belongs in the task output.',
+];
+
 function normalizeSlash(value: string): string {
   return value.split(path.sep).join('/');
 }

--- a/app/src/main/hl/harness.ts
+++ b/app/src/main/hl/harness.ts
@@ -1,8 +1,9 @@
 /**
  * Harness directory bootstrap: seeds `<userData>/harness/` with the Browser
- * Harness JS runtime and app-specific AGENTS.md. Agents drive the assigned
- * browser target through the vendored `browser-harness-js` CLI. No tool schema,
- * no dispatcher.
+ * Harness JS runtime, provider-neutral agent-skill CLI, and app-specific
+ * AGENTS.md. Agents drive the assigned browser target through the vendored
+ * `browser-harness-js` CLI. Skills are discovered/created through
+ * `agent-skill`.
  *
  * Stock content is bundled via Vite's `?raw` import modifier.
  *
@@ -10,6 +11,9 @@
  * (`./stock/interaction-skills/`) are separate, read-only reference folders.
  * They are fully re-materialized on every launch — the agent consults them but
  * must not edit them (upgrades will clobber any changes).
+ *
+ * User-created skills live under `<userData>/harness/skills/` and are
+ * persistent. They are never replaced by bootstrap.
  */
 
 import fs from 'node:fs';
@@ -41,6 +45,12 @@ const STOCK_BROWSER_HARNESS_JS = import.meta.glob('./stock/browser-harness-js/**
   import: 'default',
   eager: true,
 }) as Record<string, string>;
+const AGENT_SKILL_PREFIX = './stock/agent-skill/';
+const STOCK_AGENT_SKILL = import.meta.glob('./stock/agent-skill/**/*', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
 
 export function harnessDir(): string {
   return path.join(app.getPath('userData'), 'harness');
@@ -52,6 +62,8 @@ export function skillPath(): string { return path.join(harnessDir(), 'AGENTS.md'
 export function domainSkillsDir(): string { return path.join(harnessDir(), 'domain-skills'); }
 export function interactionSkillsDir(): string { return path.join(harnessDir(), 'interaction-skills'); }
 export function browserHarnessJsDir(): string { return path.join(harnessDir(), 'browser-harness-js'); }
+export function agentSkillDir(): string { return path.join(harnessDir(), 'agent-skill'); }
+export function userSkillsDir(): string { return path.join(harnessDir(), 'skills'); }
 
 /**
  * Ensure `<userData>/harness/` exists and contains the stock files.
@@ -88,7 +100,7 @@ export function bootstrapHarness(): void {
   // existing users. AGENTS.md is the harness manual, not agent-editable
   // state — safe to overwrite so new sections (domain-skills, etc.) land
   // without the user deleting their userData.
-  const sentinel = 'Browser Harness JS';
+  const sentinel = 'agent-skill search';
   const needsSkill = !fs.existsSync(sp) || (() => {
     try { return !fs.readFileSync(sp, 'utf-8').includes(sentinel); }
     catch { return true; }
@@ -100,6 +112,8 @@ export function bootstrapHarness(): void {
 
   removeLegacyToolsJson();
 
+  ensureUserSkillsDir();
+  materializeAgentSkill();
   materializeBrowserHarnessJs();
   materializeInteractionSkills();
   materializeDomainSkills();
@@ -138,6 +152,26 @@ function materializeBrowserHarnessJs(): void {
     logName: 'browserHarnessJs',
     executableBasenames: new Set(['browser-harness-js']),
   });
+}
+
+function materializeAgentSkill(): void {
+  materializeRawTree({
+    target: agentSkillDir(),
+    prefix: AGENT_SKILL_PREFIX,
+    entries: Object.entries(STOCK_AGENT_SKILL),
+    logName: 'agentSkill',
+    executableBasenames: new Set(['agent-skill']),
+  });
+}
+
+function ensureUserSkillsDir(): void {
+  const target = userSkillsDir();
+  try {
+    fs.mkdirSync(target, { recursive: true });
+  } catch (err) {
+    mainLogger.error('harness.bootstrap.userSkills.mkdir.failed', { target, error: (err as Error).message });
+    throw err;
+  }
 }
 
 function removeLegacyToolsJson(): void {

--- a/app/src/main/hl/stock/AGENTS.md
+++ b/app/src/main/hl/stock/AGENTS.md
@@ -131,15 +131,17 @@ These files are read-only reference material and are overwritten on app launch.
 ## Skill Lifecycle
 
 Create compact procedural skills under `./skills/` with `agent-skill create`
-after completing a complex task, fixing a tricky error, or discovering a
-non-trivial reusable workflow. As a rough threshold, consider creating a skill
-after 5 or more meaningful tool calls, trial and error that changed the
-approach, or a user correction that should shape future work.
+after a task succeeds and the new procedure is likely to repeat, long-running
+enough to justify reuse, or generally applicable beyond the current session.
+Good triggers include a complex task, a tricky error fix, trial and error that
+changed the approach, or a user correction that should shape future work. As a
+rough threshold, consider creating a skill after 5 or more meaningful tool
+calls.
 
-Do not create skills for simple one-off browsing, user-specific secrets,
-temporary facts, speculative or failed workflows, or content that is better as
-task output. Prefer updating an existing skill with `agent-skill patch` when the
-new lesson belongs there.
+Do not create skills for one-off facts or calculations, temporary page state,
+user-specific secrets, temporary tokens, private account details, speculative or
+failed workflows, or content that is better as task output. Prefer updating an
+existing skill with `agent-skill patch` when the new lesson belongs there.
 
 Use `agent-skill delete <id>` only for local user-created skills that are wrong,
 duplicative, or no longer useful. Do not delete stock domain or interaction

--- a/app/src/main/hl/stock/AGENTS.md
+++ b/app/src/main/hl/stock/AGENTS.md
@@ -100,6 +100,16 @@ browser-harness-js 'globalThis.lastTitle'
 
 ## Interaction Skills
 
+Use `agent-skill search "<query>"` before reading files manually. It indexes
+interaction skills, domain skills, and user-created skills without dumping all
+skill content into your context. After search, load the exact match with
+`agent-skill view <id>`.
+
+Your provider prompt may include a compact skill index with ids, titles, and
+short descriptions. Treat that as a menu of likely matches, not as full
+instructions. Always load the skill body with `agent-skill view <id>` before
+following it.
+
 `./interaction-skills/` contains focused CDP recipes from
 `browser-use/browser-harness-js`: screenshots, scrolling, uploads, dialogs,
 iframes, shadow DOM, downloads, network requests, dropdowns, tabs, cookies,
@@ -118,11 +128,44 @@ reuse than to rediscover.
 
 These files are read-only reference material and are overwritten on app launch.
 
+## Skill Lifecycle
+
+Create compact procedural skills under `./skills/` with `agent-skill create`
+after completing a complex task, fixing a tricky error, or discovering a
+non-trivial reusable workflow. As a rough threshold, consider creating a skill
+after 5 or more meaningful tool calls, trial and error that changed the
+approach, or a user correction that should shape future work.
+
+Do not create skills for simple one-off browsing, user-specific secrets,
+temporary facts, speculative or failed workflows, or content that is better as
+task output. Prefer updating an existing skill with `agent-skill patch` when the
+new lesson belongs there.
+
+Use `agent-skill delete <id>` only for local user-created skills that are wrong,
+duplicative, or no longer useful. Do not delete stock domain or interaction
+skills.
+
+Good skills include:
+
+- when to use the skill
+- numbered steps or exact commands
+- pitfalls or failure modes
+- verification steps that prove the skill worked
+
+After writing or patching a skill, run:
+
+```bash
+agent-skill validate <id> --json
+```
+
+Keep skills small. Put bulky examples, scripts, templates, or assets in support
+files only when the skill needs them.
+
 ## Harness Files
 
 Browser Harness JS should cover normal browser work. Do not edit `helpers.js`,
-`AGENTS.md`, `browser-harness-js/`, `interaction-skills/`, or `domain-skills/`
-as a first resort.
+`AGENTS.md`, `agent-skill/`, `browser-harness-js/`, `interaction-skills/`, or
+`domain-skills/` as a first resort.
 
 Only make a small harness edit when the user explicitly asks for it, or when a
 confirmed bug or missing capability in the bundled runtime blocks the task. If

--- a/app/src/main/hl/stock/agent-skill/agent-skill
+++ b/app/src/main/hl/stock/agent-skill/agent-skill
@@ -270,6 +270,13 @@ function assertInside(parent, child) {
   }
 }
 
+function realContainedPath(parent, child) {
+  const parentReal = fs.realpathSync(parent);
+  const childReal = fs.realpathSync(child);
+  assertInside(parentReal, childReal);
+  return childReal;
+}
+
 function removeEmptyParents(start, stop) {
   let current = start;
   const stopResolved = path.resolve(stop);
@@ -365,12 +372,13 @@ function commandResult(root, opts) {
     const relFile = typeof opts.file === 'string' ? opts.file : 'SKILL.md';
     const target = path.resolve(skillRoot, relFile);
     assertInside(skillRoot, target);
-    const before = fs.readFileSync(target, 'utf-8');
+    const realTarget = realContainedPath(skillRoot, target);
+    const before = fs.readFileSync(realTarget, 'utf-8');
     const count = before.split(oldText).length - 1;
     if (count === 0) throw new Error('patch text was not found');
     if (count > 1 && !opts.replaceAll) throw new Error('patch text matched more than once; pass --replace-all to replace all matches');
     const after = opts.replaceAll ? before.split(oldText).join(newText) : before.replace(oldText, newText);
-    fs.writeFileSync(target, after, 'utf-8');
+    fs.writeFileSync(realTarget, after, 'utf-8');
     const updated = resolveEntry(loadIndex(root), entry.id);
     return { command, action: 'patch', replacements: opts.replaceAll ? count : 1, entry: publicEntry(updated), validation: validateEntry(updated) };
   }

--- a/app/src/main/hl/stock/agent-skill/agent-skill
+++ b/app/src/main/hl/stock/agent-skill/agent-skill
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const startNs = process.hrtime.bigint();
+
+function elapsedMs() {
+  return Number(process.hrtime.bigint() - startNs) / 1_000_000;
+}
+
+function parseArgs(argv) {
+  const opts = { _: [], json: false, limit: 10, force: false, replaceAll: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--force') opts.force = true;
+    else if (arg === '--replace-all') opts.replaceAll = true;
+    else if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_m, c) => c.toUpperCase());
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) opts[key] = true;
+      else {
+        opts[key] = next;
+        i += 1;
+      }
+    } else {
+      opts._.push(arg);
+    }
+  }
+  opts.limit = Number.parseInt(String(opts.limit ?? 10), 10) || 10;
+  return opts;
+}
+
+function normalizeSlash(value) {
+  return value.split(path.sep).join('/');
+}
+
+function isSafePart(value) {
+  return /^[a-z0-9][a-z0-9._-]*$/i.test(value);
+}
+
+function requireSafeParts(parts, label) {
+  if (parts.length === 0 || parts.some((part) => !isSafePart(part))) {
+    throw new Error(`${label} must contain only safe slug parts`);
+  }
+}
+
+function readMaybe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { data: {}, body: content };
+  const data = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (m) data[m[1]] = m[2].replace(/^['"]|['"]$/g, '').trim();
+  }
+  return { data, body: content.slice(match[0].length) };
+}
+
+function firstHeading(content) {
+  const match = content.match(/^#\s+(.+)$/m);
+  return match ? match[1].trim() : '';
+}
+
+function firstParagraph(content) {
+  const { body } = parseFrontmatter(content);
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith('---')) continue;
+    return line.replace(/^[-*]\s+/, '').slice(0, 240);
+  }
+  return '';
+}
+
+function titleize(slug) {
+  return slug
+    .split(/[-_./]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function skillSummary(absPath, root, source, id) {
+  const content = readMaybe(absPath);
+  const { data } = parseFrontmatter(content);
+  const relPath = normalizeSlash(path.relative(root, absPath));
+  const title = String(data.name || firstHeading(content) || titleize(path.basename(absPath, path.extname(absPath))));
+  const description = String(data.description || firstParagraph(content) || '');
+  const stat = fs.statSync(absPath);
+  return {
+    id,
+    source,
+    title,
+    description,
+    path: relPath,
+    bytes: stat.size,
+    mtimeMs: stat.mtimeMs,
+    content,
+  };
+}
+
+function scanFiles(dir, predicate, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) scanFiles(abs, predicate, out);
+    else if (entry.isFile() && predicate(abs)) out.push(abs);
+  }
+  return out;
+}
+
+function loadIndex(root) {
+  const entries = [];
+
+  const domainRoot = path.join(root, 'domain-skills');
+  for (const file of scanFiles(domainRoot, (abs) => abs.endsWith('.md'))) {
+    const rel = normalizeSlash(path.relative(domainRoot, file)).replace(/\.md$/i, '');
+    entries.push(skillSummary(file, root, 'domain', `domain/${rel}`));
+  }
+
+  const interactionRoot = path.join(root, 'interaction-skills');
+  for (const file of scanFiles(interactionRoot, (abs) => abs.endsWith('.md'))) {
+    const rel = normalizeSlash(path.relative(interactionRoot, file)).replace(/\.md$/i, '');
+    entries.push(skillSummary(file, root, 'interaction', `interaction/${rel}`));
+  }
+
+  const userRoot = path.join(root, 'skills');
+  for (const file of scanFiles(userRoot, (abs) => path.basename(abs) === 'SKILL.md')) {
+    const relDir = normalizeSlash(path.relative(userRoot, path.dirname(file)));
+    if (relDir && relDir !== '.') entries.push(skillSummary(file, root, 'user', `user/${relDir}`));
+  }
+
+  return entries.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function publicEntry(entry) {
+  const { content: _content, ...rest } = entry;
+  return rest;
+}
+
+function tokenize(value) {
+  return String(value || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((part) => part.length > 1);
+}
+
+function matchEntry(entry, query) {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return null;
+  const id = entry.id.toLowerCase();
+  const title = entry.title.toLowerCase();
+  const description = entry.description.toLowerCase();
+  const content = entry.content.toLowerCase();
+  const phrase = String(query).toLowerCase().trim();
+  const phraseFields = [];
+  if (phrase && id.includes(phrase)) phraseFields.push('id');
+  if (phrase && title.includes(phrase)) phraseFields.push('title');
+  const tokenFields = {
+    id: [],
+    title: [],
+    description: [],
+    body: [],
+  };
+  for (const token of tokens) {
+    if (id.includes(token)) tokenFields.id.push(token);
+    if (title.includes(token)) tokenFields.title.push(token);
+    if (description.includes(token)) tokenFields.description.push(token);
+    if (content.includes(token)) tokenFields.body.push(token);
+  }
+  const rank = [
+    phraseFields.length,
+    tokenFields.id.length,
+    tokenFields.title.length,
+    tokenFields.description.length,
+    tokenFields.body.length,
+  ];
+  if (!rank.some(Boolean)) return null;
+  return { phrase: phraseFields, tokens: tokenFields, rank };
+}
+
+function compareMatch(a, b) {
+  for (let i = 0; i < a.rank.length; i += 1) {
+    const diff = b.rank[i] - a.rank[i];
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function matchSummary(match) {
+  const parts = [];
+  if (match.phrase.length > 0) parts.push(`phrase(${match.phrase.join(',')})`);
+  for (const [field, tokens] of Object.entries(match.tokens)) {
+    if (tokens.length > 0) parts.push(`${field}(${tokens.join(',')})`);
+  }
+  return parts.join('; ');
+}
+
+function publicMatch(match) {
+  const { rank: _rank, ...rest } = match;
+  return rest;
+}
+
+function resolveEntry(entries, id) {
+  const normalized = String(id || '').replace(/^\.?\//, '').replace(/\.md$/i, '');
+  const matches = entries.filter((entry) => (
+    entry.id === normalized
+    || entry.id.endsWith(`/${normalized}`)
+    || entry.path === normalized
+    || entry.path.replace(/\.md$/i, '') === normalized
+  ));
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    throw new Error(`ambiguous skill "${id}": ${matches.map((entry) => entry.id).join(', ')}`);
+  }
+  throw new Error(`skill not found: ${id}`);
+}
+
+function parseUserTarget(rawName, opts) {
+  const raw = String(rawName || '').trim().replace(/^user\//, '');
+  if (!raw) throw new Error('create requires a skill name');
+  const rawParts = raw.split('/').filter(Boolean);
+  const slug = rawParts.pop();
+  const categoryParts = opts.category
+    ? String(opts.category).split('/').filter(Boolean)
+    : (rawParts.length > 0 ? rawParts : ['general']);
+  requireSafeParts(categoryParts, 'category');
+  requireSafeParts([slug], 'name');
+  return { categoryParts, slug };
+}
+
+function readBody(opts) {
+  if (typeof opts.body === 'string') return opts.body;
+  if (typeof opts.fromFile === 'string') return fs.readFileSync(opts.fromFile, 'utf-8');
+  if (process.stdin.isTTY) throw new Error('create requires --body, --from-file, or stdin content');
+  return fs.readFileSync(0, 'utf-8');
+}
+
+function composeSkill(slug, description, body) {
+  const trimmed = String(body || '').trim();
+  if (trimmed.startsWith('---')) return `${trimmed}\n`;
+  const title = titleize(slug);
+  return [
+    '---',
+    `name: ${title}`,
+    `description: ${description || title}`,
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    trimmed || 'Describe when to use this skill and the steps to follow.',
+    '',
+  ].join('\n');
+}
+
+function assertInside(parent, child) {
+  const rel = path.relative(parent, child);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error('target path must stay inside the selected skill directory');
+  }
+}
+
+function removeEmptyParents(start, stop) {
+  let current = start;
+  const stopResolved = path.resolve(stop);
+  while (path.resolve(current) !== stopResolved) {
+    if (!fs.existsSync(current) || fs.readdirSync(current).length > 0) return;
+    fs.rmdirSync(current);
+    current = path.dirname(current);
+  }
+}
+
+function validateEntry(entry) {
+  const { data } = parseFrontmatter(entry.content);
+  const errors = [];
+  const warnings = [];
+  if (!entry.title.trim()) errors.push('missing title');
+  if (!entry.description.trim() && !String(data.description || '').trim()) errors.push('missing description');
+  if (entry.bytes > 100_000) warnings.push('skill is large; move examples/templates/scripts into support files');
+  if (!/(^|\n)#{1,3}\s+/m.test(entry.content)) warnings.push('no markdown section headings found');
+  if (!/(when|use|run|step|verify|check|done|success)/i.test(entry.content)) {
+    warnings.push('skill has few action or verification cues');
+  }
+  if (/\bTODO\b/i.test(entry.content)) warnings.push('contains TODO markers');
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function commandResult(root, opts) {
+  const [command, ...positionals] = opts._;
+  if (!command || command === 'help' || command === '--help') {
+    return {
+      command: 'help',
+      usage: [
+        'agent-skill list [--json]',
+        'agent-skill search <query> [--json] [--limit N]',
+        'agent-skill view <id> [--json]',
+        'agent-skill validate <id> [--json]',
+        'agent-skill create <name> [--category name] [--description text] [--body text|--from-file file] [--json]',
+        'agent-skill patch <user/id> --old text --new text [--file relative/path] [--replace-all] [--json]',
+        'agent-skill delete <user/id> [--json]',
+      ],
+    };
+  }
+
+  if (command === 'list') {
+    const entries = loadIndex(root).map(publicEntry);
+    return { command, count: entries.length, entries };
+  }
+
+  if (command === 'search') {
+    const query = positionals.join(' ').trim();
+    if (!query) throw new Error('search requires a query');
+    const entries = loadIndex(root)
+      .map((entry) => ({ entry, match: matchEntry(entry, query) }))
+      .filter((item) => item.match)
+      .sort((a, b) => compareMatch(a.match, b.match) || a.entry.id.localeCompare(b.entry.id))
+      .slice(0, opts.limit)
+      .map((item) => ({ ...publicEntry(item.entry), match: publicMatch(item.match) }));
+    return { command, query, count: entries.length, entries };
+  }
+
+  if (command === 'view') {
+    const entry = resolveEntry(loadIndex(root), positionals[0]);
+    return { command, entry: publicEntry(entry), content: entry.content };
+  }
+
+  if (command === 'validate') {
+    const entry = resolveEntry(loadIndex(root), positionals[0]);
+    return { command, entry: publicEntry(entry), ...validateEntry(entry) };
+  }
+
+  if (command === 'create') {
+    const { categoryParts, slug } = parseUserTarget(positionals[0], opts);
+    const description = String(opts.description || '').trim();
+    if (!description) throw new Error('create requires --description');
+    const body = readBody(opts);
+    const skillDir = path.join(root, 'skills', ...categoryParts, slug);
+    const skillPath = path.join(skillDir, 'SKILL.md');
+    const existed = fs.existsSync(skillPath);
+    if (existed && !opts.force) throw new Error(`skill already exists: user/${[...categoryParts, slug].join('/')}`);
+    fs.mkdirSync(skillDir, { recursive: true });
+    const content = composeSkill(slug, description, body);
+    fs.writeFileSync(skillPath, content, 'utf-8');
+    const entry = skillSummary(skillPath, root, 'user', `user/${[...categoryParts, slug].join('/')}`);
+    return { command, action: existed ? 'write' : 'create', entry: publicEntry(entry), validation: validateEntry(entry) };
+  }
+
+  if (command === 'patch') {
+    const entry = resolveEntry(loadIndex(root), positionals[0]);
+    if (entry.source !== 'user') throw new Error('only user skills under ./skills/ can be patched');
+    const oldText = String(opts.old ?? '');
+    const newText = String(opts.new ?? '');
+    if (!oldText) throw new Error('patch requires --old');
+    const skillRoot = path.dirname(path.join(root, entry.path));
+    const relFile = typeof opts.file === 'string' ? opts.file : 'SKILL.md';
+    const target = path.resolve(skillRoot, relFile);
+    assertInside(skillRoot, target);
+    const before = fs.readFileSync(target, 'utf-8');
+    const count = before.split(oldText).length - 1;
+    if (count === 0) throw new Error('patch text was not found');
+    if (count > 1 && !opts.replaceAll) throw new Error('patch text matched more than once; pass --replace-all to replace all matches');
+    const after = opts.replaceAll ? before.split(oldText).join(newText) : before.replace(oldText, newText);
+    fs.writeFileSync(target, after, 'utf-8');
+    const updated = resolveEntry(loadIndex(root), entry.id);
+    return { command, action: 'patch', replacements: opts.replaceAll ? count : 1, entry: publicEntry(updated), validation: validateEntry(updated) };
+  }
+
+  if (command === 'delete') {
+    const entry = resolveEntry(loadIndex(root), positionals[0]);
+    if (entry.source !== 'user') throw new Error('only user skills under ./skills/ can be deleted');
+    const userRoot = path.join(root, 'skills');
+    const skillDir = path.dirname(path.join(root, entry.path));
+    assertInside(userRoot, skillDir);
+    fs.rmSync(skillDir, { recursive: true, force: true });
+    removeEmptyParents(path.dirname(skillDir), userRoot);
+    return { command, action: 'delete', entry: publicEntry(entry) };
+  }
+
+  throw new Error(`unknown command: ${command}`);
+}
+
+function printText(result) {
+  if (result.command === 'help') {
+    console.log(result.usage.join('\n'));
+  } else if (result.command === 'list' || result.command === 'search') {
+    for (const entry of result.entries) {
+      const matched = entry.match ? `\n  matched: ${matchSummary(entry.match)}` : '';
+      console.log(`${entry.id}${matched}\n  ${entry.description || entry.title}\n  ${entry.path}`);
+    }
+  } else if (result.command === 'view') {
+    console.log(result.content);
+  } else if (result.command === 'validate') {
+    console.log(`${result.ok ? 'ok' : 'failed'} ${result.entry.id}`);
+    for (const error of result.errors) console.log(`error: ${error}`);
+    for (const warning of result.warnings) console.log(`warning: ${warning}`);
+  } else if (result.entry) {
+    console.log(`${result.action || result.command} ${result.entry.id}`);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const root = path.resolve(String(opts.root || process.cwd()));
+  try {
+    const result = commandResult(root, opts);
+    const payload = { success: true, elapsed_ms: elapsedMs(), root, ...result };
+    if (opts.json) console.log(JSON.stringify(payload, null, 2));
+    else printText(payload);
+  } catch (err) {
+    const payload = { success: false, elapsed_ms: elapsedMs(), root, error: err.message };
+    if (opts.json) console.error(JSON.stringify(payload, null, 2));
+    else console.error(`agent-skill: ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/app/src/main/hl/stock/agent-skill/agent-skill.cmd
+++ b/app/src/main/hl/stock/agent-skill/agent-skill.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0agent-skill" %*

--- a/app/src/main/hl/streamToTerm.ts
+++ b/app/src/main/hl/streamToTerm.ts
@@ -68,7 +68,7 @@ export interface TermTranslatorState {
    *  the first user_input so the initial prompt doesn't start on a blank
    *  row. */
   hasEmitted: boolean;
-  /** When the most recent tool_call targeted a domain-skills file, we
+  /** When the most recent tool_call targeted a skill file/command, we
    *  suppressed its row in favor of the synthetic skill_used / skill_written
    *  event. Stash the tool name so we can also suppress the matching
    *  tool_result row that follows. */
@@ -79,11 +79,13 @@ export function createTermTranslatorState(): TermTranslatorState {
   return { inThinking: false, hasEmitted: false, pendingSkillToolName: null };
 }
 
-const SKILL_PATH_RE = /(?:domain-skills|interaction-skills)\/[^/]+\/[^/]+\.md$/;
+const SKILL_PATH_RE = /(?:domain-skills|interaction-skills)\/.+\.md$|skills\/.+\/SKILL\.md$/;
+const AGENT_SKILL_RE = /\bagent-skill(?:\.cmd)?\s+(view|validate|create|patch|delete)\s+/;
 
 function extractSkillPath(args: unknown): string | null {
   if (!args || typeof args !== 'object') return null;
   const a = args as Record<string, unknown>;
+  if (typeof a.command === 'string' && AGENT_SKILL_RE.test(a.command)) return a.command;
   const candidates = [a.file_path, a.path, a.target_file];
   for (const c of candidates) {
     if (typeof c === 'string' && SKILL_PATH_RE.test(c)) return c;
@@ -183,7 +185,7 @@ export function hlEventToTermBytes(event: HlEvent, state: TermTranslatorState): 
     }
 
     case 'skill_written': {
-      const verb = event.action === 'patch' ? 'Edited skill' : 'Wrote skill';
+      const verb = event.action === 'delete' ? 'Deleted skill' : event.action === 'patch' ? 'Edited skill' : 'Wrote skill';
       out.push(`${FG.magenta}★ ${verb} ${event.domain}/${event.topic}${RESET}\r\n`);
       return finish();
     }

--- a/app/src/main/hl/streamToTerm.ts
+++ b/app/src/main/hl/streamToTerm.ts
@@ -80,12 +80,19 @@ export function createTermTranslatorState(): TermTranslatorState {
 }
 
 const SKILL_PATH_RE = /(?:domain-skills|interaction-skills)\/.+\.md$|skills\/.+\/SKILL\.md$/;
-const AGENT_SKILL_RE = /\bagent-skill(?:\.cmd)?\s+(view|validate|create|patch|delete)\s+/;
+const AGENT_SKILL_TARGET_RE = /\bagent-skill(?:\.cmd)?\s+(view|validate|create|patch|delete)\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/;
+
+function hasSyntheticAgentSkillEvent(command: string): boolean {
+  const match = command.match(AGENT_SKILL_TARGET_RE);
+  if (!match) return false;
+  const target = (match[2] ?? match[3] ?? match[4] ?? '').replace(/['"]+$/g, '');
+  return Boolean(target && !target.startsWith('--'));
+}
 
 function extractSkillPath(args: unknown): string | null {
   if (!args || typeof args !== 'object') return null;
   const a = args as Record<string, unknown>;
-  if (typeof a.command === 'string' && AGENT_SKILL_RE.test(a.command)) return a.command;
+  if (typeof a.command === 'string' && hasSyntheticAgentSkillEvent(a.command)) return a.command;
   const candidates = [a.file_path, a.path, a.target_file];
   for (const c of candidates) {
     if (typeof c === 'string' && SKILL_PATH_RE.test(c)) return c;

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -28,6 +28,17 @@ if (process.platform === 'linux') {
 
 app.setName('Browser Use');
 
+// ---------------------------------------------------------------------------
+// Isolated userData override.
+// Precedence: --user-data-dir CLI flag > AGB_USER_DATA_DIR env > platform default.
+// MUST be applied before crash reporting, single-instance lock, or any
+// app.getPath('userData') call. Electron's lock is scoped through userData.
+// ---------------------------------------------------------------------------
+const resolvedUserData = resolveUserDataDir(process.argv, process.env);
+if (resolvedUserData.value) {
+  app.setPath('userData', resolvedUserData.value);
+}
+
 // Native-crash minidumps → userData/Crashpad/. Captures GPU process,
 // renderer process, and main-process native crashes that our
 // uncaughtException handlers (JS-only) miss. Local-only — no upload
@@ -139,16 +150,6 @@ process.on('unhandledRejection', (reason, promise) => {
     promise: String(promise),
   });
 });
-
-// ---------------------------------------------------------------------------
-// Isolated userData override.
-// Precedence: --user-data-dir CLI flag > AGB_USER_DATA_DIR env > platform default.
-// MUST be applied before any app.getPath('userData') call.
-// ---------------------------------------------------------------------------
-const resolvedUserData = resolveUserDataDir(process.argv, process.env);
-if (resolvedUserData.value) {
-  app.setPath('userData', resolvedUserData.value);
-}
 
 // ---------------------------------------------------------------------------
 // Remote debugging port — MUST be called before app.whenReady()

--- a/app/src/renderer/hub/AgentPane.tsx
+++ b/app/src/renderer/hub/AgentPane.tsx
@@ -357,7 +357,7 @@ function OutputRow({ entry }: { entry: OutputEntry }): React.ReactElement {
   }
 
   if (entry.type === 'skill_written') {
-    const label = entry.harnessAction === 'patch' ? 'Edited skill' : 'Wrote skill';
+    const label = entry.harnessAction === 'delete' ? 'Deleted skill' : entry.harnessAction === 'patch' ? 'Edited skill' : 'Wrote skill';
     return (
       <div className="step step--skill">
         <span className="step__icon">

--- a/app/src/renderer/hub/types.ts
+++ b/app/src/renderer/hub/types.ts
@@ -7,7 +7,7 @@ export type HlEvent =
   | { type: 'done';        summary: string; iterations: number }
   | { type: 'error';       message: string }
   | { type: 'user_input';  text: string }
-  | { type: 'skill_written'; path: string; domain: string; topic: string; bytes: number; action: 'write' | 'patch' }
+  | { type: 'skill_written'; path: string; domain: string; topic: string; bytes: number; action: 'write' | 'patch' | 'delete' }
   | { type: 'skill_used'; path: string; domain?: string; topic: string }
   | { type: 'harness_edited'; target: 'helpers' | 'tools'; action: 'write' | 'patch'; path: string; added?: string[]; removed?: string[]; changed?: string[] }
   | { type: 'file_output'; name: string; path: string; size: number; mime: string }
@@ -57,7 +57,7 @@ export interface OutputEntry {
   groupEntries?: OutputEntry[];
   // harness_edited metadata
   harnessTarget?: 'helpers' | 'tools';
-  harnessAction?: 'write' | 'patch';
+  harnessAction?: 'write' | 'patch' | 'delete';
   added?: string[];
   removed?: string[];
   changed?: string[];

--- a/app/src/shared/session-schemas.ts
+++ b/app/src/shared/session-schemas.ts
@@ -53,7 +53,7 @@ export const HlEventSkillWrittenSchema = z.object({
   domain: z.string(),
   topic: z.string(),
   bytes: z.number(),
-  action: z.enum(['write', 'patch']),
+  action: z.enum(['write', 'patch', 'delete']),
 });
 
 export const HlEventNotifySchema = z.object({

--- a/app/tests/unit/hl/agentSkillCli.test.ts
+++ b/app/tests/unit/hl/agentSkillCli.test.ts
@@ -100,4 +100,25 @@ describe('agent-skill CLI', () => {
     expect(parsed.success).toBe(false);
     expect(parsed.error).toContain('only user skills');
   });
+
+  it('rejects patch files that resolve outside the selected skill directory through symlinks', () => {
+    const body = 'Use when a recurring workflow needs local notes.\n';
+    json(['create', 'workflow/crm-triage', '--description', 'Reusable CRM triage workflow'], body);
+
+    const outside = path.join(root, 'outside.md');
+    fs.writeFileSync(outside, 'outside secret\n', 'utf-8');
+    const link = path.join(root, 'skills', 'workflow', 'crm-triage', 'notes.md');
+    try {
+      fs.symlinkSync(outside, link);
+    } catch {
+      return;
+    }
+
+    const { result, parsed } = json(['patch', 'user/workflow/crm-triage', '--file', 'notes.md', '--old', 'outside', '--new', 'inside']);
+
+    expect(result.status).toBe(1);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('target path must stay inside');
+    expect(fs.readFileSync(outside, 'utf-8')).toBe('outside secret\n');
+  });
 });

--- a/app/tests/unit/hl/agentSkillCli.test.ts
+++ b/app/tests/unit/hl/agentSkillCli.test.ts
@@ -1,0 +1,103 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const cli = path.resolve(__dirname, '../../../src/main/hl/stock/agent-skill/agent-skill');
+
+let root: string;
+
+function runAgentSkill(args: string[], input?: string) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    input,
+    encoding: 'utf-8',
+  });
+}
+
+function json(args: string[], input?: string) {
+  const result = runAgentSkill([...args, '--json'], input);
+  const output = result.status === 0 ? result.stdout : result.stderr;
+  return { result, parsed: JSON.parse(output) as Record<string, unknown> };
+}
+
+describe('agent-skill CLI', () => {
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-skill-cli-'));
+    fs.mkdirSync(path.join(root, 'domain-skills', 'linkedin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'domain-skills', 'linkedin', 'invitation-manager.md'),
+      '# LinkedIn Invitation Manager\n\nUse when accepting, ignoring, or searching LinkedIn invitations.\n',
+      'utf-8',
+    );
+    fs.mkdirSync(path.join(root, 'interaction-skills'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'interaction-skills', 'screenshots.md'),
+      '# Screenshots\n\nUse Page.captureScreenshot and verify the saved PNG exists.\n',
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('searches stock skills without returning full skill content', () => {
+    const { parsed } = json(['search', 'linkedin invitations']);
+    const entries = parsed.entries as Array<Record<string, unknown>>;
+
+    expect(entries[0].id).toBe('domain/linkedin/invitation-manager');
+    expect(entries[0].content).toBeUndefined();
+    expect(typeof parsed.elapsed_ms).toBe('number');
+  });
+
+  it('creates, views, validates, patches, and deletes user skills', () => {
+    const body = [
+      'Use when a recurring CRM triage workflow needs the same checks.',
+      '',
+      '1. Search the queue.',
+      '2. Verify the account status.',
+      '3. Report done when the queue is empty.',
+    ].join('\n');
+    const created = json(['create', 'workflow/crm-triage', '--description', 'Reusable CRM triage workflow'], body);
+    expect(created.parsed.success).toBe(true);
+    expect((created.parsed.entry as Record<string, unknown>).id).toBe('user/workflow/crm-triage');
+
+    const viewed = json(['view', 'user/workflow/crm-triage']);
+    expect(viewed.parsed.content).toContain('CRM triage');
+
+    const validated = json(['validate', 'user/workflow/crm-triage']);
+    expect(validated.parsed.ok).toBe(true);
+
+    const patched = json(['patch', 'user/workflow/crm-triage', '--old', 'queue is empty', '--new', 'queue is reconciled']);
+    expect(patched.parsed.success).toBe(true);
+
+    const after = json(['view', 'user/workflow/crm-triage']);
+    expect(after.parsed.content).toContain('queue is reconciled');
+
+    const deleted = json(['delete', 'user/workflow/crm-triage']);
+    expect(deleted.parsed.success).toBe(true);
+    expect((deleted.parsed.entry as Record<string, unknown>).id).toBe('user/workflow/crm-triage');
+
+    const missing = json(['view', 'user/workflow/crm-triage']);
+    expect(missing.result.status).toBe(1);
+    expect(missing.parsed.error).toContain('skill not found');
+  });
+
+  it('rejects patching read-only stock skills', () => {
+    const { result, parsed } = json(['patch', 'interaction/screenshots', '--old', 'capture', '--new', 'snap']);
+
+    expect(result.status).toBe(1);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('only user skills');
+  });
+
+  it('rejects deleting read-only stock skills', () => {
+    const { result, parsed } = json(['delete', 'interaction/screenshots']);
+
+    expect(result.status).toBe(1);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('only user skills');
+  });
+});

--- a/app/tests/unit/hl/browserHarnessEnv.test.ts
+++ b/app/tests/unit/hl/browserHarnessEnv.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { applyBrowserHarnessEnv, browserHarnessReplPort } from '../../../src/main/hl/engines/browserHarnessEnv';
 import type { SpawnContext } from '../../../src/main/hl/engines/types';
@@ -35,5 +36,15 @@ describe('browser harness environment', () => {
     const env = applyBrowserHarnessEnv(spawnContext('target-a'), { CDP_REPL_PORT: '9876' });
 
     expect(env.CDP_REPL_PORT).toBe('9876');
+  });
+
+  it('puts provider-neutral agent-skill and Browser Harness JS CLIs on PATH', () => {
+    const env = applyBrowserHarnessEnv(spawnContext('target-a'), { PATH: '/usr/bin' });
+
+    expect(env.PATH?.split(path.delimiter).slice(0, 3)).toEqual([
+      '/tmp/harness/agent-skill',
+      '/tmp/harness/browser-harness-js/sdk',
+      '/usr/bin',
+    ]);
   });
 });

--- a/app/tests/unit/hl/browsercodeAdapter.test.ts
+++ b/app/tests/unit/hl/browsercodeAdapter.test.ts
@@ -136,6 +136,45 @@ describe('browsercode adapter tool parsing', () => {
     expect(ctx.pendingTools.size).toBe(0);
   });
 
+  it('keeps command metadata when BrowserCode reports input only on the terminal event', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-05T12:00:00.000Z'));
+
+    const adapter = browserCodeAdapter();
+    const ctx = parseContext();
+
+    adapter.parseLine(JSON.stringify({ type: 'step_start' }), ctx);
+    const finished = adapter.parseLine(JSON.stringify({
+      type: 'tool_use',
+      part: {
+        id: 'tool-terminal-with-input',
+        tool: 'Bash',
+        input: { command: 'agent-skill view domain/github/scraping' },
+        state: { status: 'completed', output: '# GitHub' },
+      },
+    }), ctx);
+
+    expect(finished.events).toEqual([
+      {
+        type: 'tool_call',
+        name: 'Bash',
+        args: {
+          preview: 'agent-skill view domain/github/scraping',
+          command: 'agent-skill view domain/github/scraping',
+        },
+        iteration: 1,
+      },
+      {
+        type: 'tool_result',
+        name: 'Bash',
+        ok: true,
+        preview: '# GitHub',
+        ms: 0,
+      },
+    ]);
+    expect(ctx.pendingTools.size).toBe(0);
+  });
+
   it('marks cancelled terminal tool events as unsuccessful', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-05T12:00:00.000Z'));

--- a/app/tests/unit/hl/browsercodeAdapter.test.ts
+++ b/app/tests/unit/hl/browsercodeAdapter.test.ts
@@ -60,6 +60,14 @@ describe('browsercode adapter stdin payload mode', () => {
     expect(args).not.toContain(wrappedPrompt);
     expect(adapter.getStdinPayload?.(ctx, wrappedPrompt)).toBe(wrappedPrompt);
   });
+
+  it('injects skill lifecycle guidance into the provider prompt', () => {
+    const adapter = browserCodeAdapter();
+    const wrappedPrompt = adapter.wrapPrompt(spawnContext());
+
+    expect(wrappedPrompt).toContain('likely to repeat, long-running enough to justify reuse, or generally applicable');
+    expect(wrappedPrompt).toContain('Do not write skills for one-off facts/calculations');
+  });
 });
 
 describe('browsercode adapter tool parsing', () => {

--- a/app/tests/unit/hl/claudeCodeAdapter.test.ts
+++ b/app/tests/unit/hl/claudeCodeAdapter.test.ts
@@ -82,4 +82,12 @@ describe('claude-code adapter spawn args', () => {
       wrappedPrompt,
     ]);
   });
+
+  it('injects skill lifecycle guidance into the provider prompt', async () => {
+    const adapter = await claudeCodeAdapter();
+    const wrappedPrompt = adapter.wrapPrompt(spawnContext());
+
+    expect(wrappedPrompt).toContain('likely to repeat, long-running enough to justify reuse, or generally applicable');
+    expect(wrappedPrompt).toContain('Do not write skills for one-off facts/calculations');
+  });
 });

--- a/app/tests/unit/hl/codexAdapter.test.ts
+++ b/app/tests/unit/hl/codexAdapter.test.ts
@@ -85,4 +85,12 @@ describe('codex adapter spawn args', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it('injects skill lifecycle guidance into the provider prompt', () => {
+    const adapter = codexAdapter();
+    const wrappedPrompt = adapter.wrapPrompt(spawnContext());
+
+    expect(wrappedPrompt).toContain('likely to repeat, long-running enough to justify reuse, or generally applicable');
+    expect(wrappedPrompt).toContain('Do not write skills for one-off facts/calculations');
+  });
 });

--- a/app/tests/unit/hl/codexAdapter.test.ts
+++ b/app/tests/unit/hl/codexAdapter.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { EngineAdapter, SpawnContext } from '../../../src/main/hl/engines/types';
 
 const { get } = await import('../../../src/main/hl/engines/registry');
@@ -10,10 +13,10 @@ function codexAdapter(): EngineAdapter {
   return adapter;
 }
 
-function spawnContext(resumeSessionId?: string): SpawnContext {
+function spawnContext(resumeSessionId?: string, harnessDir = '/tmp/harness'): SpawnContext {
   return {
     prompt: 'Open the docs and summarize the page.',
-    harnessDir: '/tmp/harness',
+    harnessDir,
     sessionId: 'session-123',
     targetId: 'target-123',
     cdpPort: 9222,
@@ -51,5 +54,35 @@ describe('codex adapter spawn args', () => {
       '-',
     ]);
     expect(adapter.getStdinPayload?.(ctx, wrappedPrompt)).toBe(wrappedPrompt);
+  });
+
+  it('injects a compact skill index into the provider prompt', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-skill-index-'));
+    try {
+      fs.mkdirSync(path.join(tmp, 'skills', 'workflow', 'crm-triage'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmp, 'skills', 'workflow', 'crm-triage', 'SKILL.md'),
+        [
+          '---',
+          'name: CRM Triage',
+          'description: Reusable CRM queue triage workflow',
+          '---',
+          '',
+          '# CRM Triage',
+          '',
+          'Full internal instructions stay out of the prompt index.',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      const adapter = codexAdapter();
+      const wrappedPrompt = adapter.wrapPrompt(spawnContext(undefined, tmp));
+
+      expect(wrappedPrompt).toContain('## Available Skills');
+      expect(wrappedPrompt).toContain('user/workflow/crm-triage: CRM Triage - Reusable CRM queue triage workflow');
+      expect(wrappedPrompt).not.toContain('Full internal instructions');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/app/tests/unit/hl/harnessBootstrap.test.ts
+++ b/app/tests/unit/hl/harnessBootstrap.test.ts
@@ -18,12 +18,14 @@ vi.mock('electron', () => ({
 }));
 
 const {
+  agentSkillDir,
   bootstrapHarness,
   browserHarnessJsDir,
   helpersPath,
   interactionSkillsDir,
   skillPath,
   toolsPath,
+  userSkillsDir,
 } = await import('../../../src/main/hl/harness');
 
 describe('bootstrapHarness browser-harness-js materialization', () => {
@@ -43,10 +45,20 @@ describe('bootstrapHarness browser-harness-js materialization', () => {
 
     const cli = path.join(browserHarnessJsDir(), 'sdk', 'browser-harness-js');
     const cliCmd = path.join(browserHarnessJsDir(), 'sdk', 'browser-harness-js.cmd');
+    const agentSkill = path.join(agentSkillDir(), 'agent-skill');
+    const userSkill = path.join(userSkillsDir(), 'general', 'existing', 'SKILL.md');
+    fs.mkdirSync(path.dirname(userSkill), { recursive: true });
+    fs.writeFileSync(userSkill, '# Existing\n');
+
+    bootstrapHarness();
+
     expect(fs.existsSync(helpersPath())).toBe(true);
     expect(fs.readFileSync(skillPath(), 'utf-8')).toContain('Browser Harness JS');
     expect(fs.existsSync(toolsPath())).toBe(false);
     expect(fs.existsSync(cli)).toBe(true);
+    expect(fs.existsSync(agentSkill)).toBe(true);
+    expect(fs.existsSync(path.join(agentSkillDir(), 'agent-skill.cmd'))).toBe(true);
+    expect(fs.existsSync(userSkill)).toBe(true);
     // Windows launcher ships alongside the bash script so Codex can find it
     // via PATHEXT (.CMD) instead of hitting the no-handler popup on the
     // extensionless bash file.
@@ -57,6 +69,7 @@ describe('bootstrapHarness browser-harness-js materialization', () => {
     // mapping doesn't expose POSIX exec bits the way the test asserts.
     if (process.platform !== 'win32') {
       expect(fs.statSync(cli).mode & 0o111).not.toBe(0);
+      expect(fs.statSync(agentSkill).mode & 0o111).not.toBe(0);
     }
   });
 });

--- a/app/tests/unit/hl/runEngineHarnessWatcher.test.ts
+++ b/app/tests/unit/hl/runEngineHarnessWatcher.test.ts
@@ -170,6 +170,122 @@ describe('runEngine harness watcher', () => {
     expect(events.some((event) => event.type === 'harness_edited')).toBe(false);
   });
 
+  test('emits skill events from provider-neutral agent-skill commands', async () => {
+    const script = [
+      "console.log(JSON.stringify({ type: 'view' }));",
+      "console.log(JSON.stringify({ type: 'shellView' }));",
+      "console.log(JSON.stringify({ type: 'create' }));",
+      "console.log(JSON.stringify({ type: 'delete' }));",
+      "console.log(JSON.stringify({ type: 'done' }));",
+    ].join('\n');
+    const engineId = registerFakeEngine(script, (line) => {
+      const event = JSON.parse(line) as { type?: string };
+      if (event.type === 'view') {
+        return {
+          events: [{
+            type: 'tool_call',
+            name: 'Bash',
+            args: { command: 'agent-skill view domain/linkedin/invitation-manager --json' },
+            iteration: 1,
+          }],
+        };
+      }
+      if (event.type === 'shellView') {
+        return {
+          events: [{
+            type: 'tool_call',
+            name: 'Bash',
+            args: { command: "/bin/zsh -lc 'agent-skill view interaction/screenshots'" },
+            iteration: 1,
+          }],
+        };
+      }
+      if (event.type === 'create') {
+        return {
+          events: [{
+            type: 'tool_call',
+            name: 'Bash',
+            args: { command: 'agent-skill create workflow/crm-triage --description "Reusable CRM triage" --json' },
+            iteration: 2,
+          }],
+        };
+      }
+      if (event.type === 'delete') {
+        return {
+          events: [{
+            type: 'tool_call',
+            name: 'Bash',
+            args: { command: 'agent-skill delete user/workflow/crm-triage --json' },
+            iteration: 3,
+          }],
+        };
+      }
+      if (event.type === 'done') return { events: [{ type: 'done', summary: 'ok', iterations: 1 }] };
+      return { events: [] };
+    });
+
+    const events = await runFakeEngine(engineId, harnessDir);
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_used',
+      domain: 'domain',
+      topic: 'linkedin/invitation-manager',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_used',
+      domain: 'interaction',
+      topic: 'screenshots',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_written',
+      domain: 'user',
+      topic: 'workflow/crm-triage',
+      action: 'write',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_written',
+      domain: 'user',
+      topic: 'workflow/crm-triage',
+      action: 'delete',
+    }));
+  });
+
+  test('emits a skill event from provider-neutral agent-skill search results', async () => {
+    const script = [
+      "console.log(JSON.stringify({ type: 'search' }));",
+      "console.log(JSON.stringify({ type: 'done' }));",
+    ].join('\n');
+    const engineId = registerFakeEngine(script, (line) => {
+      const event = JSON.parse(line) as { type?: string };
+      if (event.type === 'search') {
+        return {
+          events: [{
+            type: 'tool_result',
+            name: 'bash',
+            ok: true,
+            preview: [
+              'domain/github/scraping',
+              '  matched: id(github,scraping); title(github,scraping); body(github,scraping)',
+              '  `https://github.com` — public data.',
+              '  domain-skills/github/scraping.md',
+            ].join('\n'),
+            ms: 12,
+          }],
+        };
+      }
+      if (event.type === 'done') return { events: [{ type: 'done', summary: 'ok', iterations: 1 }] };
+      return { events: [] };
+    });
+
+    const events = await runFakeEngine(engineId, harnessDir);
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_used',
+      domain: 'domain',
+      topic: 'github/scraping',
+    }));
+  });
+
   test.skipIf(process.platform === 'win32')('exposes live pause and resume controls for the spawned process group', async () => {
     const script = [
       'let i = 0;',

--- a/app/tests/unit/hl/runEngineHarnessWatcher.test.ts
+++ b/app/tests/unit/hl/runEngineHarnessWatcher.test.ts
@@ -174,6 +174,7 @@ describe('runEngine harness watcher', () => {
     const script = [
       "console.log(JSON.stringify({ type: 'view' }));",
       "console.log(JSON.stringify({ type: 'shellView' }));",
+      "console.log(JSON.stringify({ type: 'userValidate' }));",
       "console.log(JSON.stringify({ type: 'create' }));",
       "console.log(JSON.stringify({ type: 'delete' }));",
       "console.log(JSON.stringify({ type: 'done' }));",
@@ -196,6 +197,16 @@ describe('runEngine harness watcher', () => {
             type: 'tool_call',
             name: 'Bash',
             args: { command: "/bin/zsh -lc 'agent-skill view interaction/screenshots'" },
+            iteration: 1,
+          }],
+        };
+      }
+      if (event.type === 'userValidate') {
+        return {
+          events: [{
+            type: 'tool_call',
+            name: 'Bash',
+            args: { command: 'agent-skill validate user/workflow/crm-triage --json' },
             iteration: 1,
           }],
         };
@@ -235,6 +246,11 @@ describe('runEngine harness watcher', () => {
       type: 'skill_used',
       domain: 'interaction',
       topic: 'screenshots',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'skill_used',
+      domain: 'user',
+      topic: 'workflow/crm-triage',
     }));
     expect(events).toContainEqual(expect.objectContaining({
       type: 'skill_written',

--- a/app/tests/unit/hl/skillIndexPrompt.test.ts
+++ b/app/tests/unit/hl/skillIndexPrompt.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildSkillIndexPrompt, scanSkillIndex } from '../../../src/main/hl/engines/skillIndexPrompt';
+
+let harnessDir: string;
+
+describe('skill index prompt', () => {
+  beforeEach(() => {
+    harnessDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-index-prompt-'));
+    fs.mkdirSync(path.join(harnessDir, 'domain-skills', 'linkedin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harnessDir, 'domain-skills', 'linkedin', 'invitation-manager.md'),
+      '# LinkedIn Invitation Manager\n\nUse when accepting, ignoring, or searching LinkedIn invitations.\n\nFull selector details should not be copied into search metadata.\n',
+      'utf-8',
+    );
+    fs.mkdirSync(path.join(harnessDir, 'interaction-skills'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harnessDir, 'interaction-skills', 'screenshots.md'),
+      '# Screenshots\n\nUse Page.captureScreenshot for visual verification.\n',
+      'utf-8',
+    );
+    fs.mkdirSync(path.join(harnessDir, 'skills', 'workflow', 'crm-triage'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harnessDir, 'skills', 'workflow', 'crm-triage', 'SKILL.md'),
+      [
+        '---',
+        'name: CRM Triage',
+        'description: Reusable CRM queue triage workflow',
+        '---',
+        '',
+        '# CRM Triage',
+        '',
+        'Long private instructions stay in the view output, not the prompt index.',
+      ].join('\n'),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  });
+
+  it('builds a compact metadata-only index with informative skill ids', () => {
+    const entries = scanSkillIndex(harnessDir);
+    const prompt = buildSkillIndexPrompt(harnessDir);
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      'user/workflow/crm-triage',
+      'interaction/screenshots',
+      'domain/linkedin/invitation-manager',
+    ]);
+    expect(prompt).toContain('## Available Skills');
+    expect(prompt).toContain('user/workflow/crm-triage: CRM Triage - Reusable CRM queue triage workflow');
+    expect(prompt).toContain('interaction/screenshots: Screenshots - Use Page.captureScreenshot for visual verification.');
+    expect(prompt).toContain('domain/linkedin/invitation-manager: LinkedIn Invitation Manager');
+    expect(prompt).not.toContain('Long private instructions');
+    expect(prompt).not.toContain('Full selector details');
+  });
+
+  it('caps prompt size and points agents back to search when truncated', () => {
+    const prompt = buildSkillIndexPrompt(harnessDir, 320);
+
+    expect(prompt.length).toBeLessThan(500);
+    expect(prompt).toContain('Index truncated');
+    expect(prompt).toContain('agent-skill search');
+  });
+});

--- a/app/tests/unit/hl/skillIndexPrompt.test.ts
+++ b/app/tests/unit/hl/skillIndexPrompt.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildSkillIndexPrompt, scanSkillIndex } from '../../../src/main/hl/engines/skillIndexPrompt';
 
 let harnessDir: string;
@@ -65,5 +65,14 @@ describe('skill index prompt', () => {
     expect(prompt.length).toBeLessThan(500);
     expect(prompt).toContain('Index truncated');
     expect(prompt).toContain('agent-skill search');
+  });
+
+  it('omits the index instead of throwing when scanning fails', () => {
+    const spy = vi.spyOn(fs, 'readdirSync').mockImplementationOnce(() => {
+      throw new Error('permission denied');
+    });
+
+    expect(buildSkillIndexPrompt(harnessDir)).toBe('');
+    spy.mockRestore();
   });
 });

--- a/app/tests/unit/hl/streamToTerm.test.ts
+++ b/app/tests/unit/hl/streamToTerm.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { createTermTranslatorState, hlEventToTermBytes } from '../../../src/main/hl/streamToTerm';
+
+describe('streamToTerm skill tool suppression', () => {
+  it('renders agent-skill flag/help calls that do not produce synthetic skill events', () => {
+    const state = createTermTranslatorState();
+
+    const toolBytes = hlEventToTermBytes({
+      type: 'tool_call',
+      name: 'Bash',
+      args: { command: 'agent-skill validate --help' },
+      iteration: 1,
+    }, state);
+    const resultBytes = hlEventToTermBytes({
+      type: 'tool_result',
+      name: 'Bash',
+      ok: true,
+      preview: 'Usage: agent-skill validate <id>',
+      ms: 3,
+    }, state);
+
+    expect(toolBytes).toContain('Bash');
+    expect(toolBytes).toContain('agent-skill validate --help');
+    expect(resultBytes).toContain('Usage: agent-skill validate');
+  });
+
+  it('still suppresses target-bearing agent-skill calls for synthetic skill rows', () => {
+    const state = createTermTranslatorState();
+
+    const toolBytes = hlEventToTermBytes({
+      type: 'tool_call',
+      name: 'Bash',
+      args: { command: 'agent-skill view domain/github/scraping --json' },
+      iteration: 1,
+    }, state);
+    const resultBytes = hlEventToTermBytes({
+      type: 'tool_result',
+      name: 'Bash',
+      ok: true,
+      preview: '# GitHub Scraping',
+      ms: 3,
+    }, state);
+    const skillBytes = hlEventToTermBytes({
+      type: 'skill_used',
+      path: 'agent-skill view domain/github/scraping --json',
+      domain: 'domain',
+      topic: 'github/scraping',
+    }, state);
+
+    expect(toolBytes).toBe('');
+    expect(resultBytes).toBe('');
+    expect(skillBytes).toContain('Read skill domain/github/scraping');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a provider-neutral `agent-skill` CLI with `list`, `search`, `view`, `validate`, `create`, `patch`, and `delete` commands.
- Injects a compact metadata-only skill index into Codex, Claude Code, and BrowserCode prompts, with full skill bodies loaded on demand through the CLI.
- Tracks `skill_used` / `skill_written` telemetry across provider runs and exposes those events in the hub stream.
- Adds a timed 10-task eval runner plus docs for the whitelabeled skill lifecycle, storage model, bloat prevention, and delete behavior.
- Fixes isolated app user-data initialization so real local-task smoke runs can launch without colliding with the user's existing app instance.

## Validation

- `npm run skills:eval` - 10/10 passed in 2146.8ms
- `npx vitest run tests/unit/hl/agentSkillCli.test.ts tests/unit/hl/runEngineHarnessWatcher.test.ts tests/unit/hl/skillIndexPrompt.test.ts` - 3 files, 12 tests passed
- `npm run typecheck` - passed
- `npm run lint` - passed with 0 errors and 100 existing warnings
- `git diff --check` - passed
- Real app-backed smoke sessions:
  - Codex `0161c75b-cf6e-4c97-9c74-f4712696ec43` used existing skills via `agent-skill view/search/validate`
  - Claude Code `04b5a1b7-72c0-4326-bbbd-196bd860fd97` created, validated, and deleted a user skill
  - BrowserCode `4266bc63-2540-4ba2-aaa6-e665d8b533e9` found an existing GitHub scraping skill and emitted `skill_used` without `skill_written`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider‑neutral agent skills with a local `agent-skill` CLI, a compact metadata‑only skill index in provider prompts, cross‑provider telemetry, and a timed evaluator that verifies “no‑write” behavior with live app sessions. Improves evaluator sqlite error reporting for clearer failures.

- **New Features**
  - `agent-skill` CLI: list/search/view/validate/create/patch/delete; on PATH across providers.
  - Provider prompts: add skill lifecycle guidance and a compact index; load full bodies with `agent-skill view`.
  - Telemetry: emit `skill_used` and `skill_written` (write/patch/delete) across Codex, Claude Code, and BrowserCode; shown in the Hub.
  - User skills persist under `./harness/skills`; domain/interaction skills remain read‑only.
  - Timed 10‑task eval: runs bounded live “no‑write” tasks via the local task server and checks `sessions.db` for `done` without `skill_written`; multi‑engine via `SKILLS_EVAL_ENGINES`.

- **Bug Fixes**
  - Skill index injection is fail‑safe: skip the index if scanning fails.
  - Terminal output: suppress only target‑bearing `agent-skill` calls; show help/flags; BrowserCode keeps command metadata when it only appears on the terminal event.
  - `agent-skill patch --file` resolves symlinks and enforces containment within the skill directory.
  - Honor `--user-data-dir`/`AGB_USER_DATA_DIR` before the single‑instance lock to isolate smoke runs from a running app.
  - Evaluator: sqlite errors are reported reliably (normalize stdout/stderr, handle spawn errors, and fall back to exit‑code messages).

<sup>Written for commit ba5ef15f1eb2fe781c233a308744c6633840c3cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



