### PR TITLE
fix(yarn): resolve stale git commit hashes blocking fresh installs

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -554,8 +554,7 @@
 
 "@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
-  integrity sha512-lBSgDMQqt7QWMuIjS8zNAq5FI5o5RVBAcJUGWGI6GgoQITJt3msAkUrHp8YHj3RTVE+h70ndqMGqURjp3IfRyQ==
+  resolved "git+https://github.com/electron/node-gyp.git#main"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -4714,7 +4713,7 @@ levn@^0.4.1:
 
 "libsignal@git+https://github.com/whiskeysockets/libsignal-node":
   version "2.0.1"
-  resolved "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67"
+  resolved "git+https://github.com/whiskeysockets/libsignal-node.git#master"
   dependencies:
     curve25519-js "^0.0.4"
     protobufjs "6.8.8"


### PR DESCRIPTION
## Problem

`yarn install` fails on a fresh clone with:

```
error Couldn't find match for "1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67" in "refs/heads/..." for "ssh://git@github.com/whiskeysockets/libsignal-node.git"
```

Two entries in `app/yarn.lock` were resolved to specific commit SHAs that no longer exist on any branch of their respective repos (`whiskeysockets/libsignal-node` and `electron/node-gyp`). This breaks `yarn install` for anyone on a fresh clone without those exact SHAs already in their local git object store.

## Fix

Replace the stale SHA pins with branch-head references (`master` / `main`) so Yarn can resolve them cleanly.

## Test plan

- [ ] `yarn install` completes without error on a fresh clone
- [ ] `task up` starts the app normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes yarn install failures on fresh clones by updating git dependency resolutions in `app/yarn.lock`. Replaces stale commit SHAs for `libsignal` and `@electron/node-gyp` with branch heads so installs resolve cleanly.

- **Dependencies**
  - `@electron/node-gyp`: switch to `https` and `#main` instead of a deleted SHA.
  - `libsignal`: switch to `https` and `#master` instead of a deleted SHA.

<sup>Written for commit 83f2cfc814303dd205839482b5e073d4b5e9e2ec. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/desktop/pull/433?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

