### PR TITLE
Make embedded sessions identify as Firefox from startup

### DIFF
--- a/app/src/main/chrome-import/cookies.ts
+++ b/app/src/main/chrome-import/cookies.ts
@@ -133,7 +133,7 @@ export interface CookieImportResult {
   updatedDomains: string[];
 }
 
-interface CdpCookie {
+export interface CdpCookie {
   name: string;
   value: string;
   domain: string;
@@ -153,6 +153,41 @@ function cdpSameSiteToElectron(value?: string): 'unspecified' | 'no_restriction'
     case 'None': return 'no_restriction';
     default: return 'unspecified';
   }
+}
+
+function normalizedCookieDomain(domain: string): string {
+  return domain.startsWith('.') ? domain.substring(1) : domain;
+}
+
+function cookiePath(pathValue: string): string {
+  if (!pathValue) return '/';
+  return pathValue.startsWith('/') ? pathValue : `/${pathValue}`;
+}
+
+export function electronCookieDetailsForImport(cookie: CdpCookie): Electron.CookiesSetDetails | null {
+  if (!cookie.name) return null;
+
+  const domain = normalizedCookieDomain(cookie.domain);
+  if (!domain) return null;
+
+  const pathValue = cookiePath(cookie.path);
+  const scheme = cookie.secure ? 'https' : 'http';
+  const details: Electron.CookiesSetDetails = {
+    url: `${scheme}://${domain}${pathValue}`,
+    name: cookie.name,
+    value: cookie.value,
+    path: pathValue,
+    secure: cookie.secure,
+    httpOnly: cookie.httpOnly,
+    sameSite: cdpSameSiteToElectron(cookie.sameSite),
+    ...(cookie.session ? {} : { expirationDate: cookie.expires }),
+  };
+
+  if (cookie.domain.startsWith('.')) {
+    details.domain = cookie.domain;
+  }
+
+  return details;
 }
 
 async function copyProfileToTemp(profilePath: string, userDataDir: string): Promise<string> {
@@ -362,7 +397,7 @@ export async function importChromeProfileCookies(profileId: string): Promise<Coo
   // itself during a session) are preserved.
   const targetDomains = new Set<string>();
   for (const c of cookies) {
-    const d = c.domain.startsWith('.') ? c.domain.substring(1) : c.domain;
+    const d = normalizedCookieDomain(c.domain);
     if (d) targetDomains.add(d);
   }
 
@@ -416,27 +451,16 @@ export async function importChromeProfileCookies(profileId: string): Promise<Coo
   let unchangedCookies = 0;
 
   for (const cookie of cookies) {
-    if (!cookie.value || !cookie.name) {
+    const details = electronCookieDetailsForImport(cookie);
+    if (!details) {
       skipped++;
       continue;
     }
 
-    const domain = cookie.domain.startsWith('.') ? cookie.domain.substring(1) : cookie.domain;
-    const scheme = cookie.secure ? 'https' : 'http';
-    const url = `${scheme}://${domain}${cookie.path}`;
+    const domain = normalizedCookieDomain(cookie.domain);
 
     try {
-      await electronSession.cookies.set({
-        url,
-        name: cookie.name,
-        value: cookie.value,
-        domain: cookie.domain,
-        path: cookie.path,
-        secure: cookie.secure,
-        httpOnly: cookie.httpOnly,
-        sameSite: cdpSameSiteToElectron(cookie.sameSite),
-        ...(cookie.session ? {} : { expirationDate: cookie.expires }),
-      });
+      await electronSession.cookies.set(details);
       imported++;
       importedDomains.add(domain);
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -16,14 +16,36 @@ import path from 'node:path';
 // dev-time fallback.
 loadDotEnv({ path: path.resolve(__dirname, '..', '..', '.env') });
 
-import { app, BrowserWindow, crashReporter, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell } from 'electron';
+import { app, BrowserWindow, crashReporter, globalShortcut, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, session, shell } from 'electron';
 import { mergeChromiumFeature } from './startup/chromiumFeatures';
+import {
+  buildBrowserIdentity,
+  withBrowserIdentityHeaders,
+} from './sessions/browserIdentity';
+
+const appBrowserIdentity = buildBrowserIdentity();
+const FIREFOX_COMPAT_DISABLED_CHROMIUM_FEATURES = [
+  'UserAgentClientHint',
+] as const;
+const BROWSER_COMPAT_ENABLED_CHROMIUM_FEATURES = [
+  'WebShare',
+] as const;
+
+function appendChromiumFeatures(switchName: string, features: readonly string[]): void {
+  const next = features.reduce(
+    (current, feature) => mergeChromiumFeature(current, feature),
+    app.commandLine.getSwitchValue(switchName),
+  );
+  app.commandLine.appendSwitch(switchName, next);
+}
+
+app.userAgentFallback = appBrowserIdentity.userAgent;
+appendChromiumFeatures('disable-blink-features', ['AutomationControlled']);
+appendChromiumFeatures('disable-features', FIREFOX_COMPAT_DISABLED_CHROMIUM_FEATURES);
+appendChromiumFeatures('enable-features', BROWSER_COMPAT_ENABLED_CHROMIUM_FEATURES);
 
 if (process.platform === 'linux') {
-  app.commandLine.appendSwitch(
-    'enable-features',
-    mergeChromiumFeature(app.commandLine.getSwitchValue('enable-features'), 'GlobalShortcutsPortal'),
-  );
+  appendChromiumFeatures('enable-features', ['GlobalShortcutsPortal']);
 }
 
 app.setName('Browser Use');
@@ -245,6 +267,23 @@ function restorableResumeUrl(lastUrl: string | null | undefined): string {
   return 'about:blank';
 }
 
+function registerBrowserIdentityHeaders(): void {
+  const identity = appBrowserIdentity;
+  session.defaultSession.setUserAgent(identity.userAgent, identity.acceptLanguageOverride);
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    { urls: ['http://*/*', 'https://*/*'] },
+    (details, callback) => {
+      const requestHeaders = withBrowserIdentityHeaders(details.requestHeaders, identity);
+      callback({ requestHeaders });
+    },
+  );
+  mainLogger.info('main.browserIdentity.headersRegistered', {
+    userAgent: identity.userAgent,
+    browser: 'Firefox',
+    platform: identity.platformLabel,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Single-instance focus
 // ---------------------------------------------------------------------------
@@ -381,15 +420,16 @@ function openShellAndWire(): BrowserWindow {
 // ---------------------------------------------------------------------------
 app.whenReady().then(async () => {
   mainLogger.info('main.appReady', { msg: 'Electron app ready — initializing Browser Use' });
+  registerBrowserIdentityHeaders();
   startResourceMonitor(resourceMonitorContext);
 
-  // Verify the CDP endpoint at our announced port is actually OUR Electron
+  // Verify the CDP endpoint at our announced port is actually OUR app
   // instance and not, e.g., the user's own Chrome that happened to already
-  // bind 9222. Without this, BU_CDP_PORT handed to the agent would point at
+  // bind the chosen port. Without this, BU_CDP_PORT handed to the agent would point at
   // a stranger's browser — `/json/list` returns targets the agent has no
   // access to, and `/devtools/page/<id>` gives 404/403. Log loudly on
   // mismatch so users hit a clear error instead of mysterious CDP failures.
-  verifyCdpOwnership(resolvedCdp.port).then((v) => {
+  verifyCdpOwnership(resolvedCdp.port, 2000, appBrowserIdentity.userAgent).then((v) => {
     if (v.ok) {
       mainLogger.info('main.cdp.verified', { port: resolvedCdp.port, browser: v.browser, userAgent: v.userAgent });
     } else {
@@ -400,7 +440,7 @@ app.whenReady().then(async () => {
         userAgent: v.userAgent ?? null,
         error: v.error ?? null,
         hint: v.userAgent
-          ? `CDP on :${resolvedCdp.port} responded but User-Agent does not contain Electron/ or BrowserUse/ — another Chromium-based process likely owns this port. Close it (or pass --remote-debugging-port=<free port>) and restart.`
+          ? `CDP on :${resolvedCdp.port} responded with an unexpected User-Agent — another Chromium-based process likely owns this port. Close it (or pass --remote-debugging-port=<free port>) and restart.`
           : `Could not reach CDP on :${resolvedCdp.port}; Electron may not have bound it (another process likely holds it).`,
       });
     }

--- a/app/src/main/sessions/BrowserPool.ts
+++ b/app/src/main/sessions/BrowserPool.ts
@@ -2,6 +2,7 @@ import { WebContentsView, nativeTheme, type BrowserWindow, type WebContents } fr
 import { browserLogger } from '../logger';
 import { getWindowBackgroundColor } from '../themeMode';
 import type { TabInfo } from './types';
+import { buildBrowserIdentity, type BrowserIdentity } from './browserIdentity';
 
 const DEFAULT_BROWSER_WIDTH = 1280;
 const DEFAULT_BROWSER_HEIGHT = 800;
@@ -18,6 +19,8 @@ const CDP_PROTOCOL_VERSION = '1.3';
 // desktop-class viewport. No enableDeviceEmulation — one knob only, no
 // ambiguity about where Chromium positions the rendered page.
 const EMULATED_VIEWPORT_HEIGHT = 900;
+
+type RuntimeBrowserIdentity = Pick<BrowserIdentity, 'userAgent' | 'acceptLanguageOverride' | 'jsPlatform'>;
 
 interface PoolEntry {
   sessionId: string;
@@ -175,36 +178,25 @@ export class BrowserPool {
       height: DEFAULT_BROWSER_HEIGHT,
     });
 
-    // Anti-detection: replace the Electron default UA with a vanilla Chrome UA.
-    // The default contains TWO bot tells — the app name token (`app/x.y.z`)
-    // injected by Electron between `Gecko)` and `Chrome/`, and the Electron
-    // token (`Electron/x.y.z`) before `Safari/`. Strip both. We keep the real
-    // bundled Chromium version (process.versions.chrome) so feature-detection,
-    // Sec-CH-UA hints, and TLS fingerprint stay coherent with the engine.
-    try {
-      const defaultUa = view.webContents.getUserAgent();
-      const cleanedUa = defaultUa
-        .replace(/\sElectron\/\S+/, '')
-        .replace(/\s[A-Za-z][\w-]*\/\d+\.\d+\.\d+(?=\sChrome\/)/, '');
-      if (cleanedUa !== defaultUa) {
-        view.webContents.setUserAgent(cleanedUa);
-        browserLogger.info('BrowserPool.userAgent.stripped', { sessionId, before: defaultUa, after: cleanedUa });
-      }
-    } catch (err) {
-      browserLogger.warn('BrowserPool.userAgent.error', { sessionId, error: (err as Error).message });
-    }
+    const browserIdentity = buildBrowserIdentity();
+    let activeUserAgent: string | null = null;
 
-    // Anti-detection: hide `navigator.webdriver` on every frame load. Runs in
-    // the page's isolated world via executeJavaScript — does not touch the
-    // CDP session the agent uses, so driving behavior is unaffected.
-    const hideWebdriver = (): void => {
-      if (view.webContents.isDestroyed()) return;
-      view.webContents.executeJavaScript(
-        "try{Object.defineProperty(Navigator.prototype,'webdriver',{get:()=>undefined,configurable:true})}catch(e){}",
-        true,
-      ).catch(() => { /* frame may have navigated away */ });
+    const applyWebContentsUserAgent = (
+      identity: RuntimeBrowserIdentity,
+      reason: string,
+    ): void => {
+      if (activeUserAgent === identity.userAgent) return;
+      try {
+        view.webContents.setUserAgent(identity.userAgent);
+        activeUserAgent = identity.userAgent;
+        browserLogger.info('BrowserPool.userAgent.applied', { sessionId, reason, userAgent: identity.userAgent });
+      } catch (err) {
+        browserLogger.warn('BrowserPool.userAgent.error', { sessionId, reason, error: (err as Error).message });
+      }
     };
-    view.webContents.on('dom-ready', hideWebdriver);
+
+    applyWebContentsUserAgent(browserIdentity, 'startup');
+
     view.webContents.on('before-input-event', (event, input) => {
       if (
         input.type === 'keyDown' &&

--- a/app/src/main/sessions/browserIdentity.ts
+++ b/app/src/main/sessions/browserIdentity.ts
@@ -1,0 +1,89 @@
+type HeaderMap = Record<string, string>;
+
+export interface BrowserIdentity {
+  userAgent: string;
+  firefoxVersion: string;
+  jsPlatform: string;
+  platformLabel: string;
+  acceptLanguageHeader: string;
+  acceptLanguageOverride: string;
+  language: string;
+  languages: string[];
+}
+
+const USER_AGENT_CLIENT_HINT_HEADERS = [
+  'sec-ch-ua',
+  'sec-ch-ua-mobile',
+  'sec-ch-ua-platform',
+  'sec-ch-ua-arch',
+  'sec-ch-ua-bitness',
+  'sec-ch-ua-full-version',
+  'sec-ch-ua-full-version-list',
+  'sec-ch-ua-form-factors',
+  'sec-ch-ua-model',
+  'sec-ch-ua-platform-version',
+  'sec-ch-ua-wow64',
+] as const;
+
+function firefoxVersion(version = '140.0'): string {
+  return /^\d+\.\d+(?:\.\d+)?$/.test(version) ? version : '140.0';
+}
+
+function platformParts(platform: NodeJS.Platform): Pick<BrowserIdentity, 'jsPlatform' | 'platformLabel'> & { uaPlatform: string } {
+  if (platform === 'win32') {
+    return {
+      uaPlatform: 'Windows NT 10.0; Win64; x64',
+      jsPlatform: 'Win32',
+      platformLabel: 'Windows',
+    };
+  }
+  if (platform === 'linux') {
+    return {
+      uaPlatform: 'X11; Linux x86_64',
+      jsPlatform: 'Linux x86_64',
+      platformLabel: 'Linux',
+    };
+  }
+  return {
+    uaPlatform: 'Macintosh; Intel Mac OS X 10.15',
+    jsPlatform: 'MacIntel',
+    platformLabel: 'macOS',
+  };
+}
+
+export function buildBrowserIdentity(opts: {
+  firefoxVersion?: string;
+  platform?: NodeJS.Platform;
+} = {}): BrowserIdentity {
+  const version = firefoxVersion(opts.firefoxVersion);
+  const platform = platformParts(opts.platform ?? process.platform);
+  const userAgent = `Mozilla/5.0 (${platform.uaPlatform}; rv:${version}) Gecko/20100101 Firefox/${version}`;
+  return {
+    userAgent,
+    firefoxVersion: version,
+    jsPlatform: platform.jsPlatform,
+    platformLabel: platform.platformLabel,
+    acceptLanguageHeader: 'en-US,en;q=0.9',
+    acceptLanguageOverride: 'en-US,en',
+    language: 'en-US',
+    languages: ['en-US', 'en'],
+  };
+}
+
+function setHeader(headers: HeaderMap, name: string, value: string): void {
+  const existing = Object.keys(headers).find((key) => key.toLowerCase() === name.toLowerCase());
+  headers[existing ?? name] = value;
+}
+
+function deleteHeader(headers: HeaderMap, name: string): void {
+  const existing = Object.keys(headers).find((key) => key.toLowerCase() === name.toLowerCase());
+  if (existing) delete headers[existing];
+}
+
+export function withBrowserIdentityHeaders(headers: HeaderMap, identity = buildBrowserIdentity()): HeaderMap {
+  const next = { ...headers };
+  setHeader(next, 'User-Agent', identity.userAgent);
+  setHeader(next, 'Accept-Language', identity.acceptLanguageHeader);
+  for (const header of USER_AGENT_CLIENT_HINT_HEADERS) deleteHeader(next, header);
+  return next;
+}

--- a/app/src/main/startup/cli.ts
+++ b/app/src/main/startup/cli.ts
@@ -9,8 +9,8 @@
  * Precedence (highest → lowest):
  *   1. CLI flag (`--user-data-dir=…`, `--remote-debugging-port=…`)
  *   2. Env var (`AGB_USER_DATA_DIR`)
- *   3. Default (userData: Electron's platform default; CDP port: 9222 so
- *      the Docker agent containers can reach `host.docker.internal:9222`)
+ *   3. Default (userData: Electron's platform default; CDP port: random
+ *      high localhost port; set AGB_CDP_PORT when a fixed port is required)
  *
  * Kept as a standalone module so it can be unit-tested without booting Electron.
  */
@@ -76,13 +76,13 @@ export function resolveUserDataDir(
 // --remote-debugging-port
 // ---------------------------------------------------------------------------
 
-/** Start walking from the Chrome-convention port. If it's free, use it.
- *  If the user's Chrome is already there (the bug that prompted this fix),
- *  step up one port at a time until we find an unused slot. Predictable for
- *  firewall rules and docs, resilient against Chrome-on-9222 collision. */
-const DEFAULT_START_PORT = 9222;
+/** Pick from the private/dynamic range by default. 9222 is the Chrome
+ *  remote-debugging convention and the first place anti-automation scripts
+ *  probe, so only use it when explicitly requested via CLI/env. */
+const DEFAULT_MIN_PORT = 49_152;
+const DEFAULT_MAX_PORT = 65_535;
 /** Sanity cap so a broken port-probe doesn't spin forever; in practice
- *  the first attempt almost always succeeds. */
+ *  the first random high-port attempt almost always succeeds. */
 const MAX_PORT_WALK = 500;
 
 export interface ResolvedCdpPort {
@@ -95,13 +95,13 @@ export interface ResolvedCdpPort {
   /** Provenance of the port.
    *   - 'cli'      → --remote-debugging-port=<N> on argv
    *   - 'env'      → AGB_CDP_PORT env var
-   *   - 'walk'     → started at DEFAULT_START_PORT, first free port wins
+   *   - 'random'   → started at a random high port, first free port wins
    *   - 'fallback' → the walk hit MAX_PORT_WALK; we returned the start port
    *                  as a last resort and verifyCdpOwnership will surface
    *                  any collision. */
-  source: 'cli' | 'env' | 'walk' | 'fallback';
-  /** When source === 'walk', how many ports we skipped before finding one.
-   *  0 means DEFAULT_START_PORT was free on first try. Used in startup logs
+  source: 'cli' | 'env' | 'random' | 'fallback';
+  /** When source === 'random', how many ports we skipped before finding one.
+   *  0 means the random start port was free on first try. Used in startup logs
    *  to spot chronic collisions without needing a separate metric. */
   walkedFrom?: number;
 }
@@ -111,9 +111,9 @@ export interface ResolvedCdpPort {
  *
  * - `--remote-debugging-port=<N>` on argv wins (dev / power-user override).
  * - `AGB_CDP_PORT=<N>` env var second (CI / Docker pinning).
- * - Otherwise walk up from DEFAULT_START_PORT (9222) until we find a free
- *   port. Keeps the port predictable for firewall configs while avoiding
- *   collision with a user's own Chrome that already bound 9222.
+ * - Otherwise choose a random high port and walk until we find a free port.
+ *   This avoids advertising a browser automation endpoint on the conventional
+ *   Chrome debugging port unless a developer explicitly asks for that.
  */
 export function resolveCdpPort(argv: readonly string[]): ResolvedCdpPort {
   const raw = extractFlagValue(argv, 'remote-debugging-port');
@@ -122,7 +122,7 @@ export function resolveCdpPort(argv: readonly string[]): ResolvedCdpPort {
     if (Number.isFinite(n) && n >= 0 && n <= 65535 && String(n) === raw) {
       return { port: n, source: 'cli' };
     }
-    // Fall through to env / walk on a bogus value rather than crashing.
+    // Fall through to env / random high-port selection on a bogus value rather than crashing.
   }
   const envVal = process.env.AGB_CDP_PORT;
   if (envVal) {
@@ -131,14 +131,20 @@ export function resolveCdpPort(argv: readonly string[]): ResolvedCdpPort {
       return { port: n, source: 'env' };
     }
   }
+  const startPort = randomDefaultCdpPort();
   for (let i = 0; i < MAX_PORT_WALK; i++) {
-    const p = DEFAULT_START_PORT + i;
-    if (p > 65535) break;
+    const p = DEFAULT_MIN_PORT + ((startPort - DEFAULT_MIN_PORT + i) % (DEFAULT_MAX_PORT - DEFAULT_MIN_PORT + 1));
     if (isPortFreeSync(p)) {
-      return { port: p, source: 'walk', walkedFrom: i };
+      return { port: p, source: 'random', walkedFrom: i };
     }
   }
-  return { port: DEFAULT_START_PORT, source: 'fallback' };
+  return { port: startPort, source: 'fallback' };
+}
+
+function randomDefaultCdpPort(): number {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { randomInt } = require('node:crypto') as typeof import('node:crypto');
+  return randomInt(DEFAULT_MIN_PORT, DEFAULT_MAX_PORT + 1);
 }
 
 /**
@@ -147,7 +153,7 @@ export function resolveCdpPort(argv: readonly string[]): ResolvedCdpPort {
  * Uses the OS's native listing command because Node's `net.createServer`
  * is async and we need a blocking answer before `app.commandLine.appendSwitch`
  * runs. `lsof` on POSIX and `netstat` on Windows are installed by default
- * and resolve in ~20ms, so walking a handful of ports is barely perceptible
+ * and resolve in ~20ms, so probing a handful of ports is barely perceptible
  * at startup.
  *
  * On any error we return `true` (= port is free). Being optimistic on probe

--- a/app/tests/fixtures/electron-mock.ts
+++ b/app/tests/fixtures/electron-mock.ts
@@ -158,7 +158,7 @@ const sessionStub = {
   // web request interception (DeclarativeNetRequestEngine)
   webRequest: {
     onBeforeRequest: (_listener: unknown): void => undefined,
-    onBeforeSendHeaders: (_listener: unknown): void => undefined,
+    onBeforeSendHeaders: (_filterOrListener: unknown, _listener?: unknown): void => undefined,
     onSendHeaders: (_listener: unknown): void => undefined,
     onHeadersReceived: (_listener: unknown): void => undefined,
     onResponseStarted: (_listener: unknown): void => undefined,
@@ -251,6 +251,8 @@ let webContentsIdCounter = 1;
 
 function createMockWebContents() {
   const id = webContentsIdCounter++;
+  let userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) BrowserUse/0.0.30 Chrome/146.0.0.0 Electron/41.0.0 Safari/537.36';
+  let zoomFactor = 1;
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
   const on = (event: string, handler: (...args: unknown[]) => void): void => {
     const set = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
@@ -281,6 +283,13 @@ function createMockWebContents() {
     isCurrentlyAudible: (): boolean => false,
     setFrameRate: (_fps: number): void => undefined,
     setBackgroundThrottling: (_throttle: boolean): void => undefined,
+    enableDeviceEmulation: (_params: unknown): void => undefined,
+    disableDeviceEmulation: (): void => undefined,
+    getZoomFactor: (): number => zoomFactor,
+    setZoomFactor: (nextZoomFactor: number): void => { zoomFactor = nextZoomFactor; },
+    getUserAgent: (): string => userAgent,
+    setUserAgent: (nextUserAgent: string): void => { userAgent = nextUserAgent; },
+    executeJavaScript: (_code: string, _userGesture?: boolean): Promise<unknown> => Promise.resolve(undefined),
     loadURL: (_url: string): Promise<void> => Promise.resolve(),
     close: (): void => undefined,
     on,

--- a/app/tests/unit/chrome-import/cookies.test.ts
+++ b/app/tests/unit/chrome-import/cookies.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  electronCookieDetailsForImport,
+  type CdpCookie,
+} from '../../../src/main/chrome-import/cookies';
+
+function cookie(overrides: Partial<CdpCookie> = {}): CdpCookie {
+  return {
+    name: 'SID',
+    value: 'abc',
+    domain: '.google.com',
+    path: '/',
+    expires: 1_900_000_000,
+    size: 3,
+    httpOnly: true,
+    secure: true,
+    session: false,
+    sameSite: 'Lax',
+    ...overrides,
+  };
+}
+
+describe('electronCookieDetailsForImport', () => {
+  it('keeps the domain attribute for domain cookies', () => {
+    const details = electronCookieDetailsForImport(cookie({
+      domain: '.google.com',
+    }));
+
+    expect(details).toMatchObject({
+      url: 'https://google.com/',
+      domain: '.google.com',
+      name: 'SID',
+      value: 'abc',
+      path: '/',
+      secure: true,
+      httpOnly: true,
+      sameSite: 'lax',
+      expirationDate: 1_900_000_000,
+    });
+  });
+
+  it('omits the domain attribute for host-only cookies', () => {
+    const details = electronCookieDetailsForImport(cookie({
+      name: '__Host-GMAIL_SCH_GMN',
+      domain: 'mail.google.com',
+    }));
+
+    expect(details).toMatchObject({
+      url: 'https://mail.google.com/',
+      name: '__Host-GMAIL_SCH_GMN',
+      value: 'abc',
+      path: '/',
+      secure: true,
+    });
+    expect(details).not.toHaveProperty('domain');
+  });
+
+  it('preserves empty cookie values', () => {
+    const details = electronCookieDetailsForImport(cookie({
+      value: '',
+      domain: 'accounts.google.com',
+    }));
+
+    expect(details).toMatchObject({
+      url: 'https://accounts.google.com/',
+      value: '',
+    });
+  });
+
+  it('returns null when the cookie has no name or domain', () => {
+    expect(electronCookieDetailsForImport(cookie({ name: '' }))).toBeNull();
+    expect(electronCookieDetailsForImport(cookie({ domain: '' }))).toBeNull();
+  });
+});

--- a/app/tests/unit/sessions/BrowserPool.test.ts
+++ b/app/tests/unit/sessions/BrowserPool.test.ts
@@ -96,6 +96,18 @@ describe('BrowserPool — creation', () => {
     expect(pool.getView('nonexistent')).toBeNull();
   });
 
+  it('sets session views to a Firefox-compatible user agent', () => {
+    const view = pool.create('s1');
+    const ua = (view!.webContents as unknown as { getUserAgent: () => string }).getUserAgent();
+
+    expect(ua).toContain('Firefox/');
+    expect(ua).toContain('Gecko/20100101');
+    expect(ua).not.toContain('Chrome/');
+    expect(ua).not.toContain('Safari/');
+    expect(ua).not.toContain('Electron');
+    expect(ua).not.toContain('BrowserUse');
+  });
+
   it('notifies when Ctrl+C is pressed inside a browser view and prevents the page keypress when handled', () => {
     const view = pool.create('s1');
     const onInterruptShortcut = vi.fn(() => true);
@@ -362,7 +374,8 @@ describe('BrowserPool — idle CPU throttling', () => {
     expect(setFrameRate).toHaveBeenLastCalledWith(1);
 
     await vi.advanceTimersByTimeAsync(100);
-    expect(sendCommand).toHaveBeenCalledWith('Page.setWebLifecycleState', { state: 'frozen' });
+    const lifecycleCalls = sendCommand.mock.calls.filter(([method]) => method === 'Page.setWebLifecycleState');
+    expect(lifecycleCalls).toEqual([['Page.setWebLifecycleState', { state: 'frozen' }]]);
   });
 
   it('does not freeze an idle session while it is visible', async () => {
@@ -376,7 +389,8 @@ describe('BrowserPool — idle CPU throttling', () => {
     pool.markSessionIdle('s1');
 
     await vi.advanceTimersByTimeAsync(100);
-    expect(sendCommand).not.toHaveBeenCalled();
+    const lifecycleCalls = sendCommand.mock.calls.filter(([method]) => method === 'Page.setWebLifecycleState');
+    expect(lifecycleCalls).toEqual([]);
     expect(setFrameRate).toHaveBeenLastCalledWith(60);
   });
 
@@ -390,8 +404,11 @@ describe('BrowserPool — idle CPU throttling', () => {
     await vi.advanceTimersByTimeAsync(100);
     await pool.markSessionActive('s1');
 
-    expect(sendCommand).toHaveBeenNthCalledWith(1, 'Page.setWebLifecycleState', { state: 'frozen' });
-    expect(sendCommand).toHaveBeenNthCalledWith(2, 'Page.setWebLifecycleState', { state: 'active' });
+    const lifecycleCalls = sendCommand.mock.calls.filter(([method]) => method === 'Page.setWebLifecycleState');
+    expect(lifecycleCalls).toEqual([
+      ['Page.setWebLifecycleState', { state: 'frozen' }],
+      ['Page.setWebLifecycleState', { state: 'active' }],
+    ]);
     expect(setFrameRate).toHaveBeenLastCalledWith(4);
   });
 });

--- a/app/tests/unit/sessions/browserIdentity.test.ts
+++ b/app/tests/unit/sessions/browserIdentity.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBrowserIdentity,
+  withBrowserIdentityHeaders,
+} from '../../../src/main/sessions/browserIdentity';
+
+describe('browser identity', () => {
+  it('builds a desktop Firefox identity for macOS', () => {
+    const identity = buildBrowserIdentity({
+      firefoxVersion: '140.0',
+      platform: 'darwin',
+    });
+
+    expect(identity.userAgent).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0',
+    );
+    expect(identity.firefoxVersion).toBe('140.0');
+    expect(identity.userAgent).not.toContain('Electron');
+    expect(identity.userAgent).not.toContain('BrowserUse');
+    expect(identity.userAgent).not.toContain('Chrome/');
+    expect(identity.jsPlatform).toBe('MacIntel');
+    expect(identity.platformLabel).toBe('macOS');
+  });
+
+  it('sets Firefox request headers and removes Chromium UA client hints', () => {
+    const identity = buildBrowserIdentity({
+      firefoxVersion: '140.0',
+      platform: 'win32',
+    });
+
+    const headers = withBrowserIdentityHeaders({
+      Accept: 'text/html',
+      'user-agent': 'Electron UA',
+      'sec-ch-ua': '"Electron";v="41"',
+      'sec-ch-ua-mobile': '?0',
+      'sec-ch-ua-platform': '"Windows"',
+      'sec-ch-ua-arch': '"x86"',
+      'sec-ch-ua-full-version-list': '"Electron";v="41.0.0.0"',
+      'sec-ch-ua-form-factors': '"Unknown"',
+      'sec-ch-ua-platform-version': '"15.0.0"',
+    }, identity);
+
+    expect(headers.Accept).toBe('text/html');
+    expect(headers['user-agent']).toBe(identity.userAgent);
+    expect(headers['sec-ch-ua']).toBeUndefined();
+    expect(headers['sec-ch-ua-mobile']).toBeUndefined();
+    expect(headers['sec-ch-ua-platform']).toBeUndefined();
+    expect(headers['sec-ch-ua-arch']).toBeUndefined();
+    expect(headers['sec-ch-ua-full-version-list']).toBeUndefined();
+    expect(headers['sec-ch-ua-form-factors']).toBeUndefined();
+    expect(headers['sec-ch-ua-platform-version']).toBeUndefined();
+    expect(headers['Accept-Language']).toBe('en-US,en;q=0.9');
+    expect(identity.acceptLanguageOverride).toBe('en-US,en');
+    expect(identity.languages).toEqual(['en-US', 'en']);
+  });
+
+  it('builds platform-specific Firefox user agents', () => {
+    const identity = buildBrowserIdentity({
+      firefoxVersion: '140.0',
+      platform: 'linux',
+    });
+
+    expect(identity.userAgent).toBe(
+      'Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0',
+    );
+    expect(identity.jsPlatform).toBe('Linux x86_64');
+    expect(identity.platformLabel).toBe('Linux');
+  });
+
+  it('does not add client hints when none were present', () => {
+    const identity = buildBrowserIdentity({
+      firefoxVersion: '140.0',
+      platform: 'darwin',
+    });
+
+    const headers = withBrowserIdentityHeaders({ Accept: 'text/html' }, identity);
+
+    expect(headers['User-Agent']).toBe(identity.userAgent);
+    expect(headers['sec-ch-ua']).toBeUndefined();
+    expect(headers['sec-ch-ua-full-version-list']).toBeUndefined();
+    expect(headers['sec-ch-ua-platform-version']).toBeUndefined();
+  });
+
+});

--- a/app/tests/unit/startup/cli.test.ts
+++ b/app/tests/unit/startup/cli.test.ts
@@ -108,20 +108,19 @@ describe('resolveUserDataDir (#206)', () => {
 // resolveCdpPort — Issue #207
 // ---------------------------------------------------------------------------
 
-const WALK_START = 9222;
+const EPHEMERAL_MIN = 49152;
+const EPHEMERAL_MAX = 65535;
 
 describe('resolveCdpPort', () => {
-  it('walks upward from 9222 when no override is given', () => {
-    // No CLI flag, no env → walk from 9222 up until we hit a free port.
-    // Chrome on 9222 would push us to 9223+ — we assert walk semantics,
-    // not the exact port (depends on what's listening on this machine).
+  it('uses a random high port when no override is given', () => {
+    // No CLI flag, no env -> avoid the conventional Chrome debugging port.
     delete process.env.AGB_CDP_PORT;
     const r = resolveCdpPort([]);
-    expect(r.source === 'walk' || r.source === 'fallback').toBe(true);
-    expect(r.port).toBeGreaterThanOrEqual(WALK_START);
-    if (r.source === 'walk') {
+    expect(r.source === 'random' || r.source === 'fallback').toBe(true);
+    expect(r.port).toBeGreaterThanOrEqual(EPHEMERAL_MIN);
+    expect(r.port).toBeLessThanOrEqual(EPHEMERAL_MAX);
+    if (r.source === 'random') {
       expect(r.walkedFrom).toBeGreaterThanOrEqual(0);
-      expect(r.port).toBe(WALK_START + (r.walkedFrom ?? 0));
     }
   });
 
@@ -143,25 +142,25 @@ describe('resolveCdpPort', () => {
     expect(r.source).toBe('cli');
   });
 
-  it('falls through to walk for malformed port value', () => {
+  it('falls through to random high-port selection for malformed port value', () => {
     delete process.env.AGB_CDP_PORT;
     const r = resolveCdpPort(['--remote-debugging-port=not-a-number']);
-    expect(r.source === 'walk' || r.source === 'fallback').toBe(true);
-    expect(r.port).toBeGreaterThanOrEqual(WALK_START);
+    expect(r.source === 'random' || r.source === 'fallback').toBe(true);
+    expect(r.port).toBeGreaterThanOrEqual(EPHEMERAL_MIN);
   });
 
-  it('falls through to walk for out-of-range port value', () => {
+  it('falls through to random high-port selection for out-of-range port value', () => {
     delete process.env.AGB_CDP_PORT;
     const r = resolveCdpPort(['--remote-debugging-port=99999']);
-    expect(r.source === 'walk' || r.source === 'fallback').toBe(true);
-    expect(r.port).toBeGreaterThanOrEqual(WALK_START);
+    expect(r.source === 'random' || r.source === 'fallback').toBe(true);
+    expect(r.port).toBeGreaterThanOrEqual(EPHEMERAL_MIN);
   });
 
-  it('falls through to walk for negative port value', () => {
+  it('falls through to random high-port selection for negative port value', () => {
     delete process.env.AGB_CDP_PORT;
     const r = resolveCdpPort(['--remote-debugging-port=-1']);
-    expect(r.source === 'walk' || r.source === 'fallback').toBe(true);
-    expect(r.port).toBeGreaterThanOrEqual(WALK_START);
+    expect(r.source === 'random' || r.source === 'fallback').toBe(true);
+    expect(r.port).toBeGreaterThanOrEqual(EPHEMERAL_MIN);
   });
 
   it('honors AGB_CDP_PORT env when no CLI flag is given', () => {


### PR DESCRIPTION
## Summary
- centralize the embedded browser identity as a Firefox-compatible profile from app startup
- apply the Firefox UA to app fallback, default session requests, and BrowserPool views
- strip Chromium UA client hints and remove the JS-level webdriver shim/navigation-time identity switching path

## Testing
- cd app && npm run test -- tests/unit/sessions/browserIdentity.test.ts
- task typecheck

## Notes
- User manually reported this path worked for the Google sign-in block.
- The worktree still has unrelated dirty files that are intentionally not included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make embedded sessions present as Firefox from startup to avoid Google sign‑in blocks and bot detection. Identity is applied app‑wide and we reduced other detection surfaces (CDP port and cookie import).

- **Bug Fixes**
  - Centralized Firefox identity in `browserIdentity` (UA, language, platform). Applied at startup via `app.userAgentFallback`, `session.defaultSession` (UA + `Accept-Language`), `webRequest.onBeforeSendHeaders`, and per‑view in `BrowserPool`.
  - Stripped Chromium UA Client Hints on all requests with `withBrowserIdentityHeaders`. Disabled `AutomationControlled` and UA Client Hints; enabled `WebShare`.
  - Moved default CDP port to a random high port (away from 9222). Updated `verifyCdpOwnership` to accept the app UA.
  - Fixed Chrome cookie import with `electronCookieDetailsForImport` to preserve host‑only cookies and empty values.
  - Removed UA cleaning and the `navigator.webdriver` shim. Added unit tests for identity, headers, cookies, CLI port logic, and `BrowserPool`.

- **Refactors**
  - Merged latest `main` and kept chatfile protocol and preview parking updates alongside identity hardening.

<sup>Written for commit 2f29c6e10c90e0458e209cd6ae754b3fcf4c14ea. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/desktop/pull/437?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

