### PR TITLE
fix(input): don't submit on Enter during IME composition

### DIFF
--- a/app/src/renderer/hub/AgentPane.tsx
+++ b/app/src/renderer/hub/AgentPane.tsx
@@ -578,7 +578,7 @@ function FollowUpInput({ sessionId, onUserInput, autoFocus }: { sessionId: strin
     if (e.key === 'Escape') {
       e.preventDefault();
       textareaRef.current?.blur();
-    } else if (e.key === 'Enter' && !e.shiftKey) {
+    } else if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
       e.preventDefault();
       handleSubmit();
     }

--- a/app/src/renderer/hub/TaskInput.tsx
+++ b/app/src/renderer/hub/TaskInput.tsx
@@ -203,7 +203,7 @@ export const TaskInput = forwardRef<TaskInputHandle, TaskInputProps>(function Ta
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
         e.preventDefault();
         submit();
       } else if (e.key === 'Escape') {

--- a/app/src/renderer/logs/LogsApp.tsx
+++ b/app/src/renderer/logs/LogsApp.tsx
@@ -342,7 +342,7 @@ export function LogsApp(): React.ReactElement {
 
   const onInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
         e.preventDefault();
         void sendFollowUp();
       }

--- a/app/src/renderer/pill/Pill.tsx
+++ b/app/src/renderer/pill/Pill.tsx
@@ -423,7 +423,7 @@ export function Pill(): React.ReactElement {
           setAttachments([]);
           setAttachError(null);
         }
-      } else if (e.key === 'Enter' && !e.shiftKey) {
+      } else if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
         e.preventDefault();
         submit();
       }


### PR DESCRIPTION
## Summary
Pressing **Enter to confirm an IME conversion** (Japanese/CJK) was being treated as "send", submitting half-converted text and making the app unusable for IME input.

## Fix
Guard the Enter-to-submit handlers with `!e.nativeEvent.isComposing && e.keyCode !== 229` across all prompt inputs:
- `TaskInput.tsx`
- `AgentPane.tsx` (FollowUpInput)
- `Pill.tsx`
- `LogsApp.tsx`

`isComposing` is the standard signal; `keyCode === 229` covers IMEs/browsers that fire a synthetic key during composition. `ChatTurn.tsx` uses Cmd/Ctrl+Enter and is unaffected.

## Test plan
- With a Japanese IME: type + convert + Enter → conversion is confirmed, message is NOT sent.
- Press Enter on confirmed text → message sends as before.
- Shift+Enter still inserts a newline.

Closes #445

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop submitting on Enter during IME composition so conversion confirms without sending. Fixes #445.

- **Bug Fixes**
  - Guard Enter-to-submit with `!e.nativeEvent.isComposing && e.keyCode !== 229`.
  - Applied to TaskInput, AgentPane FollowUpInput, Pill, and LogsApp.
  - Shift+Enter still inserts a newline; ChatTurn’s Cmd/Ctrl+Enter remains unchanged.

<sup>Written for commit e25a8b04c90681dddc2f1931a4793a0db4ddbbd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/desktop/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

